### PR TITLE
docs: added global flags information to the doc

### DIFF
--- a/docs/docs/cli-reference/index.md
+++ b/docs/docs/cli-reference/index.md
@@ -47,10 +47,10 @@ kurtosis run --cli-level-log error github.com/package-author/package-repo
 
 :::info
 
-Users can use the `--cli-level-log` flag to display entire flag traces to the cli. By default the entire stack-traces are logged on to `kurtosis-cli.log` file. The command below, for example, will display the entire stack-traces to the cli for debugging purpose.
+Users can use the `--cli-log-level` flag to display entire flag traces to the cli. By default the entire stack-traces are logged on to `kurtosis-cli.log` file. The command below, for example, will display the entire stack-traces to the cli for debugging purpose.
 
 ```
-kurtosis run --cli-level-log debug github.com/package-author/package-repo 
+kurtosis run --cli-log-level debug github.com/package-author/package-repo 
 ```
 :::
 

--- a/docs/docs/cli-reference/index.md
+++ b/docs/docs/cli-reference/index.md
@@ -32,7 +32,7 @@ kurtosis version
 Kurtosis CLI supports two global flags - `help` and `cli-log-level`. These flags can be used with any Kurtosis CLI commands.
 
 #### -h or --help
-This flag prints the helptext for all commands and subcommands. You can use this at any time to see information on the command you're trying to run. For example:
+This flag prints the help text for all commands and subcommands. You can use this at any time to see information on the command you're trying to run. For example:
 ```
 kurtosis service -h
 ```

--- a/docs/docs/cli-reference/index.md
+++ b/docs/docs/cli-reference/index.md
@@ -36,6 +36,31 @@ This flag prints the help text for all commands and subcommands. You can use thi
 ```
 kurtosis service -h
 ```
+<details>
+    <summary>Example Output of the above command</summary>
+
+```bash
+Manage services
+
+Usage:
+  kurtosis service [command]
+
+Available Commands:
+  add         Adds a service to an enclave
+  logs        Get service logs
+  rm          Removes a service from an enclave
+  shell       Gets a shell on a service
+
+Flags:
+  -h, --help   help for service
+
+Global Flags:
+      --cli-log-level string   Sets the level that the CLI will log at (panic|fatal|error|warning|info|debug|trace) (default "info")
+
+Use "kurtosis service [command] --help" for more information about a command.
+```
+</details>
+
 
 #### cli-log-level
 This flag sets the level of details that the Kurtosis CLI will print logs with - by default it only logs `info` level logs to the CLI. The following other log levels are supported by Kurtosis -
@@ -45,17 +70,65 @@ This flag sets the level of details that the Kurtosis CLI will print logs with -
 kurtosis run --cli-level-log error github.com/package-author/package-repo 
 ```
 
-:::info
+<details>
+    <summary>Example Output of the above command</summary>
 
-Users can use the `--cli-log-level` flag to display the entire stack trace to the CLI. By default the entire stack trace is saved to the `kurtosis-cli.log` file. The command below, for example, will display the entire stack-traces to the CLI for debugging purposes:
+```bash
+DEBU[2023-04-03T12:54:00-04:00] Instantiating a context aware backend with no remote backend config ends up returninga regular local Docker backend. 
+INFO[2023-04-03T12:54:00-04:00] No Kurtosis engine was found; attempting to start one... 
+DEBU[2023-04-03T12:54:00-04:00] Metrics user id filepath: '' 
+INFO[2023-04-03T12:54:00-04:00] Pulling image 'kurtosistech/engine:0.73.0'... 
+DEBU[2023-04-03T12:54:00-04:00] Binds: [/var/run/docker.sock:/var/run/docker.sock] 
+DEBU[2023-04-03T12:54:00-04:00] Created container with ID 'b9c8f6509ebe7831a96a926e0514f049884b30a8ff4359cd06d9592464d7f017' from image 'kurtosistech/engine:0.73.0' 
+DEBU[2023-04-03T12:54:01-04:00] Netstat availability-waiting command '[ -n "$(netstat -anp tcp | grep LISTEN | grep 9710)" ]' returned without a Docker error, but exited with non-0 exit code '1' and logs: 
+INFO[2023-04-03T12:54:02-04:00] Successfully started Kurtosis engine         
+DEBU[2023-04-03T12:54:02-04:00] Kurtosis Portal daemon is currently not reachable. If Kurtosis is being used ona local-only context, this is fine as Portal is not required for local-only contexts. 
+INFO[2023-04-03T12:54:02-04:00] Creating a new enclave for Starlark to run inside... 
+INFO[2023-04-03T12:54:04-04:00] Enclave 'murky-volcano' created successfully 
+INFO[2023-04-03T12:54:04-04:00] Executing Starlark package at '' as the passed argument '' looks like a directory 
+INFO[2023-04-03T12:54:04-04:00] Compressing package '' at '' for upload 
+INFO[2023-04-03T12:54:04-04:00] Uploading and executing package '' 
 
