### PR TITLE
fix: revert files download enclave flag to arg 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -686,9 +686,9 @@ jobs:
 
       # File commands
       - run: "${KURTOSIS_BINPATH} files rendertemplate test-enclave << pipeline.parameters.rendertemplate-cli-test-template-relative-path >> << pipeline.parameters.rendertemplate-cli-test-data-json-relative-path >> ./rendered --name rendered-file"
-      - run: "${KURTOSIS_BINPATH} files download --enclave test-enclave rendered-file ."
+      - run: "${KURTOSIS_BINPATH} files download test-enclave rendered-file ."
       - run: "${KURTOSIS_BINPATH} files storeservice test-enclave test1 /usr/local/apache2/conf/httpd.conf --name stored-file"
-      - run: "${KURTOSIS_BINPATH} files download --enclave test-enclave stored-file ."
+      - run: "${KURTOSIS_BINPATH} files download test-enclave stored-file ."
 
       # Module inside an enclave
       - run: "${KURTOSIS_BINPATH} enclave ls"

--- a/cli/cli/commands/files/download/download.go
+++ b/cli/cli/commands/files/download/download.go
@@ -53,7 +53,7 @@ const (
 var FilesUploadCmd = &engine_consuming_kurtosis_command.EngineConsumingKurtosisCommand{
 	CommandStr:                command_str_consts.FilesDownloadCmdStr,
 	ShortDescription:          "Download a files artifact from an enclave",
-	LongDescription:           "Download a files artifact using an identifier(name, uuid, shortened uuid) from an enclave to the host machine",
+	LongDescription:           "Download the given files artifact from the given enclave to your machine. The files artifact and enclave are specified by identifier (name, UUID, or shortened UUID). Read more about identifiers here: https://docs.kurtosis.com/reference/resource-identifier",
 	KurtosisBackendContextKey: kurtosisBackendCtxKey,
 	EngineClientContextKey:    engineClientCtxKey,
 	Flags: []*flags.FlagConfig{

--- a/docs/docs/cli-reference/files-download.md
+++ b/docs/docs/cli-reference/files-download.md
@@ -7,7 +7,7 @@ slug: /files-download
 To download a [files artifact](../concepts-reference/files-artifacts.md) using a resource identifier (e.g. name, UUID, shortened UUID) from an enclave to the host machine, use:
 
 ```bash
-kurtosis files download --enclave $THE_ENCLAVE_IDENTIFIER $THE_ARTIFACT_IDENTIFIER $FILE_DESTINATION_PATH
+kurtosis files download $THE_ENCLAVE_IDENTIFIER $THE_ARTIFACT_IDENTIFIER $FILE_DESTINATION_PATH
 ```
 where `$THE_ENCLAVE_IDENTIFIER` and the `$THE_ARTIFACT_IDENTIFIER` are [resource identifiers](../concepts-reference/resource-identifier.md) for the enclave and file artifact, respectively. 
 


### PR DESCRIPTION
## Description:
We had moved enclave to a flag instead of an identifier. Reverting it to arg.

## Is this change user facing?
YES

## References (if applicable):
Closes #460 
