### PR TITLE
fix: fixed grpc-file-transfer Golang module name

### DIFF
--- a/grpc-file-transfer/golang/go.mod
+++ b/grpc-file-transfer/golang/go.mod
@@ -1,4 +1,4 @@
-module grpc-file-transfer
+module github.com/kurtosis-tech/kurtosis/grpc-file-transfer/golang
 
 go 1.18
 


### PR DESCRIPTION
## Description:
fixed grpc-file-transfer Golang module name

## Is this change user facing?
NO

## References (if applicable):
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
