### PR TITLE
fix: preserve cli provided ordering of completions throughout shells

### DIFF
--- a/cli/cli/command_framework/lowlevel/args/arg_completion_provider.go
+++ b/cli/cli/command_framework/lowlevel/args/arg_completion_provider.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	shellDirectiveForManualCompletionProvider          = cobra.ShellCompDirectiveNoFileComp & cobra.ShellCompDirectiveKeepOrder
+	shellDirectiveForManualCompletionProvider          = cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveKeepOrder
 	shellDirectiveForShellProvideDefaultFileCompletion = cobra.ShellCompDirectiveDefault
 	defaultShellDirective                              = cobra.ShellCompDirectiveDefault
 	noShellDirectiveDefined                            = 999999

--- a/cli/cli/command_framework/lowlevel/args/arg_completion_provider.go
+++ b/cli/cli/command_framework/lowlevel/args/arg_completion_provider.go
@@ -8,10 +8,10 @@ import (
 )
 
 const (
-	shellDirectiveForManualCompletionProvider = cobra.ShellCompDirectiveNoFileComp
+	shellDirectiveForManualCompletionProvider          = cobra.ShellCompDirectiveNoFileComp & cobra.ShellCompDirectiveKeepOrder
 	shellDirectiveForShellProvideDefaultFileCompletion = cobra.ShellCompDirectiveDefault
-	defaultShellDirective = cobra.ShellCompDirectiveDefault
-	noShellDirectiveDefined = 999999
+	defaultShellDirective                              = cobra.ShellCompDirectiveDefault
+	noShellDirectiveDefined                            = 999999
 )
 
 var (
@@ -34,7 +34,7 @@ func (impl *argCompletionProviderImpl) RunCompletionFunction(
 	ctx context.Context,
 	flags *flags.ParsedFlags,
 	previousArgs *ParsedArgs,
-)([]string, cobra.ShellCompDirective, error) {
+) ([]string, cobra.ShellCompDirective, error) {
 
 	if impl.customCompletionFunc != noCustomCompletionFuncDefined {
 		completionFunc := *impl.customCompletionFunc
@@ -49,21 +49,21 @@ func (impl *argCompletionProviderImpl) RunCompletionFunction(
 	return nil, defaultShellDirective, stacktrace.NewError("The custom completion func and the shell completion directive are not defined, this should never happens; this is a bug in Kurtosis")
 }
 
-//Receive a custom completion function which should generate the completions list for the argument and return it
+// Receive a custom completion function which should generate the completions list for the argument and return it
 func NewManualCompletionsProvider(
 	customCompletionFunc func(ctx context.Context, flags *flags.ParsedFlags, previousArgs *ParsedArgs) ([]string, error),
 ) argCompletionProvider {
 	newManualCompletionProvider := &argCompletionProviderImpl{
-		customCompletionFunc: &customCompletionFunc,
+		customCompletionFunc:     &customCompletionFunc,
 		shellCompletionDirective: noShellDirectiveDefined,
 	}
 	return newManualCompletionProvider
 }
 
-//This argument completion provider enables the default shell file completion functionality for the argument
+// This argument completion provider enables the default shell file completion functionality for the argument
 func NewDefaultShellFileCompletionProvider() argCompletionProvider {
 	newDefaultShellFileCompletionProvider := &argCompletionProviderImpl{
-		customCompletionFunc: noCustomCompletionFuncDefined,
+		customCompletionFunc:     noCustomCompletionFuncDefined,
 		shellCompletionDirective: shellDirectiveForShellProvideDefaultFileCompletion,
 	}
 	return newDefaultShellFileCompletionProvider

--- a/cli/cli/go.mod
+++ b/cli/cli/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/manifoldco/promptui v0.9.0
 	github.com/mattn/go-isatty v0.0.14
 	github.com/sirupsen/logrus v1.8.1
-	github.com/spf13/cobra v1.2.1
+	github.com/spf13/cobra v1.6.1-0.20230225213037-567ea8ebc9b4
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.4
 	golang.org/x/crypto v0.0.0-20220214200702-86341886e292
@@ -61,7 +61,7 @@ require (
 	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/imdario/mergo v0.3.11 // indirect
-	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/kurtosis-tech/free-ip-addr-tracker-lib v0.0.0-20211106222342-1f73d028840d // indirect
 	github.com/mattn/go-colorable v0.1.2 // indirect

--- a/cli/cli/go.sum
+++ b/cli/cli/go.sum
@@ -89,6 +89,7 @@ github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWH
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
+github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -266,6 +267,10 @@ github.com/imdario/mergo v0.3.11 h1:3tnifQM4i+fbajXKBHXWEH+KvNHqojZ778UH75j3bGA=
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/inconshreveable/mousetrap v1.0.1 h1:U3uMjPSQEBMNp1lFxmllqCPM6P5u/Xq7Pgzkat/bFNc=
+github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jarcoal/httpmock v1.0.4/go.mod h1:ATjnClrvW/3tijVmpL/va5Z3aAyGvqU3gCT8nX0Txik=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
@@ -373,6 +378,7 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBOAvL+k=
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/segmentio/backo-go v1.0.0 h1:kbOAtGJY2DqOR0jfRkYEorx/b18RgtepGtY3+Cpe6qA=
@@ -389,6 +395,10 @@ github.com/spf13/afero v1.6.0/go.mod h1:Ai8FlHk4v/PARR026UzYexafAt9roJ7LcLMAmO6Z
 github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v1.2.1 h1:+KmjbUw1hriSNMF55oPrkZcb27aECyrj8V2ytv7kWDw=
 github.com/spf13/cobra v1.2.1/go.mod h1:ExllRjgxM/piMAM+3tAZvg8fsklGAf3tPfi+i8t68Nk=
+github.com/spf13/cobra v1.6.1-0.20230225213037-567ea8ebc9b4 h1:Lz7CkhugL9Vx4mZwiEYS0VmG3z/g07fQf0oNkIvoSRk=
+github.com/spf13/cobra v1.6.1-0.20230225213037-567ea8ebc9b4/go.mod h1:uLxZILRyS/50WlhOIKD7W6V5bgeIt+4sICxh6uRMrb0=
+github.com/spf13/cobra v1.6.1 h1:o94oiPyS4KD1mPy2fmcYYHHfCxLqYjJOhGsCHFZtEzA=
+github.com/spf13/cobra v1.6.1/go.mod h1:IOw/AERYS7UzyrGinqmz6HLUo219MORXGxhbaJUqzrY=
 github.com/spf13/jwalterweatherman v1.1.0/go.mod h1:aNWZUN0dPAAO/Ljvb5BEdw96iTZ0EXowPYD95IqWIGo=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=


### PR DESCRIPTION
we sort the completions, Shell resorts it for us with the new version and this directive we can keep our ordering (names followed by uuids)