### PR TITLE
fix: Add back fetch depth to change version GH action

### DIFF
--- a/.github/workflows/change-versions.yml
+++ b/.github/workflows/change-versions.yml
@@ -12,6 +12,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           token: "${{ secrets.RELEASER_TOKEN }}"
+          fetch-depth: 0
       - name: Change versions
         run: | 
           api/scripts/update-package-versions.sh "$(cat version.txt)"


### PR DESCRIPTION
## Description:

During the process of removing , an accidental line was removed from the change version Github Action: https://github.com/kurtosis-tech/kurtosis/commit/d5d58c3c666bd4da9d886c9f777e9fc6b14fb57d#diff-39713e0e880264021f8f50fa74fc6f9a0fd40e39a82f233d0f46ea12adb9799dL15

## Is this change user facing?
<!-- A user facing change is one that you should expect a day-to-day user to encounter or if the change requires user-action upon or before upgrading. If in doubt, select "Yes" -->
* [ ] Yes
* [X] No

<!-- If yes, please add the  label to this Pull Request -->

## References (if applicable):
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->

Changelog picked up from commits here:

fix: Add back fetch depth to change version GH action