### PR TITLE
fix: sort services by name

### DIFF
--- a/cli/cli/commands/enclave/inspect/user_services.go
+++ b/cli/cli/commands/enclave/inspect/user_services.go
@@ -121,7 +121,7 @@ func getSortedUserServiceSliceFromUserServiceMap(userServices map[service.Servic
 	sort.Slice(userServicesResult, func(i, j int) bool {
 		firstService := userServicesResult[i]
 		secondService := userServicesResult[j]
-		return firstService.GetRegistration().GetUUID() < secondService.GetRegistration().GetUUID()
+		return firstService.GetRegistration().GetName() < secondService.GetRegistration().GetName()
 	})
 
 	return userServicesResult


### PR DESCRIPTION
we currently sort by uuid, so my-nginx-0, my-nginx-2 and my-nginx-1 might get sorted in the wrong order. This sorts by name which is similar to how things were sorted before we went from GUID (service-id-timestamp) to UUID (hex string)

Note, services aren't still sorted by creation time as they never were. That would be a result of #135