### PR TITLE
fix: rename cloud-->kloud in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ To read more about "why Kurtosis?", go [here](https://docs.kurtosis.com/#why-use
 
 To read about the architecture, go [here](https://docs.kurtosis.com/explanations/architecture).
 
-Kurtosis Cloud Early Access
+Kurtosis Kloud Early Access
 ===========================
 
 If you're looking to run a distributed system on the cloud, look no further! 
-We're excited to launch an early access offering for Kurtosis Cloud. Once you [sign up](https://mp2k8nqxxgj.typeform.com/to/U1HcXT1H), we'll reach out to you with the next steps.
+We're excited to launch an early access offering for Kurtosis Kloud. Once you [sign up](https://mp2k8nqxxgj.typeform.com/to/U1HcXT1H), we'll reach out to you with the next steps.
 
 Running Kurtosis
 ================


### PR DESCRIPTION
We're inconsistently using cloud and kloud in various places. Let's centralize on `kloud`. 

Example: we refer to Kloud in our early access signup form.
<img width="647" alt="image" src="https://github.com/kurtosis-tech/kurtosis/assets/103802618/c07ca62e-6fde-4769-8478-81d3b12baf99">

