### PR TITLE
fix: Use version.txt for kurtosis_version instead of Git tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -935,8 +935,8 @@ jobs:
 
       # Generate Kurtosis Version
       - run: |
-          tag="$(git describe --tag)"
-          "<<pipeline.parameters.generate-kurtosis-version-script-path>>" $tag
+          version="$(cat version.txt)"
+          "<<pipeline.parameters.generate-kurtosis-version-script-path>>" $version
 
 
       - setup_remote_docker:
@@ -975,8 +975,8 @@ jobs:
 
       # Generate Kurtosis Version
       - run: |
-          tag="$(git describe --tag)"
-          "<<pipeline.parameters.generate-kurtosis-version-script-path>>" $tag
+          version="$(cat version.txt)"
+          "<<pipeline.parameters.generate-kurtosis-version-script-path>>" $version
 
       # Cache our dependencies
       - restore_cache:


### PR DESCRIPTION
Changelog picked up from commits here:

fix: Use version.txt for kurtosis_version instead of Git tags