### PR TITLE
fix: Pass Content-Type header to request

### DIFF
--- a/core/server/api_container/server/service_network/default_service_network.go
+++ b/core/server/api_container/server/service_network/default_service_network.go
@@ -799,6 +799,9 @@ func (network *DefaultServiceNetwork) HttpRequestService(ctx context.Context, se
 	if err != nil {
 		return nil, stacktrace.NewError("An error occurred building HTTP request on service '%v', URL '%v'", service, url)
 	}
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
+	}
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, stacktrace.Propagate(err, "An error occurred on HTTP request on service '%v', URL '%v'", service, url)

--- a/core/server/api_container/server/startosis_engine/recipe/extractor.go
+++ b/core/server/api_container/server/startosis_engine/recipe/extractor.go
@@ -41,7 +41,7 @@ func extract(input []byte, query string) (starlark.Comparable, error) {
 		}
 	}
 	if len(parsedMatchList) == 0 {
-		return nil, stacktrace.NewError("No field '%v' was found on input '%v'", query, input)
+		return nil, stacktrace.NewError("No field '%v' was found on input '%v'", query, string(input))
 	}
 	if len(parsedMatchList) == 1 {
 		return parsedMatchList[0].(starlark.Comparable), nil

--- a/internal_testsuites/golang/testsuite/startosis_request_wait_assert_test/startosis_complex_request_wait_assert_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_request_wait_assert_test/startosis_complex_request_wait_assert_test.go
@@ -45,7 +45,7 @@ def run(plan):
 		body=response["extract.exploded-slash"],
 		extract = {
 			"my-body": ".body",
-			"my-content-type": ".headers.content-type"
+			"my-content-type": ".headers.[\"content-type\"]"
 		}
 	)
 	plan.wait(recipe=post_recipe, field="code", assertion="==", target_value=200, service_name="web-server")
@@ -57,7 +57,7 @@ def run(plan):
 		port_id = "http-port",
 		endpoint = "/",
 		extract = {
-			"my-content-type": ".headers.content-type"
+			"my-content-type": ".headers.[\"content-type\"]"
 		}
 	)
 	plan.wait(recipe=post_recipe_no_body, field="code", assertion="==", target_value=200, service_name = "web-server")

