### PR TITLE
chore: removed validator for ReadyCondition.target_value attribute

### DIFF
--- a/core/server/api_container/server/startosis_engine/kurtosis_types/service_config/ready_condition.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_types/service_config/ready_condition.go
@@ -55,9 +55,7 @@ func NewReadyConditionType() *kurtosis_type_constructor.KurtosisTypeConstructor 
 					Name:              TargetAttr,
 					IsOptional:        false,
 					ZeroValueProvider: builtin_argument.ZeroValueProvider[starlark.Comparable],
-					Validator: func(value starlark.Value) *startosis_errors.InterpretationError {
-						return builtin_argument.NonEmptyString(value, FieldAttr)
-					},
+					Validator:         nil,
 				},
 				{
 					Name:              IntervalAttr,


### PR DESCRIPTION
## Description:
Removed validator for the `ReadyCondition.target_value` attribute, because it was validating only string, and we don't have validators for comparable yet

## Is this change user-facing?
NO

## References (if applicable):
