### PR TITLE
feat: Help developers to work across the project modules

### DIFF
--- a/go.work
+++ b/go.work
@@ -1,0 +1,17 @@
+go 1.18
+
+use (
+	./api/golang
+	./cli/cli
+	./container-engine-lib
+	./contexts-config-store
+	./core/files_artifacts_expander
+	./core/launcher
+	./core/server
+	./engine/launcher
+	./engine/server
+	./grpc-file-transfer/golang
+	./internal_testsuites/golang
+	./kurtosis_version
+	./name_generator
+)


### PR DESCRIPTION
## Description:
The `kurtosis` project contains multiple Go modules.  Starting with Go 1.18, a [Go workspace file](https://go.dev/ref/mod#workspaces) can be used to work across modules.  IDEs such as VSCode support workspaces and use them to resolve imports when working against the entire project instead of a single module.

## Is this change user facing?
NO

