### PR TITLE
ci: Push only when PR is labeled

### DIFF
--- a/.github/workflows/push-docs.yml
+++ b/.github/workflows/push-docs.yml
@@ -39,7 +39,7 @@ jobs:
         if: github.ref == 'refs/heads/main' || steps.docs-diff.outputs.DOCS_CHANGED != 0
       - name: Publish to Cloudflare Pages
         uses: cloudflare/pages-action@v1
-        if: github.ref == 'refs/heads/main' || (steps.docs-diff.outputs.DOCS_CHANGED != 0 && contains(github.event.issue.labels.*.name, 'push docs'))
+        if: github.ref == 'refs/heads/main' || (steps.docs-diff.outputs.DOCS_CHANGED != 0 && contains(github.event.pull_request.labels.*.name, 'push docs'))
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/push-docs.yml
+++ b/.github/workflows/push-docs.yml
@@ -1,6 +1,8 @@
 name: Deploy documentation
 
-on: push
+on:
+  pull_request:
+    types: [ opened, reopened, synchronize, labeled ]
 
 jobs:
   publish:
@@ -37,7 +39,7 @@ jobs:
         if: github.ref == 'refs/heads/main' || steps.docs-diff.outputs.DOCS_CHANGED != 0
       - name: Publish to Cloudflare Pages
         uses: cloudflare/pages-action@v1
-        if: github.ref == 'refs/heads/main' || steps.docs-diff.outputs.DOCS_CHANGED != 0
+        if: github.ref == 'refs/heads/main' || (steps.docs-diff.outputs.DOCS_CHANGED != 0 && contains(github.event.issue.labels.*.name, 'push docs'))
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
## Description:
<!-- Describe this change, how it works, and the motivation behind it. -->
There are plenty of tools to devs to local build/test docs, that being `yarn dev` or even `Markdown Previewer`. The workflow of pushing branch to cloudflare is still relevant for user interviews "A/B test", but can be skipped most of the time.

From now on, we only build docs as part of regular CI, only pushing when on `main` or when a PR has `push docs` label
 
## Is this change user facing?
NO
<!-- If yes, please add the "user facing" label to the PR -->
<!-- If yes, don't forget to include docs changes where relevant -->

## References (if applicable):
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
