### PR TITLE
ci: fix squash and merge automation

### DIFF
--- a/.github/workflows/dependabot-auto-approve-and-merge.yml
+++ b/.github/workflows/dependabot-auto-approve-and-merge.yml
@@ -11,6 +11,23 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '>=1.18.0'
+      # update go mod
+      - name: Clean up go mod as dependabot deletes kurtosis_version
+        run: |
+          cd "./${{steps.dependabot-metadata.outputs.directory}}"
+          go mod tidy
+      # commit the go mod update
+      - uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          token: "${{ secrets.RELEASER_TOKEN }}"
       - name: Approve a PR
         run: gh pr review --approve "$PR_URL"
         env:

--- a/.github/workflows/dependabot-auto-approve-and-merge.yml
+++ b/.github/workflows/dependabot-auto-approve-and-merge.yml
@@ -17,7 +17,7 @@ jobs:
           PR_URL: ${{github.event.pull_request.html_url}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       - name: Enable auto-merge for Dependabot PRs
-        run: gh pr merge --auto --merge "$PR_URL"
+        run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,10 +18,6 @@ on:
 
 jobs:
   golangci:
-    # skip dependabot PRs as they don't change code
-    # and  there is some bug with Golang CI lint and PRs fail
-    # TODO fix the actual issue
-    if: ${{ github.actor != 'dependabot[bot]' }}
     name: golang-lint
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,6 +18,10 @@ on:
 
 jobs:
   golangci:
+    # skip dependabot PRs as they don't change code
+    # and  there is some bug with Golang CI lint and PRs fail
+    # TODO fix the actual issue
+    if: ${{ github.actor != 'dependabot[bot]' }}
     name: golang-lint
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
https://github.com/kurtosis-tech/kurtosis/pull/469

this was failing as 

1. we tried auto enabling a merge instead of a squash and merge 
2. `kurtosis_version` goes missing because of which the package updated doesn't build