### PR TITLE
docs: Add documentation on how to install Windows binary

### DIFF
--- a/docs/docs/guides/installing-the-cli.md
+++ b/docs/docs/guides/installing-the-cli.md
@@ -79,7 +79,16 @@ Download the appropriate artifact from [the release artifacts page][release-arti
 
 <TabItem value="windows" label="Windows">
 
-The Kurtosis CLI cannot be installed directly on Windows. Windows users are encouraged to use [Windows Subsystem for Linux (WSL)][windows-susbsystem-for-linux] to use Kurtosis.
+Windows users are encouraged to use [Windows Subsystem for Linux (WSL)][windows-susbsystem-for-linux] to use Kurtosis.
+If you want to run a native executable, you can download the latest build for your architechture [here](https://github.com/kurtosis-tech/kurtosis-cli-release-artifacts/tags).
+
+Or do it using PowerShell:
+
+```bash
+Invoke-WebRequest -Uri "https://github.com/kurtosis-tech/kurtosis-cli-release-artifacts/releases/download/REPLACE_VERSION/kurtosis-cli_REPLACE_VERSION_windows_REPLACE_ARCH.tar.gz" -OutFile kurtosis.tar.gz
+tar -xvzf kurtosis.tar.gz
+kurtosis.exe
+```
 
 </TabItem>
 


### PR DESCRIPTION
## Description:
Downloading binary is not the best distribution channel, but the alternatives are:
- [Windows Package Manager](https://learn.microsoft.com/en-us/windows/package-manager/): No out of the box integration with GoReleaser
- [Chocolatey](https://chocolatey.org/): Has out of the box integration with GoReleaser, but requires either:
  - Using a Windows image to run `choco.exe`
  - Using a custom docker image that build our own choco using Mono https://github.com/chocolatey/choco#other-platforms






Follow up from https://github.com/kurtosis-tech/kurtosis/pull/608
<!-- Describe this change, how it works, and the motivation behind it. -->

## Is this change user facing?
YES
<!-- If yes, please add the "user facing" label to the PR -->
<!-- If yes, don't forget to include docs changes where relevant -->

## References (if applicable):
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
