### PR TITLE
fix: use with-subnetworks

### DIFF
--- a/cli/cli/commands/enclave/add/add.go
+++ b/cli/cli/commands/enclave/add/add.go
@@ -70,7 +70,7 @@ var EnclaveAddCmd = &engine_consuming_kurtosis_command.EngineConsumingKurtosisCo
 			Shorthand: "p",
 			Type:      flags.FlagType_Bool,
 			Default:   defaultIsSubnetworksEnabled,
-			Usage:     "If set to true then the enclave that gets created will have subnetwork capabilities (default false)",
+			Usage:     "If set to true then the enclave that gets created will have subnetwork capabilities",
 		}, {
 			Key:       enclaveIdFlagKey,
 			Shorthand: "i",

--- a/cli/cli/commands/enclave/add/add.go
+++ b/cli/cli/commands/enclave/add/add.go
@@ -21,9 +21,9 @@ import (
 )
 
 const (
-	apiContainerVersionFlagKey   = "api-container-version"
-	apiContainerLogLevelFlagKey  = "api-container-log-level"
-	isPartitioningEnabledFlagKey = "with-partitioning"
+	apiContainerVersionFlagKey  = "api-container-version"
+	apiContainerLogLevelFlagKey = "api-container-log-level"
+	isSubnetworksEnabledFlagKey = "with-subnetworks"
 	// TODO(deprecation) remove enclave ids in favor of names
 	enclaveIdFlagKey   = "id"
 	enclaveNameFlagKey = "name"
@@ -66,7 +66,7 @@ var EnclaveAddCmd = &engine_consuming_kurtosis_command.EngineConsumingKurtosisCo
 			Default:   defaults.DefaultAPIContainerVersion,
 			Usage:     "The version of the Kurtosis API container that should be started inside the enclave (blank tells the engine to use the default version)",
 		}, {
-			Key:       isPartitioningEnabledFlagKey,
+			Key:       isSubnetworksEnabledFlagKey,
 			Shorthand: "p",
 			Type:      flags.FlagType_Bool,
 			Default:   defaultIsPartitioningEnabled,
@@ -110,9 +110,9 @@ func run(
 		return stacktrace.Propagate(err, "An error occurred while getting the API Container Version using flag with key '%v'; this is a bug in Kurtosis", apiContainerVersionFlagKey)
 	}
 
-	isPartitioningEnabled, err := flags.GetBool(isPartitioningEnabledFlagKey)
+	isPartitioningEnabled, err := flags.GetBool(isSubnetworksEnabledFlagKey)
 	if err != nil {
-		return stacktrace.Propagate(err, "An error occurred while getting is partitioning enabled flag using key '%v'; this is a bug in Kurtosis", isPartitioningEnabledFlagKey)
+		return stacktrace.Propagate(err, "An error occurred while getting is partitioning enabled flag using key '%v'; this is a bug in Kurtosis", isSubnetworksEnabledFlagKey)
 	}
 
 	kurtosisLogLevelStr, err := flags.GetString(apiContainerLogLevelFlagKey)

--- a/cli/cli/commands/enclave/add/add.go
+++ b/cli/cli/commands/enclave/add/add.go
@@ -28,7 +28,7 @@ const (
 	enclaveIdFlagKey   = "id"
 	enclaveNameFlagKey = "name"
 
-	defaultIsPartitioningEnabled = "false"
+	defaultIsSubnetworksEnabled = "false"
 
 	// Signifies that an enclave ID should be auto-generated
 	autogenerateEnclaveIdKeyword = ""
@@ -69,8 +69,8 @@ var EnclaveAddCmd = &engine_consuming_kurtosis_command.EngineConsumingKurtosisCo
 			Key:       isSubnetworksEnabledFlagKey,
 			Shorthand: "p",
 			Type:      flags.FlagType_Bool,
-			Default:   defaultIsPartitioningEnabled,
-			Usage:     "Enable network partitioning functionality (repartitioning won't work if this is set to false)",
+			Default:   defaultIsSubnetworksEnabled,
+			Usage:     "If set to true then the enclave that gets created will have subnetwork capabilities (default false)",
 		}, {
 			Key:       enclaveIdFlagKey,
 			Shorthand: "i",
@@ -112,7 +112,7 @@ func run(
 
 	isPartitioningEnabled, err := flags.GetBool(isSubnetworksEnabledFlagKey)
 	if err != nil {
-		return stacktrace.Propagate(err, "An error occurred while getting is partitioning enabled flag using key '%v'; this is a bug in Kurtosis", isSubnetworksEnabledFlagKey)
+		return stacktrace.Propagate(err, "An error occurred getting the is-subnetwork-enabled setting using flag key '%v'; this is a bug in Kurtosis", isSubnetworksEnabledFlagKey)
 	}
 
 	kurtosisLogLevelStr, err := flags.GetString(apiContainerLogLevelFlagKey)


### PR DESCRIPTION
## Description:
Change a flag from 'with-partitioning' to 'with-subnetworks'

## Is this change user facing?
<!-- A user facing change is one that you should expect a day-to-day user to encounter or if the change requires user-action upon or before upgrading. If in doubt, select "Yes" -->
* [x] Yes
* [ ] No

<!-- If yes, please add the  label to this Pull Request -->

## References (if applicable):
Closes https://github.com/kurtosis-tech/kurtosis/issues/154