### PR TITLE
docs: fix docker exec link

### DIFF
--- a/docs/docs/client-libs-reference.md
+++ b/docs/docs/client-libs-reference.md
@@ -596,7 +596,7 @@ Gets the ports that the service is reachable at from _outside_ the enclave that 
 The ports (if any) that the service is reachable at from outside the enclave, identified by the user-chosen ID set in [ContainerConfig.usedPorts][containerconfig_usedports] when the service was created.
 
 ### `execCommand(List<String> command) -> (int exitCode, String logs)`
-Uses [Docker exec](https://docs.docker.com/engine/concepts-reference/commandline/exec/) functionality to execute a command inside the service's running Docker container.
+Uses [Docker exec](https://docs.docker.com/engine/reference/commandline/exec/) functionality to execute a command inside the service's running Docker container.
 
 **Args**
 


### PR DESCRIPTION
## Description:
 fix docker exec link

## Is this change user facing?
YES

## References (if applicable):
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
