### PR TITLE
docs: added some tips about commands

### DIFF
--- a/docs/docs/starlark-reference/exec-recipe.md
+++ b/docs/docs/starlark-reference/exec-recipe.md
@@ -30,8 +30,8 @@ exec_recipe = ExecRecipe(
 ```
 
 :::tip
-If you are trying to run a complex `command` with `|` we recommend that you prefix the command with `/bin/sh -c` and wrap the command in a string; so something like `command = ["echo" "a", "|" "grep a"]` should
-be rewritten as `command = ["/bin/sh", "-c", "echo a | grep a"]`. This is because `Docker` treats everything after the `echo` as args; instead of what you'd expect. 
+If you are trying to run a complex `command` with `|`, you should prefix the command with `/bin/sh -c` and wrap the actual command in a string; for example: `command = ["echo", "a", "|", "grep a"]` should
+be rewritten as `command = ["/bin/sh", "-c", "echo a | grep a"]`. Not doing so makes everything after the `echo` as args of that command, instead of following the behavior you would expect from a shell.
 :::
 
 <!--------------- ONLY LINKS BELOW THIS POINT ---------------------->

--- a/docs/docs/starlark-reference/exec-recipe.md
+++ b/docs/docs/starlark-reference/exec-recipe.md
@@ -29,6 +29,11 @@ exec_recipe = ExecRecipe(
 )
 ```
 
+:::tip
+If you are trying to run a complex `command` with `|` we recommend that you prefix the command with `/bin/sh -c` and wrap the command in a string; so something like `command = ["echo" "a", "|" "grep a"]` should
+be rewritten as `command = ["/bin/sh", "-c", "echo a | grep a"]`. This is because `Docker` treats everything after the `echo` as args; instead of what you'd expect. 
+:::
+
 <!--------------- ONLY LINKS BELOW THIS POINT ---------------------->
 [exec-reference]: ./plan.md#exec
 [wait-reference]: ./plan.md#wait

--- a/docs/docs/starlark-reference/service-config.md
+++ b/docs/docs/starlark-reference/service-config.md
@@ -95,7 +95,7 @@ You can see how to configure the [`ReadyCondition` type here][ready-condition].
 
 :::tip
 If you are trying to use more complex versions of `cmd` and are running into issues we recommend using `cmd` in addition to `entrypoint`. You can
-set the `entrypoint` to `["/bin/sh", "-c"]` and then set the `cmd` to whatever you want.
+set the `entrypoint` to `["/bin/sh", "-c"]` and then set the `cmd` to the command as you would type it in your shell, for example: `cmd = ["echo a", "|", "grep a"]`
 :::
 
 <!--------------- ONLY LINKS BELOW THIS POINT ---------------------->

--- a/docs/docs/starlark-reference/service-config.md
+++ b/docs/docs/starlark-reference/service-config.md
@@ -91,7 +91,12 @@ The `files` dictionary argument accepts a key value pair, where `key` is the pat
 
 For more info about the `subnetwork` argument, see [Kurtosis subnetworks][subnetworks-reference].
 
-You can see how to configure the [`ReadyCondition` type here][ready-condition]. 
+You can see how to configure the [`ReadyCondition` type here][ready-condition].
+
+:::tip
+If you are trying to use more complex versions of `cmd` and are running into issues we recommend using `cmd` in addition to `entrypoint`. You can
+set the `entrypoint` to `["/bin/sh", "-c"]` and then set the `cmd` to whatever you want.
+:::
 
 <!--------------- ONLY LINKS BELOW THIS POINT ---------------------->
 [add-service-reference]: ./plan.md#add_service


### PR DESCRIPTION
## Description:
Earlier the way commands were run using `/bin/sh` `-c` was an internal thing we knew and now we share it with the world.

## Is this change user facing?
YES