--- a/internal_testsuites/golang/testsuite/startosis_request_wait_assert_test/startosis_complex_request_wait_assert_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_request_wait_assert_test/startosis_complex_request_wait_assert_test.go
@@ -41,6 +41,7 @@ def run(plan):
 	post_recipe = PostHttpRequestRecipe(
 		port_id = "http-port",
 		endpoint = "/",
+		content_type="text/plain",
 		body=response["extract.exploded-slash"],
 		extract = {
 			"my-body": ".body",
@@ -55,13 +56,12 @@ def run(plan):
 	post_recipe_no_body = PostHttpRequestRecipe(
 		port_id = "http-port",
 		endpoint = "/",
-		content_type="application/json",
 		extract = {
 			"my-content-type": ".headers.content-type"
 		}
 	)
 	plan.wait(recipe=post_recipe_no_body, field="code", assertion="==", target_value=200, service_name = "web-server")
-	plan.assert(post_recipe_no_body["extract.my-content-type"], "==", "application/json")
+	plan.assert(post_response["extract.my-content-type"], "==", "application/json")
 	exec_recipe = ExecRecipe(
 		command = ["echo", "hello", post_response["extract.my-body"]]
 	)

--- a/internal_testsuites/golang/testsuite/startosis_request_wait_assert_test/startosis_complex_request_wait_assert_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_request_wait_assert_test/startosis_complex_request_wait_assert_test.go
@@ -41,22 +41,27 @@ def run(plan):
 	post_recipe = PostHttpRequestRecipe(
 		port_id = "http-port",
 		endpoint = "/",
-		content_type="text/plain",
+		content_type="application/json",
 		body=response["extract.exploded-slash"],
 		extract = {
-			"my-body": ".body"
+			"my-body": ".body",
+			"my-content-type": ".headers.content-type"
 		}
 	)
 	plan.wait(recipe=post_recipe, field="code", assertion="==", target_value=200, service_name="web-server")
 	post_response = plan.request(recipe=post_recipe, service_name="web-server")
 	plan.assert(post_response["code"], "==", 200)
+	plan.assert(post_response["extract.my-content-type"], "==", "application/json")
 	plan.assert(post_response["extract.my-body"], "==", "bar")
 	post_recipe_no_body = PostHttpRequestRecipe(
 		port_id = "http-port",
 		endpoint = "/",
-		content_type="text/plain",
+		extract = {
+			"my-content-type": ".headers.content-type"
+		}
 	)
 	plan.wait(recipe=post_recipe_no_body, field="code", assertion="==", target_value=200, service_name = "web-server")
+	plan.assert(post_response["extract.my-content-type"], "==", "application/json")
 	exec_recipe = ExecRecipe(
 		command = ["echo", "hello", post_response["extract.my-body"]]
 	)

--- a/internal_testsuites/golang/testsuite/startosis_request_wait_assert_test/startosis_complex_request_wait_assert_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_request_wait_assert_test/startosis_complex_request_wait_assert_test.go
@@ -41,7 +41,6 @@ def run(plan):
 	post_recipe = PostHttpRequestRecipe(
 		port_id = "http-port",
 		endpoint = "/",
-		content_type="application/json",
 		body=response["extract.exploded-slash"],
 		extract = {
 			"my-body": ".body",
@@ -51,17 +50,18 @@ def run(plan):
 	plan.wait(recipe=post_recipe, field="code", assertion="==", target_value=200, service_name="web-server")
 	post_response = plan.request(recipe=post_recipe, service_name="web-server")
 	plan.assert(post_response["code"], "==", 200)
-	plan.assert(post_response["extract.my-content-type"], "==", "application/json")
+	plan.assert(post_response["extract.my-content-type"], "==", "text/plain")
 	plan.assert(post_response["extract.my-body"], "==", "bar")
 	post_recipe_no_body = PostHttpRequestRecipe(
 		port_id = "http-port",
 		endpoint = "/",
+		content_type="application/json",
 		extract = {
 			"my-content-type": ".headers.content-type"
 		}
 	)
 	plan.wait(recipe=post_recipe_no_body, field="code", assertion="==", target_value=200, service_name = "web-server")
-	plan.assert(post_response["extract.my-content-type"], "==", "application/json")
+	plan.assert(post_recipe_no_body["extract.my-content-type"], "==", "application/json")
 	exec_recipe = ExecRecipe(
 		command = ["echo", "hello", post_response["extract.my-body"]]
 	)

--- a/internal_testsuites/golang/testsuite/startosis_request_wait_assert_test/startosis_complex_request_wait_assert_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_request_wait_assert_test/startosis_complex_request_wait_assert_test.go
@@ -61,8 +61,8 @@ def run(plan):
 			"my-content-type": '.headers["content-type"]'
 		}
 	)
-	plan.wait(recipe=post_recipe_no_body, field="code", assertion="==", target_value=200, service_name = "web-server")
-	plan.assert(post_response["extract.my-content-type"], "==", "application/json")
+	post_recipe_no_body_output = plan.wait(recipe=post_recipe_no_body, field="code", assertion="==", target_value=200, service_name = "web-server")
+	plan.assert(post_recipe_no_body_output["extract.my-content-type"], "==", "application/json")
 	exec_recipe = ExecRecipe(
 		command = ["echo", "hello", post_response["extract.my-body"]]
 	)

--- a/internal_testsuites/golang/testsuite/startosis_request_wait_assert_test/startosis_complex_request_wait_assert_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_request_wait_assert_test/startosis_complex_request_wait_assert_test.go
@@ -45,7 +45,7 @@ def run(plan):
 		body=response["extract.exploded-slash"],
 		extract = {
 			"my-body": ".body",
-			"my-content-type": ".headers.[\"content-type\"]"
+			"my-content-type": '.headers["content-type"]'
 		}
 	)
 	plan.wait(recipe=post_recipe, field="code", assertion="==", target_value=200, service_name="web-server")
@@ -56,8 +56,9 @@ def run(plan):
 	post_recipe_no_body = PostHttpRequestRecipe(
 		port_id = "http-port",
 		endpoint = "/",
+		body = "0",
 		extract = {
-			"my-content-type": ".headers.[\"content-type\"]"
+			"my-content-type": '.headers["content-type"]'
 		}
 	)
 	plan.wait(recipe=post_recipe_no_body, field="code", assertion="==", target_value=200, service_name = "web-server")


### PR DESCRIPTION
## Description:
<!-- Describe this change, how it works, and the motivation behind it. -->
Before https://github.com/kurtosis-tech/kurtosis/pull/493, we had a branch for `GET` and `POST` request, using `http.Get` and `http.Post`, the latter required you explicitly passing a `contentType`.

Now we are using a `http.DefaultClient.Do`, that does not pre-fill any headers for us, and we simply logged it without passing it along. This is currently breaking https://github.com/kurtosis-tech/eth2-package with

`invalid content type, only application/json is supported`

## Is this change user facing?
NO
<!-- If yes, please add the "user facing" label to the PR -->
<!-- If yes, don't forget to include docs changes where relevant -->

## References (if applicable):
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
