### PR TITLE
ci: make CI less fragile by making publish CLI check for files artifacts expander image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1126,6 +1126,7 @@ workflows:
             - publish_kurtosis_api_typescript
             - publish_api_container_server_image
             - publish_engine_server_image
+            - publish_files_artifacts_expander_image
           filters:
             branches:
               ignore: /.*/


### PR DESCRIPTION
## Description:
We didn't care about an image that we should have cared for

## Is this change user facing?
NO
