### PR TITLE
fix: name all args for add_services instruction in quickstart

### DIFF
--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -8,15 +8,6 @@ Introduction
 ------------
 Welcome to the [Kurtosis][homepage] quickstart! This guide will take ~15 minutes and will walk you through building a basic Kurtosis package.
 
-:::info
-In this Quickstart, you will:
-- Start a containerized Postgres database in Kurtosis
-- Seed your database with test data using task sequencing
-- Connect an API server to your database using dynamic service dependencies
-- Parameterize your application setup in order to automate loading data into your API
-:::
-
-
 #### Setup
 Before you proceed, make sure you have [Kurtosis installed][installing-kurtosis-guide] (or [upgraded to latest][upgrading-kurtosis-guide] if you already have it), Docker is started, and the Docker engine is running.
 

--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -6,7 +6,12 @@ slug: /quickstart
 
 Introduction
 ------------
-Welcome to the [Kurtosis][homepage] quickstart! This guide will take ~15 minutes and will walk you through building a basic Kurtosis package.
+Welcome to the [Kurtosis][homepage] quickstart! 
+
+If you arrived here by chance and you're curious as to what Kurtosis _is_, [see here][what-is-kurtosis-explanation].
+
+If you're ready to get going, this guide will take ~15 minutes and will walk you through building a basic Kurtosis package. The package that you build will start a Postgres server, seed it with data, put an API in front of it, and automate loading data into it.
+
 
 #### Setup
 Before you proceed, make sure you have [Kurtosis installed][installing-kurtosis-guide] (or [upgraded to latest][upgrading-kurtosis-guide] if you already have it), Docker is started, and the Docker engine is running.

--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -6,11 +6,16 @@ slug: /quickstart
 
 Introduction
 ------------
-Welcome to the [Kurtosis][homepage] quickstart!
+Welcome to the [Kurtosis][homepage] quickstart! This guide will take ~15 minutes and will walk you through building a basic Kurtosis package.
 
-If you arrived here by chance and you're curious as to what Kurtosis _is_, [see here][what-is-kurtosis-explanation].
+:::info
+In this Quickstart, you will:
+- Start a containerized Postgres database in Kurtosis
+- Seed your database with test data using task sequencing
+- Connect an API server to your database using dynamic service dependencies
+- Parameterize your application setup in order to automate loading data into your API
+:::
 
-If you're ready to get going, this guide will take ~15 minutes and will walk you through building a basic Kurtosis package. The package that you build will start a Postgres server, seed it with data, put an API in front of it, and automate loading data into it.
 
 #### Setup
 Before you proceed, make sure you have [Kurtosis installed][installing-kurtosis-guide] (or [upgraded to latest][upgrading-kurtosis-guide] if you already have it), Docker is started, and the Docker engine is running.
@@ -118,8 +123,8 @@ POSTGRES_PASSWORD = "password"
 def run(plan, args):
     # Add a Postgres server
     postgres = plan.add_service(
-        "postgres",
-        ServiceConfig(
+        serivce_name = "postgres",
+        config = ServiceConfig(
             image = "postgres:15.2-alpine",
             ports = {
                 POSTGRES_PORT_ID: PortSpec(5432, application_protocol = "postgresql"),
@@ -208,7 +213,7 @@ def run(plan, args):
     # Add a Postgres server
     postgres = plan.add_service(
         service_name = "postgres",
-        ServiceConfig(
+        config = ServiceConfig(
             image = "postgres:15.2-alpine",
             ports = {
                 POSTGRES_PORT_ID: PortSpec(5432, application_protocol = "postgresql"),
@@ -365,8 +370,8 @@ Kurtosis' first-class data primitive is called a [files artifact][files-artifact
 
 ```python
 postgres = plan.add_service(
-    "postgres",
-    ServiceConfig(
+    service_name = "postgres",
+    config = ServiceConfig(
         # ...omitted...
         files = {
             SEED_DATA_DIRPATH: data_package_module_result.files_artifact,
@@ -427,7 +432,7 @@ def run(plan, args):
     # Add a Postgres server
     postgres = plan.add_service(
         service_name = "postgres",
-        ServiceConfig(
+        config = ServiceConfig(
             image = "postgres:15.2-alpine",
             ports = {
                 POSTGRES_PORT_ID: PortSpec(5432, application_protocol = "postgresql"),
@@ -569,7 +574,7 @@ def run(plan, args):
     # Add a Postgres server
     postgres = plan.add_service(
         service_name = "postgres",
-        ServiceConfig(
+        config = ServiceConfig(
             # ...
             env_vars = {
                 # ...
@@ -715,7 +720,7 @@ def run(plan, args):
     # Add a Postgres server
     postgres = plan.add_service(
         service_name = "postgres",
-        ServiceConfig(
+        config = ServiceConfig(
             image = "postgres:15.2-alpine",
             ports = {
                 POSTGRES_PORT_ID: PortSpec(5432, application_protocol = "postgresql"),


### PR DESCRIPTION
## Description:
Since Starlark requires named args to come after positional args, or have all args be named, the change made [here](https://github.com/kurtosis-tech/kurtosis/pull/299/files#diff-db23839e9fa71374d53983730e318028367dff34e8c817cd1e8acfec09624fe8L200) meant that the starlark package would fail to run. 

This PR names _all_ the args in the `add_service` and `add_services` instruction in our quickstart code snippets to ensure it runs smoothly. This change also ensures that the code snippet follows the same syntax structure as what our reference docs say [here](https://docs.kurtosis.com/reference/starlark-instructions#add_service)

## Is this change user facing?
YES
<!-- If yes, please add the "user facing" label to the PR -->
<!-- If yes, don't forget to include docs changes where relevant -->

## References (if applicable):
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
#299 
