### PR TITLE
fix: Re-enable `--platform=linux/amd64` for Engine and APIC docker image

### DIFF
--- a/core/server/Dockerfile
+++ b/core/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17
+FROM --platform=linux/amd64 alpine:3.17
 
 # We need protobut-dev to run protobuf compiler against startosis .proto files
 RUN apk update && apk add --no-cache bash protobuf-dev && apk add musl

--- a/engine/server/Dockerfile
+++ b/engine/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17
+FROM --platform=linux/amd64 alpine:3.17
 
 RUN apk update && apk add bash && apk add musl
 


### PR DESCRIPTION
## Description:
We're seeing this when starting the engine on 0.75.2:
```
┌─[gbouvignies@gorilla]─(~/git/kurtosis-2)(gbouv/upload-starlark-package-streaming ✓)
└─[20:14]-(^_^)-(90%)-[$] kurtosis engine restart
INFO[2023-04-17T20:15:06-04:00] Restarting Kurtosis engine...
INFO[2023-04-17T20:15:06-04:00] No Kurtosis engine was found; attempting to start one...
INFO[2023-04-17T20:15:06-04:00] Pulling image 'kurtosistech/engine:0.75.2'...
Error:  An error occurred restarting the Kurtosis engine
  Caused by: An error occurred starting a new engine
  Caused by: An error occurred starting the engine with the engine existence guarantor
  Caused by: An error occurred guaranteeing that a Kurtosis engine is running
  Caused by: An error occurred launching the engine server container
  Caused by: An error occurred launching the engine server container with default version tag '0.75.2'
  Caused by: An error occurred launching the engine server container with environment variables 'map[SERIALIZED_ARGS:{"grpcListenPortNum":9710,"grpcProxyListenPortNum":9711,"logLevelStr":"debug","imageVersionTag":"0.75.2","metricsUserId":"ea8e05954da673a3786470316860d107ccfc69742d8bd2cd85667d17a2904701","didUserAcceptSendingMetrics":true,"kurtosisBackendType":"docker","kurtosisBackendConfig":{}}]'
  Caused by: An error occurred creating the engine using image 'kurtosistech/engine' with tag '0.75.2'
  Caused by: An error occurred starting the Kurtosis engine container
  Caused by: An error occurred checking if container '31a0c18ea2f4547ac0f4a8117aa4ffb92be175b61f022e146c042832ac20b840' is running
  Caused by: Container '31a0c18ea2f4547ac0f4a8117aa4ffb92be175b61f022e146c042832ac20b840' (with image 'kurtosistech/engine:0.75.2') die with a non zero exit code rapidly after it was started. This likely indicates a misconfiguration with how the container was started. Container should either exit gracefully or keep running for Kurtosis to consider it in a good state; logs are below:
  --------------------- CONTAINER LOGS -----------------------
  Rqemu-x86_64: Could not open '/lib/ld-musl-x86_64.so.1': No such file or directory

  ------------------- END CONTAINER LOGS --------------------
```

## Is this change user facing?
NO
<!-- If yes, please add the "user facing" label to the PR -->
<!-- If yes, don't forget to include docs changes where relevant -->

## References (if applicable):
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
