### PR TITLE
fix: bump historical cli install down the sidebar

### DIFF
--- a/docs/docs/guides/installing-historical-versions.md
+++ b/docs/docs/guides/installing-historical-versions.md
@@ -2,7 +2,7 @@
 title: Installing Historical Versions of Kurtosis CLI
 sidebar_label: Installing Historical Versions
 slug: /install-historical
-sidebar_position: 1
+sidebar_position: 2
 ---
 
 Occasionally, using historical versions of Kurtosis is necessary. For example, when working with a [Starlark](../explanations/starlark.md) Kurtosis package that was initially developed with an older version of Kurtosis, we might want rollback our Kurtosis version to ensure the version of Kurtosis we are running is compatible with the Kurtosis package.


### PR DESCRIPTION
Right now, the sidebar has "Installing Historical Versions" above the instructions for a net new install ("Installing the CLI"). This PR bumps the sidebar position of the instructions for installing historical CLI versions down by 1 to be _below_ the instructions for a fresh install of the CLI.

Screenshot of status quo:
<img width="206" alt="image" src="https://user-images.githubusercontent.com/103802618/224811955-dcbad01e-7d87-497a-9a84-2fa6d4eaf488.png">

Changelog picked up from commits here:

fix: bump historical cli install down the sidebar