### PR TITLE
docs: fix "service_name" typo in our quickstart

### DIFF
--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -121,7 +121,7 @@ POSTGRES_PASSWORD = "password"
 def run(plan, args):
     # Add a Postgres server
     postgres = plan.add_service(
-        serivce_name = "postgres",
+        service_name = "postgres",
         config = ServiceConfig(
             image = "postgres:15.2-alpine",
             ports = {


### PR DESCRIPTION
## Description:
Fixes a typo introduced in #316

## Is this change user facing?
YES
<!-- If yes, please add the "user facing" label to the PR -->
<!-- If yes, don't forget to include docs changes where relevant -->

## References (if applicable):
#316 
