### PR TITLE
docs: change navbar logo to link to homepage

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -67,6 +67,7 @@ const config = {
         logo: {
           alt: 'Kurtosis',
           src: 'img/brand/kurtosis-logo-white-text.png',
+          target: 'https://kurtosis.com'
         },
         items: [
           {

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -67,7 +67,8 @@ const config = {
         logo: {
           alt: 'Kurtosis',
           src: 'img/brand/kurtosis-logo-white-text.png',
-          href: 'https://kurtosis.com'
+          href: 'https://kurtosis.com',
+          target: '_self'
         },
         items: [
           {

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -67,7 +67,7 @@ const config = {
         logo: {
           alt: 'Kurtosis',
           src: 'img/brand/kurtosis-logo-white-text.png',
-          target: 'https://kurtosis.com'
+          href: 'https://kurtosis.com'
         },
         items: [
           {


### PR DESCRIPTION
## Description:
We used to link to docs.kurtosis.com now we link to kurtoiss.com if you click on the logo on the top left of navbar

## Is this change user facing?
YES

## References (if applicable):
https://kurtosistech.slack.com/archives/C04CKKMLK96/p1679932314878619
