### PR TITLE
feat: best effort autocomplete for service logs after engine restart

### DIFF
--- a/engine/server/engine/enclave_manager/enclave_manager.go
+++ b/engine/server/engine/enclave_manager/enclave_manager.go
@@ -352,17 +352,16 @@ func (manager *EnclaveManager) GetExistingAndHistoricalEnclaveIdentifiers() ([]*
 	// TODO fix this - this is a hack while we persist enclave identifier information to disk
 	// this is a hack that will only send enclaves that are still registered; removed or destroyed enclaves will not show up
 	ctx := context.Background()
-	allCurrentEnclavesToBackFillRestart, err := manager.kurtosisBackend.GetEnclaves(ctx, getAllEnclavesFilter())
+	allCurrentEnclavesToBackFillRestart, err := manager.getEnclavesWithoutMutex(ctx)
 	if err != nil {
 		return nil, stacktrace.Propagate(err, "Found no registered enclaves in the in memory map; tried fetching them from backend but failed")
 	}
 
 	for _, enclave := range allCurrentEnclavesToBackFillRestart {
-		enclaveUuidStr := string(enclave.GetUUID())
 		identifiers := &kurtosis_engine_rpc_api_bindings.EnclaveIdentifiers{
-			EnclaveUuid:   enclaveUuidStr,
-			Name:          enclave.GetName(),
-			ShortenedUuid: uuid_generator.ShortenedUUIDString(enclaveUuidStr),
+			EnclaveUuid:   enclave.EnclaveUuid,
+			Name:          enclave.Name,
+			ShortenedUuid: enclave.ShortenedUuid,
 		}
 		enclaveIdentifiersResult = append(enclaveIdentifiersResult, identifiers)
 	}

--- a/engine/server/engine/server/engine_server_service.go
+++ b/engine/server/engine/server/engine_server_service.go
@@ -89,7 +89,10 @@ func (service *EngineServerService) GetEnclaves(ctx context.Context, _ *emptypb.
 }
 
 func (service *EngineServerService) GetExistingAndHistoricalEnclaveIdentifiers(_ context.Context, _ *emptypb.Empty) (*kurtosis_engine_rpc_api_bindings.GetExistingAndHistoricalEnclaveIdentifiersResponse, error) {
-	allIdentifiers := service.enclaveManager.GetExistingAndHistoricalEnclaveIdentifiers()
+	allIdentifiers, err := service.enclaveManager.GetExistingAndHistoricalEnclaveIdentifiers()
+	if err != nil {
+		return nil, stacktrace.Propagate(err, "An error occurred while fetching enclave identifiers")
+	}
 	response := &kurtosis_engine_rpc_api_bindings.GetExistingAndHistoricalEnclaveIdentifiersResponse{AllIdentifiers: allIdentifiers}
 	return response, nil
 }


### PR DESCRIPTION
## Description:
Earlier engine restart would make autocomplete for service logs not work. Now we do a best effort and fetch whatever we can from disk. In the longer term we want identifiers to be persisted on disk so that this doesn't happen.

## Is this change user facing?
YES

## References (if applicable):
Closes #373 
