### PR TITLE
feat: show enclave inspect immediately after run

### DIFF
--- a/cli/cli/commands/enclave/inspect/inspect.go
+++ b/cli/cli/commands/enclave/inspect/inspect.go
@@ -103,6 +103,14 @@ func run(
 		return stacktrace.Propagate(err, "An error occurred creating Kurtosis Context from local engine")
 	}
 
+	if err = PrintEnclaveInspect(ctx, kurtosisBackend, kurtosisCtx, enclaveIdentifier, showFullUuids); err != nil {
+		// this is already wrapped up
+		return err
+	}
+	return nil
+}
+
+func PrintEnclaveInspect(ctx context.Context, kurtosisBackend backend_interface.KurtosisBackend, kurtosisCtx *kurtosis_context.KurtosisContext, enclaveIdentifier string, showFullUuids bool) error {
 	enclaveInfo, err := kurtosisCtx.GetEnclave(ctx, enclaveIdentifier)
 	if err != nil {
 		return stacktrace.Propagate(err, "An error occurred getting the enclave for identifier '%v'", enclaveIdentifier)

--- a/cli/cli/commands/run/run.go
+++ b/cli/cli/commands/run/run.go
@@ -16,6 +16,7 @@ import (
 	"github.com/kurtosis-tech/kurtosis/cli/cli/command_str_consts"
 	"github.com/kurtosis-tech/kurtosis/cli/cli/commands/enclave/inspect"
 	"github.com/kurtosis-tech/kurtosis/cli/cli/helpers/output_printers"
+	"github.com/kurtosis-tech/kurtosis/cli/cli/out"
 	"github.com/kurtosis-tech/kurtosis/cli/cli/user_support_constants"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface"
 	metrics_client "github.com/kurtosis-tech/metrics-library/golang/lib/client"
@@ -289,6 +290,7 @@ func run(
 		}
 	}
 
+	out.PrintOutLn("")
 	if err = inspect.PrintEnclaveInspect(ctx, kurtosisBackend, kurtosisCtx, enclaveCtx.GetEnclaveName(), false); err != nil {
 		// this error is already wrapped up
 		return err

--- a/cli/cli/commands/run/run.go
+++ b/cli/cli/commands/run/run.go
@@ -246,7 +246,6 @@ func run(
 
 	if showEnclaveInspect {
 		defer func() {
-			output_printers.GetSpotlightMessagePrinter().PrintWithLogger("Current Enclave State")
 			if err = inspect.PrintEnclaveInspect(ctx, kurtosisBackend, kurtosisCtx, enclaveCtx.GetEnclaveName(), showFullUuids); err != nil {
 				logrus.Errorf("An error occurred while printing enclave status and contents:\n%s", err)
 			}

--- a/cli/cli/commands/run/run.go
+++ b/cli/cli/commands/run/run.go
@@ -16,7 +16,6 @@ import (
 	"github.com/kurtosis-tech/kurtosis/cli/cli/command_str_consts"
 	"github.com/kurtosis-tech/kurtosis/cli/cli/commands/enclave/inspect"
 	"github.com/kurtosis-tech/kurtosis/cli/cli/helpers/output_printers"
-	"github.com/kurtosis-tech/kurtosis/cli/cli/out"
 	"github.com/kurtosis-tech/kurtosis/cli/cli/user_support_constants"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface"
 	metrics_client "github.com/kurtosis-tech/metrics-library/golang/lib/client"
@@ -244,18 +243,18 @@ func run(
 	if err != nil {
 		return stacktrace.Propagate(err, "An error occurred getting the enclave context for enclave '%v'", userRequestedEnclaveIdentifier)
 	}
-	if isNewEnclave {
-		defer output_printers.PrintEnclaveName(enclaveCtx.GetEnclaveName())
-	}
 
 	if showEnclaveInspect {
-		output_printers.GetSpotlightMessagePrinter().PrintWithLogger("Current Enclave State")
 		defer func() {
-			out.PrintOutLn("")
+			output_printers.GetSpotlightMessagePrinter().PrintWithLogger("Current Enclave State")
 			if err = inspect.PrintEnclaveInspect(ctx, kurtosisBackend, kurtosisCtx, enclaveCtx.GetEnclaveName(), showFullUuids); err != nil {
 				logrus.Errorf("An error occurred while printing enclave status and contents:\n%s", err)
 			}
 		}()
+	}
+
+	if isNewEnclave {
+		defer output_printers.PrintEnclaveName(enclaveCtx.GetEnclaveName())
 	}
 
 	var responseLineChan <-chan *kurtosis_core_rpc_api_bindings.StarlarkRunResponseLine

--- a/cli/cli/commands/run/run.go
+++ b/cli/cli/commands/run/run.go
@@ -289,7 +289,7 @@ func run(
 		}
 	}
 
-	if err = inspect.PrintEnclaveInspect(ctx, kurtosisBackend, kurtosisCtx, userRequestedEnclaveIdentifier, false); err != nil {
+	if err = inspect.PrintEnclaveInspect(ctx, kurtosisBackend, kurtosisCtx, enclaveCtx.GetEnclaveName(), false); err != nil {
 		// this error is already wrapped up
 		return err
 	}

--- a/cli/cli/commands/run/run.go
+++ b/cli/cli/commands/run/run.go
@@ -239,22 +239,18 @@ func run(
 		return stacktrace.Propagate(err, "An error occurred connecting to the local Kurtosis engine")
 	}
 
-	enclaveCtx, isNewEnclave, err := getOrCreateEnclaveContext(ctx, userRequestedEnclaveIdentifier, kurtosisCtx, isPartitioningEnabled, metricsClient)
+	enclaveCtx, _, err := getOrCreateEnclaveContext(ctx, userRequestedEnclaveIdentifier, kurtosisCtx, isPartitioningEnabled, metricsClient)
 	if err != nil {
 		return stacktrace.Propagate(err, "An error occurred getting the enclave context for enclave '%v'", userRequestedEnclaveIdentifier)
 	}
 
 	if showEnclaveInspect {
 		defer func() {
-			output_printers.GetSpotlightMessagePrinter().PrintWithLogger("Current Enclave State")
+			output_printers.GetSpotlightMessagePrinter().PrintWithLogger("State of Enclave")
 			if err = inspect.PrintEnclaveInspect(ctx, kurtosisBackend, kurtosisCtx, enclaveCtx.GetEnclaveName(), showFullUuids); err != nil {
 				logrus.Errorf("An error occurred while printing enclave status and contents:\n%s", err)
 			}
 		}()
-	}
-
-	if isNewEnclave {
-		defer output_printers.PrintEnclaveName(enclaveCtx.GetEnclaveName())
 	}
 
 	var responseLineChan <-chan *kurtosis_core_rpc_api_bindings.StarlarkRunResponseLine

--- a/cli/cli/commands/run/run.go
+++ b/cli/cli/commands/run/run.go
@@ -248,6 +248,16 @@ func run(
 		defer output_printers.PrintEnclaveName(enclaveCtx.GetEnclaveName())
 	}
 
+	if showEnclaveInspect {
+		output_printers.GetSpotlightMessagePrinter().PrintWithLogger("Current Enclave State")
+		defer func() {
+			out.PrintOutLn("")
+			if err = inspect.PrintEnclaveInspect(ctx, kurtosisBackend, kurtosisCtx, enclaveCtx.GetEnclaveName(), showFullUuids); err != nil {
+				logrus.Errorf("An error occurred while printing enclave status and contents:\n%s", err)
+			}
+		}()
+	}
+
 	var responseLineChan <-chan *kurtosis_core_rpc_api_bindings.StarlarkRunResponseLine
 	var cancelFunc context.CancelFunc
 	var errRunningKurtosis error
@@ -306,14 +316,6 @@ func run(
 	} else {
 		if err := metricsClient.TrackKurtosisRunFinishedEvent(starlarkScriptOrPackagePath, len(servicesInEnclaveForMetrics), runSucceeded); err != nil {
 			logrus.Warn("An error occurred tracking kurtosis run finished event")
-		}
-	}
-
-	out.PrintOutLn("")
-	if showEnclaveInspect {
-		if err = inspect.PrintEnclaveInspect(ctx, kurtosisBackend, kurtosisCtx, enclaveCtx.GetEnclaveName(), showFullUuids); err != nil {
-			// this error is already wrapped up
-			return err
 		}
 	}
 


### PR DESCRIPTION
## Description:
Shows the output of enclave inspect immediately after run automatically

## Is this change user facing?
<!-- A user facing change is one that you should expect a day-to-day user to encounter or if the change requires user-action upon or before upgrading. If in doubt, select "Yes" -->
* [x] Yes
* [ ] No

<!-- If yes, please add the  label to this Pull Request -->

## References (if applicable):
https://github.com/kurtosis-tech/kurtosis/issues/165