### PR TITLE
fix: polish Github issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,6 +1,5 @@
 name: "Bug Report"
 description: Report a bug with Kurtosis
-title: "[bug]: "
 labels: ["bug"]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,5 +1,5 @@
 name: "Bug Report"
-description: We are always striving to improve Kurtosis. Use this form to report a bug with Kurtosis.
+description: Report a bug with Kurtosis
 title: "[bug]: "
 labels: ["bug"]
 body:

--- a/.github/ISSUE_TEMPLATE/docs-issue.yml
+++ b/.github/ISSUE_TEMPLATE/docs-issue.yml
@@ -1,7 +1,6 @@
 name: "Docs Issue"
 description: Report an issue in our documentation
 labels: ["docs"]
-title: "[Docs]: "
 assignees:
   - leeederek
 body:

--- a/.github/ISSUE_TEMPLATE/docs-issue.yml
+++ b/.github/ISSUE_TEMPLATE/docs-issue.yml
@@ -1,5 +1,5 @@
 name: "Docs Issue"
-description: We are always striving to improve Kurtosis. Use this form to report an issue with our documentation. 
+description: Report an issue in our documentation
 labels: ["docs"]
 title: "[Docs]: "
 assignees:

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,7 +1,6 @@
 name: "Feature Request"
-description: We are always striving to improve Kurtosis. Use this form to suggest a new feature or improvement. 
+description: Suggest a new feature, improvement, or change 
 labels: ["feature request"]
-title: "[FR]: "
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -6,7 +6,7 @@ body:
     attributes:
       value: |
         Thank you for taking the time to fill out this Feature Request form. We value your feedback.
-        Please make sure to update the title of this Feature Request to concisely describe the request.
+        Please make sure to add a title to this Feature Request to concisely describe your suggestion.
   - type: textarea
     id: background-and-motivation
     attributes:


### PR DESCRIPTION

## Description:
- Shorten bug report, FR, and docs tagline from the "choose new issue" page
- Remove the title prefix in the bug report, FR, and docs issue templates

## Is this change user facing?
YES

## References (if applicable):
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
