### PR TITLE
docs: hyperlink the *entire* calendly banner

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -52,7 +52,7 @@ const config = {
       announcementBar: {
         id: 'support_us',
         content:
-            '<a target="_blank" rel="noopener noreferrer" href="https://calendly.com/d/zgt-f2c-66p/kurtosis-onboarding">Schedule a live session with us to get started or to learn more here</a>',
+            '<a target="_blank" rel="noopener noreferrer" href="https://calendly.com/d/zgt-f2c-66p/kurtosis-onboarding">Schedule a live session with us to help getting started or to learn more.</a>',
         backgroundColor: '#fafbfc',
         textColor: '#091E42',
         isCloseable: false,

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -52,7 +52,7 @@ const config = {
       announcementBar: {
         id: 'support_us',
         content:
-            'Schedule a live session with us to get started or to learn more <a target="_blank" rel="noopener noreferrer" href="https://calendly.com/d/zgt-f2c-66p/kurtosis-onboarding">here</a>',
+            '<a target="_blank" rel="noopener noreferrer" href="https://calendly.com/d/zgt-f2c-66p/kurtosis-onboarding">Schedule a live session with us to get started or to learn more here</a>',
         backgroundColor: '#fafbfc',
         textColor: '#091E42',
         isCloseable: false,


### PR DESCRIPTION
## Description:
Right now, the link for our calendly link in the Docs is only hyperlinked for the word "here". This PR proposes to hyperlink the entire *text* in the banner in our docs.

## Is this change user facing?
<!-- A user facing change is one that you should expect a day-to-day user to encounter or if the change requires user-action upon or before upgrading. If in doubt, select "Yes" -->
* [X] Yes
* [ ] No

<!-- If yes, please add the  label to this Pull Request -->

## References (if applicable):
https://github.com/kurtosis-tech/kurtosis/pull/157

Changelog picked up from commits here:

docs: hyperlink the *entire* calendly banner