### PR TITLE
docs: re-word onboarding link to have fewer words

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -91,7 +91,7 @@ const config = {
           {
             href: 'https://calendly.com/d/zgt-f2c-66p/kurtosis-onboarding',
             position: 'right',
-            label: 'Schedule a personalized on-boarding session with us.',
+            label: 'Schedule a live session with us',
           },
         ],
       },


### PR DESCRIPTION
Right now, the link to schedule an onboarding session with us contains alot of words (e.g. [Schedule a personalized on-boarding session with us.](https://calendly.com/d/zgt-f2c-66p/kurtosis-onboarding)). 

This PR reduces those words to simply "Schedule a live session with us" to make it easier to read and more compelling to engage with.

Changelog picked up from commits here:

docs: re-word onboarding link to have fewer words