### PR TITLE
ci: Do not rely on map ordering on TestExtractor_FailureInput

### DIFF
--- a/core/server/api_container/server/startosis_engine/recipe/extractor_test.go
+++ b/core/server/api_container/server/startosis_engine/recipe/extractor_test.go
@@ -67,16 +67,16 @@ func TestExtractor_FailureInput(t *testing.T) {
 		"\"hi\"":  "length",
 		"\"bye\"": ".",
 	}
-	testOutputs := []any{
-		starlark.MakeInt(1),
-		starlark.MakeInt(2),
-		starlark.String("bye"),
+	testOutputs := map[string]starlark.Comparable{
+		"1":       starlark.MakeInt(1),
+		"\"hi\"":  starlark.MakeInt(2),
+		"\"bye\"": starlark.String("bye"),
 	}
 	index := 0
 	for input, query := range testInputs {
 		result, err := extract([]byte(input), query)
 		assert.Nil(t, err)
-		assert.Equal(t, testOutputs[index], result)
+		assert.Equal(t, testOutputs[input], result)
 		index += 1
 	}
 }


### PR DESCRIPTION
## Description:
<!-- Describe this change, how it works, and the motivation behind it. -->

## Is this change user facing?
NO
<!-- If yes, please add the "user facing" label to the PR -->
<!-- If yes, don't forget to include docs changes where relevant -->

## References (if applicable):
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