+> print msg={"key": "value"}
+{"key": "value"}
+
+Starlark code successfully run. No output was returned.
+DEBU[2023-04-03T12:54:04-04:00] Successfully reached the end of the response stream. Closing. 
+DEBU[2023-04-03T12:54:04-04:00] Current context is local, not mapping enclave service ports 
+INFO[2023-04-03T12:54:04-04:00] ====================================================== 
+INFO[2023-04-03T12:54:04-04:00] ||          Created enclave: murky-volcano          || 
+INFO[2023-04-03T12:54:04-04:00] ====================================================== 
+Name:            murky-volcano
+UUID:            f2fa01a0293f
+Status:          RUNNING
+Creation Time:   Mon, 03 Apr 2023 12:54:02 EDT
+
+========================================= Files Artifacts =========================================
+UUID   Name
+
+========================================== User Services ==========================================
+UUID   Name   Ports   Status
 ```
-kurtosis run --cli-log-level debug github.com/package-author/package-repo 
+</details>
+
+
+:::info
+Users can use the `debug` `--cli-log-level` flag, , as shown above, to display the entire stack trace to the CLI. By default the entire stack trace is saved to the `kurtosis-cli.log` file. 
+
+The sample error stack-trace that can be seen on the cli after `debug` level is shown below:
+
+```bash
+DEBU[2023-04-03T12:58:03-04:00] Cluster setting filepath: '' 
+DEBU[2023-04-03T12:58:03-04:00] Kurtosis config YAML filepath: '' 
+DEBU[2023-04-03T12:58:03-04:00] Loaded Kurtosis Config  &{overrides:0x1400000e510 shouldSendMetrics:true clusters:map[docker:0x14000097680 minikube:0x140000976b0]} 
+DEBU[2023-04-03T12:58:03-04:00] Instantiating a context aware backend with no remote backend config ends up returninga regular local Docker backend. 
+Error:  An error occurred validating arg ''
+ --- at /root/project/cli/cli/command_framework/lowlevel/lowlevel_kurtosis_command.go:290 (LowlevelKurtosisCommand.MustGetCobraCommand.func2) ---
+Caused by: Error reading filepath_or_dirpath ''
+ --- at /root/project/cli/cli/command_framework/highlevel/file_system_path_arg/file_system_path_arg.go:109 (getValidationFunc.func1) ---
+Caused by: stat ../../../per/other/submodul/: no such file or directory
 ```
 :::
-
-
-
 
 <!-------------------- ONLY LINKS BELOW THIS POINT ----------------------->
 [adding-command-line-completion]: ../guides/adding-command-line-completion.md

--- a/docs/docs/cli-reference/index.md
+++ b/docs/docs/cli-reference/index.md
@@ -131,6 +131,6 @@ Caused by: stat ../../../per/other/submodul/: no such file or directory
 :::
 
 <!-------------------- ONLY LINKS BELOW THIS POINT ----------------------->
-[adding-command-line-completion]: ../guides/adding-command-line-completion
-[installing-the-cli]: ../guides/installing-the-cli
-[client-library-reference]: ../client-libs-reference
+[adding-command-line-completion]: ../guides/adding-command-line-completion.md
+[installing-the-cli]: ../guides/installing-the-cli.md
+[client-library-reference]: ../client-libs-reference.md

--- a/docs/docs/cli-reference/index.md
+++ b/docs/docs/cli-reference/index.md
@@ -8,12 +8,6 @@ sidebar_position: 1
 
 The Kurtosis CLI is a Go CLI wrapped around the Kurtosis Go [client library][client-library-reference]. This section will go through the most common Kurtosis CLI commands and some useful tips on getting started. If you have not already done so, the CLI can be installed by following the instructions [here][installing-the-cli].
 
-:::tip
-The `kurtosis` command, and all of its subcommands, will print helptext when passed the `-h` or `--help` flag. You can use this at any time to see information on the command you're trying to run. For example:
-```
-kurtosis service -h
-```
-:::
 
 :::tip
 Kurtosis supports command-line completion; we recommend [installing it][adding-command-line-completion] for the best experience.
@@ -33,6 +27,35 @@ The version of the CLI and the currently-running engine can be printed with the 
 ```
 kurtosis version
 ```
+
+### Global Flags
+Kurtosis cli supports two global flags - `help` and `cli-log-level`. These flags can be used with any kurtosis cli commands.
+
+#### -h or --help
+This flag prints the helptext for all commands and subcommands. You can use this at any time to see information on the command you're trying to run. For example:
+```
+kurtosis service -h
+```
+
+#### cli-log-level
+This flag sets the level that kurtosis cli will log at - by default it only logs `info` level to the cli. Thesea are all the levels supported by kurtosis -
+```panic|fatal|error|warning|info|debug|trace```. For example, logs with error level can be printed using the command below:- 
+
+```
+kurtosis run --cli-level-log error github.com/package-author/package-repo 
+```
+
+:::info
+
+Users can use the `--cli-level-log` flag to display entire flag traces to the cli. By default the entire stack-traces are logged on to `kurtosis-cli.log` file. The command below, for example, will display the entire stack-traces to the cli for debugging purpose.
+
+```
+kurtosis run --cli-level-log debug github.com/package-author/package-repo 
+```
+:::
+
+
+
 
 <!-------------------- ONLY LINKS BELOW THIS POINT ----------------------->
 [adding-command-line-completion]: ../guides/adding-command-line-completion.md

--- a/docs/docs/cli-reference/index.md
+++ b/docs/docs/cli-reference/index.md
@@ -29,7 +29,7 @@ kurtosis version
 ```
 
 ### Global Flags
