### PR TITLE
ci: Add back docker-user requirement for build and test steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -248,6 +248,7 @@ jobs:
       # Generate Kurtosis Version
       - run: "<<pipeline.parameters.generate-kurtosis-version-script-path>>"
 
+
       - setup_remote_docker:
           version: "<< pipeline.parameters.docker-engine-version>>"
 
@@ -1027,6 +1028,8 @@ workflows:
               ignore:
                 - main
       - build_files_artifacts_expander:
+          context:
+            - docker-user
           filters:
             branches:
               ignore:
@@ -1037,6 +1040,8 @@ workflows:
               ignore:
                 - main
       - build_api_container_server:
+          context:
+            - docker-user
           filters:
             branches:
               ignore:
@@ -1048,6 +1053,8 @@ workflows:
               ignore:
                 - main
       - build_engine_server:
+          context:
+            - docker-user
           filters:
             branches:
               ignore:
@@ -1058,6 +1065,8 @@ workflows:
       - test_basic_cli_functionality:
           name: "Test Basic CLI Functionality in Docker"
           cli-cluster-backend: "docker"
+          context:
+            - docker-user
           requires:
             - build_cli
             - build_api_container_server
@@ -1068,6 +1077,8 @@ workflows:
       - test_ci_for_failure:
           name: "Test Basic CLI for failure"
           cli-cluster-backend: "docker"
+          context:
+            - docker-user
           requires:
             - build_cli
             - build_api_container_server
@@ -1078,6 +1089,8 @@ workflows:
       - build_golang_testsuite:
           name: "Build golang testsuite against Docker"
           cli-cluster-backend: "docker"
+          context:
+            - docker-user
           requires:
             - build_cli
             - build_api_container_server
@@ -1088,6 +1101,8 @@ workflows:
       - build_typescript_testsuite:
           name: "Build typescript testsuite against Docker"
           cli-cluster-backend: "docker"
+          context:
+            - docker-user
           requires:
             - build_cli
             - build_api_container_server
@@ -1096,6 +1111,8 @@ workflows:
           <<: *filters_ignore_main
 
       - test_old_enclave_continuity:
+          context:
+            - docker-user
           requires:
             - build_cli
             - build_api_container_server


### PR DESCRIPTION
Reverts kurtosis-tech/kurtosis#520

As @gbouv noted, we are currently facing download rate limit from DockerHub (https://docs.docker.com/docker-hub/download-rate-limit/#whats-the-download-rate-limit-on-docker-hub), that's why we need to authenticate to fetch images