### PR TITLE
ci: make title checker use pull_request_target to allow forked PRs

### DIFF
--- a/.github/workflows/conventional-pr-title-checker.yml
+++ b/.github/workflows/conventional-pr-title-checker.yml
@@ -7,9 +7,9 @@ on:
       - reopened
       - edited
       - synchronize
-#  push:
-#    branches:
-#      - gh-readonly-queue/main/**
+  push:
+    branches:
+      - gh-readonly-queue/main/**
 
 # cancel redundant builds
 concurrency:
@@ -18,8 +18,8 @@ concurrency:
 
 jobs:
   title_check:
-#    # weg want this job to be skipped on merge queue PRs
-#    if: contains(github.ref_name, 'gh-readonly-queue/main/') != true
+    # weg want this job to be skipped on merge queue PRs
+    if: contains(github.ref_name, 'gh-readonly-queue/main/') != true
 
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/conventional-pr-title-checker.yml
+++ b/.github/workflows/conventional-pr-title-checker.yml
@@ -1,25 +1,25 @@
 # Check PR title for conventional commits
 name: Check PR title
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - reopened
       - edited
       - synchronize
-  push:
-    branches:
-      - gh-readonly-queue/main/**
+#  push:
+#    branches:
+#      - gh-readonly-queue/main/**
 
 # cancel redundant builds
 concurrency:
-  group: "title-checker-${{ github.ref }}"
+  group: "title-checker-${{ github.head_ref }}"
   cancel-in-progress: true
 
 jobs:
   title_check:
-    # weg want this job to be skipped on merge queue PRs
-    if: contains(github.ref_name, 'gh-readonly-queue/main/') != true
+#    # weg want this job to be skipped on merge queue PRs
+#    if: contains(github.ref_name, 'gh-readonly-queue/main/') != true
 
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/conventional-pr-title-checker.yml
+++ b/.github/workflows/conventional-pr-title-checker.yml
@@ -13,7 +13,9 @@ on:
 
 # cancel redundant builds
 concurrency:
-  group: "title-checker-${{ github.head_ref }}"
+  # for a pull_request_target trigger head_ref will be available otherwise
+  # it falls back to ref
+  group: "title-checker-${{ github.head_ref || github.ref }}"
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Description:
Forked PRs break with title checker if we use pull_request instead of pull_request_target

## Is this change user facing?
NO