-Kurtosis CLI supports two global flags - `help` and `cli-log-level`. These flags can be used with any Kurtosis CLI commands.
+The Kurtosis CLI supports two global flags - `help` and `cli-log-level`. These flags can be used with any Kurtosis CLI command.
 
 #### -h or --help
 This flag prints the help text for all commands and subcommands. You can use this at any time to see information on the command you're trying to run. For example:

--- a/docs/docs/cli-reference/index.md
+++ b/docs/docs/cli-reference/index.md
@@ -131,6 +131,6 @@ Caused by: stat ../../../per/other/submodul/: no such file or directory
 :::
 
 <!-------------------- ONLY LINKS BELOW THIS POINT ----------------------->
-[adding-command-line-completion]: ../guides/adding-command-line-completion.md
-[installing-the-cli]: ../guides/installing-the-cli.md
-[client-library-reference]: ../client-libs-reference.md
+[adding-command-line-completion]: ../guides/adding-command-line-completion
+[installing-the-cli]: ../guides/installing-the-cli
+[client-library-reference]: ../client-libs-reference

--- a/docs/docs/cli-reference/index.md
+++ b/docs/docs/cli-reference/index.md
@@ -47,7 +47,7 @@ kurtosis run --cli-level-log error github.com/package-author/package-repo
 
 :::info
 
-Users can use the `--cli-log-level` flag to display entire flag traces to the cli. By default the entire stack-traces are logged on to `kurtosis-cli.log` file. The command below, for example, will display the entire stack-traces to the cli for debugging purpose.
+Users can use the `--cli-log-level` flag to display the entire stack trace to the CLI. By default the entire stack trace is saved to the `kurtosis-cli.log` file. The command below, for example, will display the entire stack-traces to the CLI for debugging purposes:
 
 ```
 kurtosis run --cli-log-level debug github.com/package-author/package-repo 

--- a/docs/docs/cli-reference/index.md
+++ b/docs/docs/cli-reference/index.md
@@ -67,7 +67,7 @@ This flag sets the level of details that the Kurtosis CLI will print logs with -
 `panic|fatal|error|warning|info|debug|trace`. For example, logs with error level can be printed using the command below:-
 
 ```
-kurtosis run --cli-level-log error github.com/package-author/package-repo 
+kurtosis run --cli-level-log debug github.com/package-author/package-repo 
 ```
 
 <details>

--- a/docs/docs/cli-reference/index.md
+++ b/docs/docs/cli-reference/index.md
@@ -38,7 +38,7 @@ kurtosis service -h
 ```
 
 #### cli-log-level
-This flag sets the level that kurtosis cli will log at - by default it only logs `info` level to the cli. Thesea are all the levels supported by kurtosis -
+This flag sets the level of details that the Kurtosis CLI will print logs with - by default it only logs `info` level logs to the CLI. The following other log levels are supported by Kurtosis -
 ```panic|fatal|error|warning|info|debug|trace```. For example, logs with error level can be printed using the command below:- 
 
 ```

--- a/docs/docs/cli-reference/index.md
+++ b/docs/docs/cli-reference/index.md
@@ -29,7 +29,7 @@ kurtosis version
 ```
 
 ### Global Flags
-Kurtosis cli supports two global flags - `help` and `cli-log-level`. These flags can be used with any kurtosis cli commands.
+Kurtosis CLI supports two global flags - `help` and `cli-log-level`. These flags can be used with any Kurtosis CLI commands.
 
 #### -h or --help
 This flag prints the helptext for all commands and subcommands. You can use this at any time to see information on the command you're trying to run. For example:

--- a/docs/docs/cli-reference/index.md
+++ b/docs/docs/cli-reference/index.md
@@ -64,7 +64,7 @@ Use "kurtosis service [command] --help" for more information about a command.
 
 #### cli-log-level
 This flag sets the level of details that the Kurtosis CLI will print logs with - by default it only logs `info` level logs to the CLI. The following other log levels are supported by Kurtosis -
-```panic|fatal|error|warning|info|debug|trace```. For example, logs with error level can be printed using the command below:- 
+`panic|fatal|error|warning|info|debug|trace`. For example, logs with error level can be printed using the command below:-
 
 ```
 kurtosis run --cli-level-log error github.com/package-author/package-repo 


### PR DESCRIPTION
## Description:
This PR updates the doc; we did not have information for global flag (`cli-log-level)`. This flag can be used to set what level of logs users want see on the cli. By default, it is `info` , some of the other values are `debug, error, panic` etc.

## Is this change user facing?
YES/NO
<!-- If yes, please add the "user facing" label to the PR -->
<!-- If yes, don't forget to include docs changes where relevant -->

## References (if applicable):
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
