### PR TITLE
ci: Remove docker login from build step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -244,7 +244,6 @@ jobs:
 
       - setup_remote_docker:
           version: "<< pipeline.parameters.docker-engine-version>>"
-      - run: echo "${DOCKER_PASSWORD}" | docker login -u ${DOCKER_USERNAME} --password-stdin
 
       - run: |
           core/files_artifacts_expander/scripts/build.sh
@@ -293,7 +292,6 @@ jobs:
 
       - setup_remote_docker:
           version: "<< pipeline.parameters.docker-engine-version>>"
-      - run: echo "${DOCKER_PASSWORD}" | docker login -u ${DOCKER_USERNAME} --password-stdin
 
       # Cache our dependencies
       - restore_cache:
@@ -348,7 +346,6 @@ jobs:
 
       - setup_remote_docker:
           version: "<< pipeline.parameters.docker-engine-version>>"
-      - run: echo "${DOCKER_PASSWORD}" | docker login -u ${DOCKER_USERNAME} --password-stdin
 
       # Cache our dependencies
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -426,7 +426,6 @@ jobs:
       # We call Kurtosis a bunch later, so add it to the PATH so we can call it easily
       - run: |
           echo 'export KURTOSIS_BINPATH="<< pipeline.parameters.workspace-with-cli-binary-and-images-mountpoint >>/<< pipeline.parameters.cli-dist-home-relative-dirpath >>/<< pipeline.parameters.cli-linux-amd-64-binary-relative-filepath >>"' >> "${BASH_ENV}"
-      - run: echo "${DOCKER_PASSWORD}" | docker login -u ${DOCKER_USERNAME} --password-stdin
       #Run config init to avoid metrics consent prompt when execute engine start command,
       #We do not send metrics from CI to not dirty the metrics data
       - run: "${KURTOSIS_BINPATH} analytics disable"
@@ -495,7 +494,6 @@ jobs:
       # We call Kurtosis a bunch later, so add it to the PATH so we can call it easily
       - run: |
           echo 'export KURTOSIS_BINPATH="<< pipeline.parameters.workspace-with-cli-binary-and-images-mountpoint >>/<< pipeline.parameters.cli-dist-home-relative-dirpath >>/<< pipeline.parameters.cli-linux-amd-64-binary-relative-filepath >>"' >> "${BASH_ENV}"
-      - run: echo "${DOCKER_PASSWORD}" | docker login -u ${DOCKER_USERNAME} --password-stdin
 
       #Run install Yarn because TypeScript tests are managed with Yarn package manager
       - run: npm install -g yarn
@@ -564,8 +562,6 @@ jobs:
       - checkout
 
       - <<: *abort_job_if_only_docs_changes
-
-      - run: echo "${DOCKER_PASSWORD}" | docker login -u ${DOCKER_USERNAME} --password-stdin
 
       # Set up Kurtosis
       - attach_workspace:
@@ -638,8 +634,6 @@ jobs:
       - checkout
 
       - <<: *abort_job_if_only_docs_changes
-
-      - run: echo "${DOCKER_PASSWORD}" | docker login -u ${DOCKER_USERNAME} --password-stdin
 
       # Set up Kurtosis
       - attach_workspace:


### PR DESCRIPTION
## Description:
<!-- Describe this change, how it works, and the motivation behind it. -->
This step is unnecessary for anything that is not a publish step, while blocking OSS contributions due to the usage of docker hub credentials.

## Is this change user facing?
NO
<!-- If yes, please add the "user facing" label to the PR -->
<!-- If yes, don't forget to include docs changes where relevant -->

## References (if applicable):
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
