### PR TITLE
fix: Support redirects with cookies in the user support URLs validation test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -995,6 +995,9 @@ workflows:
                     },
                     {
                         "pattern": "https://github.com/kurtosis-tech/kurtosis/compare/.*"
+                    },
+                    {
+                        "pattern": "https://twitter.com/.*"
                     }
                 ]
             }

--- a/cli/cli/user_support_constants/user_support_constants_test.go
+++ b/cli/cli/user_support_constants/user_support_constants_test.go
@@ -8,12 +8,21 @@ package user_support_constants
 import (
 	"github.com/stretchr/testify/assert"
 	"net/http"
+	"net/http/cookiejar"
 	"testing"
 )
 
 func TestValidUrls(t *testing.T) {
 	for _, url := range urlsToValidateInTest {
-		resp, err := http.Get(url)
+		jar, err := cookiejar.New(nil)
+		if err != nil { 
+			assert.NoError(t, err, "Got an unexpected error creating the cookie jar")
+		}
+		// nolint: exhaustruct
+		client := &http.Client{
+			Jar: jar,
+		}
+		resp, err := client.Get(url)
 		assert.NoError(t, err, "Got an unexpected error checking url '%v'", url)
 		assert.True(t, isValidReturnCode(resp.StatusCode), "URL '%v' returned unexpected status code: '%d'", url, resp.StatusCode)
 		assert.NoError(t, err, "Got an unexpected error checking url '%v'", url)

--- a/core/server/api_container/server/startosis_engine/starlark_warning/warning_test.go
+++ b/core/server/api_container/server/startosis_engine/starlark_warning/warning_test.go
@@ -12,7 +12,7 @@ func TestStarlarkWarningMessage(t *testing.T) {
 
 	warnings := GetContentFromWarningSet()
 	require.Equal(t, 2, len(warnings))
-	require.Equal(t, []string{"warning one", "warning second"}, warnings)
+	require.ElementsMatch(t, []string{"warning one", "warning second"}, warnings)
 
 	// this ensures that `GetContentFromWarningSet` actually deletes all the previous warnings
 	PrintOnceAtTheEndOfExecutionf("warning three")


### PR DESCRIPTION
## Description:
Use a cookie jar in the URLs validation function to support redirects with cookies.
Ignore twitter.com URLs in the CI markdown link checker until it supports redirects with cookies.
Fix get content from warning set flaky test by checking the elements in any order since the global warningMessageSet is a set.

## Is this change user facing?
NO

## References (if applicable):
Closes #599 
