### PR TITLE
fix: Lock default context in contexts config

### DIFF
--- a/contexts-config-store/store/contexts_config_store.go
+++ b/contexts-config-store/store/contexts_config_store.go
@@ -7,11 +7,11 @@ import (
 )
 
 var (
-	once               sync.Once
-	contextConfigStore ContextConfigStore
+	once                sync.Once
+	contextsConfigStore ContextsConfigStore
 )
 
-type ContextConfigStore interface {
+type ContextsConfigStore interface {
 	// GetKurtosisContextsConfig returns the currently saved contexts configuration.
 	GetKurtosisContextsConfig() (*generated.KurtosisContextsConfig, error)
 
@@ -31,9 +31,9 @@ type ContextConfigStore interface {
 	RemoveContext(contextUuid *generated.ContextUuid) error
 }
 
-func GetContextConfigStore() ContextConfigStore {
+func GetContextsConfigStore() ContextsConfigStore {
 	once.Do(func() {
-		contextConfigStore = NewContextConfigStore(persistence.NewFileBackedConfigPersistence())
+		contextsConfigStore = NewContextConfigStore(persistence.NewFileBackedConfigPersistence())
 	})
-	return contextConfigStore
+	return contextsConfigStore
 }

--- a/contexts-config-store/store/contexts_config_store_impl.go
+++ b/contexts-config-store/store/contexts_config_store_impl.go
@@ -94,8 +94,8 @@ func (store *contextConfigStoreImpl) AddNewContext(newContext *generated.Kurtosi
 	defer store.Unlock()
 
 	if newContext.GetName() == persistence.DefaultContextName {
-		return stacktrace.NewError("Adding a new context names '%s' is not allowed as it is the reserved context "+
-			"name", persistence.DefaultContextName)
+		return stacktrace.NewError("Adding a new context with name '%s' is not allowed as it is a reserved "+
+			"context name", persistence.DefaultContextName)
 	}
 
 	contextsConfig, err := store.storage.LoadContextsConfig()

--- a/contexts-config-store/store/contexts_config_store_impl_test.go
+++ b/contexts-config-store/store/contexts_config_store_impl_test.go
@@ -143,7 +143,7 @@ func TestAddNewContext_DefaultContext(t *testing.T) {
 	newDefaultContext := api.NewLocalOnlyContext(contextUuid, persistence.DefaultContextName)
 	err := testContextConfigStore.AddNewContext(newDefaultContext)
 	require.Error(t, err)
-	expectedErr := fmt.Sprintf("Adding a new context names '%s' is not allowed as it is the reserved context name",
+	expectedErr := fmt.Sprintf("Adding a new context with name '%s' is not allowed as it is a reserved context name",
 		persistence.DefaultContextName)
 	require.Contains(t, err.Error(), expectedErr)
 

--- a/contexts-config-store/store/contexts_config_store_impl_test.go
+++ b/contexts-config-store/store/contexts_config_store_impl_test.go
@@ -134,6 +134,25 @@ func TestAddNewContext_AlreadyExists(t *testing.T) {
 	storage.AssertNotCalled(t, method.Name, mock.Anything)
 }
 
+func TestAddNewContext_DefaultContext(t *testing.T) {
+	// Setup storage mock
+	storage := persistence.NewMockConfigPersistence(t)
+
+	// Run test
+	testContextConfigStore := NewContextConfigStore(storage)
+	newDefaultContext := api.NewLocalOnlyContext(contextUuid, persistence.DefaultContextName)
+	err := testContextConfigStore.AddNewContext(newDefaultContext)
+	require.Error(t, err)
+	expectedErr := fmt.Sprintf("Adding a new context names '%s' is not allowed as it is the reserved context name",
+		persistence.DefaultContextName)
+	require.Contains(t, err.Error(), expectedErr)
+
+	// Need to check the method exist first because if the method name changes in the future this test would do nothing
+	method, found := reflect.TypeOf(storage).MethodByName(persistMethodName)
+	require.True(t, found)
+	storage.AssertNotCalled(t, method.Name, mock.Anything)
+}
+
 func TestRemoveContext(t *testing.T) {
 	// Setup storage mock
 	storage := persistence.NewMockConfigPersistence(t)
@@ -159,9 +178,31 @@ func TestRemoveContext_FailureCurrentContext(t *testing.T) {
 	testContextConfigStore := NewContextConfigStore(storage)
 	err := testContextConfigStore.RemoveContext(contextUuid)
 	require.Error(t, err)
-	expecteErr := fmt.Sprintf("Cannot remove context '%s' as it is currently the selected context. Switch to a "+
+	expectedErr := fmt.Sprintf("Cannot remove context '%s' as it is currently the selected context. Switch to a "+
 		"different context before removing it", contextUuid.GetValue())
-	require.Contains(t, err.Error(), expecteErr)
+	require.Contains(t, err.Error(), expectedErr)
+
+	// Need to check the method exist first because if the method name changes in the future this test would do nothing
+	persistMethod, found := reflect.TypeOf(storage).MethodByName(persistMethodName)
+	require.True(t, found)
+	storage.AssertNotCalled(t, persistMethod.Name, mock.Anything)
+}
+
+func TestRemoveContext_FailureDefaultContext(t *testing.T) {
+	// Setup storage mock
+	storage := persistence.NewMockConfigPersistence(t)
+	defaultContextUuid := api.NewContextUuid("default-context-uuid")
+	defaultDefaultContext := api.NewLocalOnlyContext(defaultContextUuid, persistence.DefaultContextName)
+	contextsConfig := api.NewKurtosisContextsConfig(contextUuid, defaultDefaultContext, localContext)
+	storage.EXPECT().LoadContextsConfig().Return(contextsConfig, nil)
+
+	// Run test
+	testContextConfigStore := NewContextConfigStore(storage)
+	err := testContextConfigStore.RemoveContext(defaultContextUuid)
+	require.Error(t, err)
+	expectedErr := fmt.Sprintf("Cannot remove context '%s' as it is a reserved context",
+		persistence.DefaultContextName)
+	require.Contains(t, err.Error(), expectedErr)
 
 	// Need to check the method exist first because if the method name changes in the future this test would do nothing
 	persistMethod, found := reflect.TypeOf(storage).MethodByName(persistMethodName)

--- a/contexts-config-store/store/persistence/default_contexts_config.go
+++ b/contexts-config-store/store/persistence/default_contexts_config.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	defaultContextName = "default"
+	DefaultContextName = "default"
 )
 
 func NewDefaultContextsConfig() (*generated.KurtosisContextsConfig, error) {
@@ -23,6 +23,6 @@ func NewDefaultContextsConfig() (*generated.KurtosisContextsConfig, error) {
 	newContextUuidStr := strings.Replace(randomUuid.String(), "-", "", -1)
 
 	defaultContextUuid := api.NewContextUuid(newContextUuidStr)
-	defaultContext := api.NewLocalOnlyContext(defaultContextUuid, defaultContextName)
+	defaultContext := api.NewLocalOnlyContext(defaultContextUuid, DefaultContextName)
 	return api.NewKurtosisContextsConfig(defaultContextUuid, defaultContext), nil
 }


### PR DESCRIPTION
## Description:
Disable possibility to add a new context with name `default` or removing the `default` context. This can lead to unexpected situation where someone ends up having a single remote context, and this remote context not working properly on the server. This might be something we want to allow in the future, but for now disabling it will save us some edge cases pain.

## Is this change user facing?
<!-- A user facing change is one that you should expect a day-to-day user to encounter or if the change requires user-action upon or before upgrading. If in doubt, select "Yes" -->
NO

<!-- If yes, please add the `user facing` label to this Pull Request -->

## References (if applicable):
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
