### PR TITLE
refactor!: Moved the `sevice_name` argument to the first position in the `exec`, `request`, and `wait` instructions, users will have to adapt these instructions calls if where using positional arguments.

### DIFF
--- a/core/server/api_container/server/startosis_engine/kurtosis_instruction/exec/exec.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_instruction/exec/exec.go
@@ -39,18 +39,18 @@ func NewExec(serviceNetwork service_network.ServiceNetwork, runtimeValueStore *r
 			Name: ExecBuiltinName,
 			Arguments: []*builtin_argument.BuiltinArgument{
 				{
-					Name:              RecipeArgName,
-					IsOptional:        false,
-					ZeroValueProvider: builtin_argument.ZeroValueProvider[*recipe.ExecRecipe],
-					Validator:         nil,
-				},
-				{
 					Name:              ServiceNameArgName,
 					IsOptional:        false,
 					ZeroValueProvider: builtin_argument.ZeroValueProvider[starlark.String],
 					Validator: func(value starlark.Value) *startosis_errors.InterpretationError {
 						return builtin_argument.NonEmptyString(value, ServiceNameArgName)
 					},
+				},
+				{
+					Name:              RecipeArgName,
+					IsOptional:        false,
+					ZeroValueProvider: builtin_argument.ZeroValueProvider[*recipe.ExecRecipe],
+					Validator:         nil,
 				},
 				{
 					Name:              AcceptableCodesArgName,

--- a/core/server/api_container/server/startosis_engine/kurtosis_instruction/request/request.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_instruction/request/request.go
@@ -50,18 +50,18 @@ func NewRequest(serviceNetwork service_network.ServiceNetwork, runtimeValueStore
 
 			Arguments: []*builtin_argument.BuiltinArgument{
 				{
-					Name:              RecipeArgName,
-					IsOptional:        false,
-					ZeroValueProvider: builtin_argument.ZeroValueProvider[*recipe.HttpRequestRecipe],
-					Validator:         nil,
-				},
-				{
 					Name:              ServiceNameArgName,
 					IsOptional:        false,
 					ZeroValueProvider: builtin_argument.ZeroValueProvider[starlark.String],
 					Validator: func(value starlark.Value) *startosis_errors.InterpretationError {
 						return builtin_argument.NonEmptyString(value, ServiceNameArgName)
 					},
+				},
+				{
+					Name:              RecipeArgName,
+					IsOptional:        false,
+					ZeroValueProvider: builtin_argument.ZeroValueProvider[*recipe.HttpRequestRecipe],
+					Validator:         nil,
 				},
 				{
 					Name:              AcceptableCodesArgName,

--- a/core/server/api_container/server/startosis_engine/kurtosis_instruction/wait/wait.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_instruction/wait/wait.go
@@ -41,6 +41,14 @@ func NewWait(serviceNetwork service_network.ServiceNetwork, runtimeValueStore *r
 
 			Arguments: []*builtin_argument.BuiltinArgument{
 				{
+					Name:              ServiceNameArgName,
+					IsOptional:        false,
+					ZeroValueProvider: builtin_argument.ZeroValueProvider[starlark.String],
+					Validator: func(value starlark.Value) *startosis_errors.InterpretationError {
+						return builtin_argument.NonEmptyString(value, ServiceNameArgName)
+					},
+				},
+				{
 					Name:              RecipeArgName,
 					IsOptional:        false,
 					ZeroValueProvider: builtin_argument.ZeroValueProvider[starlark.Value],
@@ -75,14 +83,6 @@ func NewWait(serviceNetwork service_network.ServiceNetwork, runtimeValueStore *r
 					IsOptional:        true,
 					ZeroValueProvider: builtin_argument.ZeroValueProvider[starlark.String],
 					Validator:         nil,
-				},
-				{
-					Name:              ServiceNameArgName,
-					IsOptional:        false,
-					ZeroValueProvider: builtin_argument.ZeroValueProvider[starlark.String],
-					Validator: func(value starlark.Value) *startosis_errors.InterpretationError {
-						return builtin_argument.NonEmptyString(value, ServiceNameArgName)
-					},
 				},
 			},
 		},

--- a/core/server/api_container/server/startosis_engine/kurtosis_starlark_framework/test_engine/exec_framework_test_case_1_test.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_starlark_framework/test_engine/exec_framework_test_case_1_test.go
@@ -50,7 +50,7 @@ func (t execTestCase1) GetInstruction() *kurtosis_plan_instruction.KurtosisPlanI
 
 func (t execTestCase1) GetStarlarkCode() string {
 	recipe := `ExecRecipe(command=["mkdir", "-p", "/tmp/store"])`
-	return fmt.Sprintf("%s(%s=%s, %s=%q)", exec.ExecBuiltinName, exec.RecipeArgName, recipe, exec.ServiceNameArgName, execServiceName)
+	return fmt.Sprintf("%s(%s=%q, %s=%s)", exec.ExecBuiltinName, exec.ServiceNameArgName, execServiceName, exec.RecipeArgName, recipe)
 }
 
 func (t *execTestCase1) GetStarlarkCodeForAssertion() string {

--- a/core/server/api_container/server/startosis_engine/kurtosis_starlark_framework/test_engine/exec_framework_test_case_2_test.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_starlark_framework/test_engine/exec_framework_test_case_2_test.go
@@ -46,12 +46,12 @@ func (t execTestCase2) GetInstruction() *kurtosis_plan_instruction.KurtosisPlanI
 
 func (t execTestCase2) GetStarlarkCode() string {
 	recipe := `ExecRecipe(command=["mkdir", "-p", "/tmp/store"])`
-	return fmt.Sprintf("%s(%s, %q)", exec.ExecBuiltinName, recipe, execServiceName)
+	return fmt.Sprintf("%s(%q, %s)", exec.ExecBuiltinName, execServiceName, recipe)
 }
 
 func (t *execTestCase2) GetStarlarkCodeForAssertion() string {
 	recipe := `ExecRecipe(command=["mkdir", "-p", "/tmp/store"])`
-	return fmt.Sprintf("%s(%s=%s, %s=%q)", exec.ExecBuiltinName, exec.RecipeArgName, recipe, exec.ServiceNameArgName, execServiceName)
+	return fmt.Sprintf("%s(%s=%q, %s=%s)", exec.ExecBuiltinName, exec.ServiceNameArgName, execServiceName, exec.RecipeArgName, recipe)
 }
 
 func (t execTestCase2) Assert(interpretationResult starlark.Value, executionResult *string) {

--- a/core/server/api_container/server/startosis_engine/kurtosis_starlark_framework/test_engine/request_framework_test_case_1_test.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_starlark_framework/test_engine/request_framework_test_case_1_test.go
@@ -78,7 +78,7 @@ func (t *requestTestCase1) GetInstruction() *kurtosis_plan_instruction.KurtosisP
 
 func (t *requestTestCase1) GetStarlarkCode() string {
 	recipe := fmt.Sprintf(`GetHttpRequestRecipe(port_id=%q, endpoint=%q, extract={"key": ".value"})`, requestPortId, requestEndpoint)
-	return fmt.Sprintf("%s(%s=%s, %s=%q)", request.RequestBuiltinName, request.RecipeArgName, recipe, request.ServiceNameArgName, requestTestCaseServiceName)
+	return fmt.Sprintf("%s(%s=%q, %s=%s)", request.RequestBuiltinName, request.ServiceNameArgName, requestTestCaseServiceName, request.RecipeArgName, recipe)
 }
 
 func (t *requestTestCase1) GetStarlarkCodeForAssertion() string {

--- a/core/server/api_container/server/startosis_engine/kurtosis_starlark_framework/test_engine/request_framework_test_case_2_test.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_starlark_framework/test_engine/request_framework_test_case_2_test.go
@@ -67,12 +67,12 @@ func (t *requestTestCase2) GetInstruction() *kurtosis_plan_instruction.KurtosisP
 
 func (t *requestTestCase2) GetStarlarkCode() string {
 	recipe := fmt.Sprintf(`GetHttpRequestRecipe(port_id=%q, endpoint=%q, extract={"key": ".value"})`, requestPortId, requestEndpoint)
-	return fmt.Sprintf("%s(%s, %q)", request.RequestBuiltinName, recipe, requestTestCaseServiceName)
+	return fmt.Sprintf("%s(%q, %s)", request.RequestBuiltinName, requestTestCaseServiceName, recipe)
 }
 
 func (t *requestTestCase2) GetStarlarkCodeForAssertion() string {
 	recipe := fmt.Sprintf(`GetHttpRequestRecipe(port_id=%q, endpoint=%q, extract={"key": ".value"})`, requestPortId, requestEndpoint)
-	return fmt.Sprintf("%s(%s=%s, %s=%q)", request.RequestBuiltinName, request.RecipeArgName, recipe, request.ServiceNameArgName, requestTestCaseServiceName)
+	return fmt.Sprintf("%s(%s=%q, %s=%s)", request.RequestBuiltinName, request.ServiceNameArgName, requestTestCaseServiceName, request.RecipeArgName, recipe)
 }
 
 func (t *requestTestCase2) Assert(interpretationResult starlark.Value, executionResult *string) {

--- a/core/server/api_container/server/startosis_engine/kurtosis_starlark_framework/test_engine/wait_framework_test_case_1_test.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_starlark_framework/test_engine/wait_framework_test_case_1_test.go
@@ -84,7 +84,7 @@ func (t *waitTestCase1) GetInstruction() *kurtosis_plan_instruction.KurtosisPlan
 
 func (t *waitTestCase1) GetStarlarkCode() string {
 	recipeStr := fmt.Sprintf(`PostHttpRequestRecipe(port_id=%q, endpoint=%q, body=%q, content_type=%q, extract={"key": ".value"})`, waitRecipePortId, waitRecipeEndpoint, waitRecipeBody, waitRecipeContentType)
-	return fmt.Sprintf("%s(%s=%s, %s=%q, %s=%q, %s=%s, %s=%q, %s=%q, %s=%q)", wait.WaitBuiltinName, wait.RecipeArgName, recipeStr, wait.ValueFieldArgName, waitValueField, wait.AssertionArgName, waitAssertion, wait.TargetArgName, waitTargetValue, wait.IntervalArgName, waitInterval, wait.TimeoutArgName, waitTimeout, wait.ServiceNameArgName, waitRecipeTestCaseServiceName)
+	return fmt.Sprintf("%s(%s=%q, %s=%s, %s=%q, %s=%q, %s=%s, %s=%q, %s=%q)", wait.WaitBuiltinName, wait.ServiceNameArgName, waitRecipeTestCaseServiceName, wait.RecipeArgName, recipeStr, wait.ValueFieldArgName, waitValueField, wait.AssertionArgName, waitAssertion, wait.TargetArgName, waitTargetValue, wait.IntervalArgName, waitInterval, wait.TimeoutArgName, waitTimeout)
 }
 
 func (t *waitTestCase1) GetStarlarkCodeForAssertion() string {

--- a/core/server/api_container/server/startosis_engine/kurtosis_starlark_framework/test_engine/wait_framework_test_case_2_test.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_starlark_framework/test_engine/wait_framework_test_case_2_test.go
@@ -68,12 +68,12 @@ func (t *waitTestCase2) GetInstruction() *kurtosis_plan_instruction.KurtosisPlan
 
 func (t *waitTestCase2) GetStarlarkCode() string {
 	recipeStr := fmt.Sprintf(`PostHttpRequestRecipe(port_id=%q, endpoint=%q, body=%q, content_type=%q, extract={"key": ".value"})`, waitRecipePortId, waitRecipeEndpoint, waitRecipeBody, waitRecipeContentType)
-	return fmt.Sprintf("%s(%s, %q, %q, %s, %q, %q, %q)", wait.WaitBuiltinName, recipeStr, waitValueField, waitAssertion, waitTargetValue, waitInterval, waitTimeout, waitRecipeTestCaseServiceName)
+	return fmt.Sprintf("%s(%q, %s, %q, %q, %s, %q, %q)", wait.WaitBuiltinName, waitRecipeTestCaseServiceName, recipeStr, waitValueField, waitAssertion, waitTargetValue, waitInterval, waitTimeout)
 }
 
 func (t *waitTestCase2) GetStarlarkCodeForAssertion() string {
 	recipeStr := fmt.Sprintf(`PostHttpRequestRecipe(port_id=%q, endpoint=%q, body=%q, content_type=%q, extract={"key": ".value"})`, waitRecipePortId, waitRecipeEndpoint, waitRecipeBody, waitRecipeContentType)
-	return fmt.Sprintf("%s(%s=%s, %s=%q, %s=%q, %s=%s, %s=%q, %s=%q, %s=%q)", wait.WaitBuiltinName, wait.RecipeArgName, recipeStr, wait.ValueFieldArgName, waitValueField, wait.AssertionArgName, waitAssertion, wait.TargetArgName, waitTargetValue, wait.IntervalArgName, waitInterval, wait.TimeoutArgName, waitTimeout, wait.ServiceNameArgName, waitRecipeTestCaseServiceName)
+	return fmt.Sprintf("%s(%s=%q, %s=%s, %s=%q, %s=%q, %s=%s, %s=%q, %s=%q)", wait.WaitBuiltinName, wait.ServiceNameArgName, waitRecipeTestCaseServiceName, wait.RecipeArgName, recipeStr, wait.ValueFieldArgName, waitValueField, wait.AssertionArgName, waitAssertion, wait.TargetArgName, waitTargetValue, wait.IntervalArgName, waitInterval, wait.TimeoutArgName, waitTimeout)
 }
 
 func (t *waitTestCase2) Assert(interpretationResult starlark.Value, executionResult *string) {

--- a/docs/docs/reference/starlark-instructions.md
+++ b/docs/docs/reference/starlark-instructions.md
@@ -185,6 +185,11 @@ exec_recipe = ExecRecipe(
 )
 
 result = plan.exec(
+    # A Service name designating a service that already exists inside the enclave
+    # If it does not, a validation error will be thrown
+    # MANDATORY
+    service_name = "my-service",
+    
     # The recipe that will determine the exec to be performed.
     # Valid values are of the following types: (ExecRecipe)
     # MANDATORY
@@ -198,11 +203,6 @@ result = plan.exec(
     # You can chain this call with assert to check codes after request is done.
     # OPTIONAL (Defaults to False)
     skip_code_check = False,
-
-    # A Service name designating a service that already exists inside the enclave
-    # If it does not, a validation error will be thrown
-    # MANDATORY
-    service_name = "my-service",
 )
 
 plan.print(result["output"])
@@ -337,6 +337,11 @@ To make a GET or POST request, simply set the `recipe` field to use the specifie
 
 ```python
 http_response = plan.request(
+    # A service name designating a service that already exists inside the enclave
+    # If it does not, a validation error will be thrown
+    # MANDATORY
+    service_name = "my_service",
+    
     # The recipe that will determine the request to be performed.
     # Valid values are of the following types: (GetHttpRequestRecipe, PostHttpRequestRecipe)
     # MANDATORY
@@ -350,11 +355,6 @@ http_response = plan.request(
     # You can chain this call with assert to check codes after request is done.
     # OPTIONAL (defaults to False)
     skip_code_check = false,
-    
-    # A service name designating a service that already exists inside the enclave
-    # If it does not, a validation error will be thrown
-    # MANDATORY
-    service_name = "my_service",
 )
 plan.print(get_response["body"]) # Prints the body of the request
 plan.print(get_response["code"]) # Prints the result code of the request (e.g. 200, 500)
@@ -558,6 +558,11 @@ If it succeeds, it returns a [future references][future-references-reference] wi
 ```python
 # This fails in runtime if response["code"] != 200 for each request in a 5 minute time span
 response = plan.wait(
+    # A Service name designating a service that already exists inside the enclave
+    # If it does not, a validation error will be thrown
+    # MANDATORY
+    service_name = "example-datastore-server-1",
+    
     # The recipe that will be run until assert passes.
     # Valid values are of the following types: (ExecRecipe, GetHttpRequestRecipe, PostHttpRequestRecipe)
     # MANDATORY
@@ -587,11 +592,6 @@ response = plan.wait(
     # Follows Go "time.Duration" format https://pkg.go.dev/time#ParseDuration
     # OPTIONAL (Default: "10s")
     timeout = "5m",
-
-    # A Service name designating a service that already exists inside the enclave
-    # If it does not, a validation error will be thrown
-    # MANDATORY
-    service_name = "example-datastore-server-1",
 )
 # If this point of the code is reached, the assertion has passed therefore the print statement will print "200"
 plan.print(response["code"])


### PR DESCRIPTION
## Description:
Moved the `sevice_name` argument to the first position in the `exec`, `request`, and `wait` instructions

## Is this change user facing?
YES

## References (if applicable):
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
