### PR TITLE
fix: Remove no-dead-links Remark plugin

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "docusaurus": "docusaurus",
     "remark": "remark",
-    "remark:once": "yarn run remark --quiet --frail --use remark-validate-links --use remark-lint-no-dead-urls docs/",
+    "remark:once": "yarn run remark --quiet --frail --use remark-validate-links docs/",
     "start": "docusaurus start",
     "build": "yarn run remark:once && docusaurus build",
     "swizzle": "docusaurus swizzle",


### PR DESCRIPTION
## Description:
This is breaking the build due to the way historical version changelogs work: https://github.com/kurtosis-tech/kurtosis/actions/runs/4586853621/jobs/8099983419?pr=419

## Is this change user facing?
NO
