### PR TITLE
docs: update the headers for the delay dist objects

### DIFF
--- a/docs/docs/reference/starlark-types.md
+++ b/docs/docs/reference/starlark-types.md
@@ -169,13 +169,9 @@ Make sure that the endpoint returns valid JSON response for both POST and GET re
 
 :::
 
-### PacketDelayDistribution
+### UniformPacketDelayDistribution
 
-The `PacketDelayDistribution` can be used in conjuction with [`ConnectionConfig`][connection-config] to introduce latency between two [`subnetworks`][subnetworks-reference]. See [`set_connection`][starlark-instructions-set-connection] instruction to learn more about its usage.
-
-#### UniformPacketDelayDistribution
-
-The `UniformPacketDelayDistribution` creates a packet delay distribution with constant delay in `ms`
+The `UniformPacketDelayDistribution` creates a packet delay distribution with constant delay in `ms`. This can be used in conjuction with [`ConnectionConfig`][connection-config] to introduce latency between two [`subnetworks`][subnetworks-reference]. See [`set_connection`][starlark-instructions-set-connection] instruction to learn more about its usage.
 
 ```python
 
@@ -187,9 +183,9 @@ delay  = UniformPacketDelayDistribution(
 )
 ```
 
-#### NormalPacketDelayDistribution
+### NormalPacketDelayDistribution
 
-The `NormalPacketDelayDistribution` can be used to create packet delays that are distributed according to a normal distribution.
+The `NormalPacketDelayDistribution` creates a packet delay distirbution that follows a normal distribution. This can be used in conjuction with [`ConnectionConfig`][connection-config] to introduce latency between two [`subnetworks`][subnetworks-reference]. See [`set_connection`][starlark-instructions-set-connection] instruction to learn more about its usage.
 
 ```python
 


### PR DESCRIPTION
## Description:
Similar to #189, this PR breaks out the header titles for the docs about the packet delay distribution objects 

## Is this change user facing?
<!-- A user facing change is one that you should expect a day-to-day user to encounter or if the change requires user-action upon or before upgrading. If in doubt, select "Yes" -->
* [X] Yes
* [ ] No

<!-- If yes, please add the  label to this Pull Request -->

## References (if applicable):
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->

Changelog picked up from commits here:

docs: update the headers for the delay dist objects