### PR TITLE
docs: fix CLI sidebar title

### DIFF
--- a/docs/docs/reference/cli/cli.md
+++ b/docs/docs/reference/cli/cli.md
@@ -1,6 +1,6 @@
 ---
 title: Getting Started
-sidebar_label: Getting Started
+sidebar_label: CLI
 slug: /cli
 sidebar_position: 1
 ---


### PR DESCRIPTION
The CLI sidebar title right now says "Getting Started" but it is not obvious for a user that the section is about the CLI and the "getting started" title should be reserved solely for the page title itself and NOT the sidebar

Changelog picked up from commits here:

docs: fix CLI sidebar title