### PR TITLE
fix: warn if engine version is greater than cli and error if cli > engine

### DIFF
--- a/cli/cli/helpers/engine_manager/engine_existence_guarantor.go
+++ b/cli/cli/helpers/engine_manager/engine_existence_guarantor.go
@@ -223,12 +223,6 @@ func (guarantor *engineExistenceGuarantor) VisitRunning() error {
 	}
 
 	if runningEngineSemver.LessThan(cliEngineSemver) {
-		logrus.Errorf(
-			"The currently-running Kurtosis engine version is '%v' but the latest version is '%v'; you can pull the latest fixes by running '%v'",
-			runningEngineSemver.String(),
-			cliEngineSemver.String(),
-			engineRestartCmd,
-		)
 		return stacktrace.NewError("The current version of the CLI '%s' is greater than the version of the running engine '%s' which could lead to unexpected behavior. Use '%s' to upgrade the current running engine", cliEngineSemver.String(), runningEngineSemver.String(), engineRestartCmd)
 	} else if runningEngineSemver.GreaterThan(cliEngineSemver) {
 		logrus.Warningf("The version of the current running engine '%v' is greater than the version of the CLI '%v'. Please upgrade the CLI by following the steps here %v", runningEngineSemver.String(), cliEngineSemver.String(), user_support_constants.UpgradeCLIInstructionsPage)
@@ -253,7 +247,7 @@ func (guarantor *engineExistenceGuarantor) getRunningAndCLIEngineVersions() (*se
 	launcherEngineSemverStr := kurtosis_version.KurtosisVersion
 	launcherEngineSemver, err := semver.StrictNewVersion(launcherEngineSemverStr)
 	if err != nil {
-		return nil, nil, stacktrace.Propagate(err, "An error occurred parsing CLI's engine version string '%v' to semantic version.", launcherEngineSemverStr)
+		return nil, nil, stacktrace.Propagate(err, "An error occurred parsing CLI's engine version string '%v' to semantic version", launcherEngineSemverStr)
 	}
 
 	return runningEngineSemver, launcherEngineSemver, nil

--- a/cli/cli/helpers/engine_manager/engine_existence_guarantor.go
+++ b/cli/cli/helpers/engine_manager/engine_existence_guarantor.go
@@ -224,7 +224,9 @@ func (guarantor *engineExistenceGuarantor) VisitRunning() error {
 
 	if runningEngineSemver.LessThan(cliEngineSemver) {
 		return stacktrace.NewError("The current version of the CLI '%s' is greater than the version of the running engine '%s' which could lead to unexpected behavior. Use '%s' to upgrade the current running engine", cliEngineSemver.String(), runningEngineSemver.String(), engineRestartCmd)
-	} else if runningEngineSemver.GreaterThan(cliEngineSemver) {
+	}
+
+	if runningEngineSemver.GreaterThan(cliEngineSemver) {
 		logrus.Warningf("The version of the current running engine '%v' is greater than the version of the CLI '%v'. Please upgrade the CLI by following the steps here %v", runningEngineSemver.String(), cliEngineSemver.String(), user_support_constants.UpgradeCLIInstructionsPage)
 	}
 	return nil

--- a/cli/cli/helpers/engine_manager/engine_existence_guarantor.go
+++ b/cli/cli/helpers/engine_manager/engine_existence_guarantor.go
@@ -224,7 +224,7 @@ func (guarantor *engineExistenceGuarantor) VisitRunning() error {
 			engineRestartCmd,
 		)
 	} else {
-		logrus.Debugf("Currently running engine version '%v' is >= the version the CLI expects", guarantor.maybeCurrentlyRunningEngineVersionTag)
+		logrus.Warningf("Currently running engine version '%v' is >= the version the CLI expects", guarantor.maybeCurrentlyRunningEngineVersionTag)
 	}
 	return nil
 }


### PR DESCRIPTION
## Description:
We would log with debug if engine > cli but people couldn't see it; caused confusion

## Is this change user facing?
<!-- A user facing change is one that you should expect a day-to-day user to encounter or if the change requires user-action upon or before upgrading. If in doubt, select "Yes" -->
* [x] Yes
* [ ] No

<!-- If yes, please add the  label to this Pull Request -->

## References (if applicable):
(https://kurtosistech.slack.com/archives/C04B5FXNKU4/p1679056232033679)