### PR TITLE
fix: Fix bug with release-please PR getting a modified Yarn lockfile

### DIFF
--- a/.github/workflows/change-versions.yml
+++ b/.github/workflows/change-versions.yml
@@ -30,7 +30,8 @@ jobs:
           cd docs/
 
           # Very important to use Yarn, rather than NPM so we don't get two lockfiles!
-          yarn install
+          # Also, important to use a frozen lockfile so that Yarn isn't silently pushing updated dependencies right to 'main'
+          yarn --frozen-lockfile install
           yarn run docusaurus docs:version "${version}"
 
           cp ../CHANGELOG.md "versioned_docs/version-${version}/changelog.md"

--- a/.github/workflows/change-versions.yml
+++ b/.github/workflows/change-versions.yml
@@ -19,8 +19,8 @@ jobs:
           api/scripts/update-own-version-constants.sh "$(cat version.txt)"
           scripts/update-license-version.sh "$(cat version.txt)"
       - run: |
-          sudo apt install nodejs npm
-        name: Setup NPM for cutting new version of docs
+          sudo apt install nodejs yarn
+        name: Set up Node & Yarn for cutting new version of docs
       - name: Cut a New Docs version
         run: |
           version="$(cat version.txt)"
@@ -28,9 +28,12 @@ jobs:
           git rm -r docs/
           git checkout origin/main -- docs/
           cd docs/
-          npm install
-          npm run docusaurus docs:version $version
-          cp ../CHANGELOG.md versioned_docs/version-$version/changelog.md
+
+          # Very important to use Yarn, rather than NPM so we don't get two lockfiles!
+          yarn install
+          yarn run docusaurus docs:version "${version}"
+
+          cp ../CHANGELOG.md "versioned_docs/version-${version}/changelog.md"
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:
           token: "${{ secrets.RELEASER_TOKEN }}"

--- a/.github/workflows/push-docs.yml
+++ b/.github/workflows/push-docs.yml
@@ -14,6 +14,14 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - name:
+        run: |
+          # We had a bug where we were using both Yarn and NPM to maintain Docusaurus, which
+          # meant separate and conflicting lockfiles
+          # Only Yarn should be used
+          if [ -f docs/package-lock.json ]; then
+            exit 1
+          fi
       - name: Docs have changed
         run: |
           echo "DOCS_CHANGED=$(git --no-pager diff --exit-code origin/main...HEAD -- ':docs' > /dev/null; echo $?)" >> $GITHUB_OUTPUT

--- a/.github/workflows/push-docs.yml
+++ b/.github/workflows/push-docs.yml
@@ -30,7 +30,7 @@ jobs:
         run: cat CHANGELOG.md >> docs/docs/changelog.md
         if: github.ref == 'refs/heads/main' || steps.docs-diff.outputs.DOCS_CHANGED != 0
       - name: Yarn Install
-        run: yarn --cwd ./docs install
+        run: yarn --cwd ./docs --frozen-lockfile install
         if: github.ref == 'refs/heads/main' || steps.docs-diff.outputs.DOCS_CHANGED != 0
       - name: Yarn Build
         run: yarn --cwd ./docs build

--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,8 @@ tsconfig.tsbuildinfo
 # Generated files
 .docusaurus
 .cache-loader
+
+# We had a bug where we were using both Yarn and NPM to maintain Docusaurus, which
+# meant separate and conflicting lockfiles
+# We don't want NPM lockfiles for Docusaurus - just Yarn
+docs/package-lock.json


### PR DESCRIPTION
fix: Fix bug where the Yarn lockfile could change in the release-please PR

## Description:
Nasty bug where the release-please PR could have extra changes that weren't PR-reviewed due to:
- Using both NPM and Yarn to manage Docusaurus
- Not using frozen Yarn lockfile

## Is this change user facing?
NO
