### PR TITLE
fix: ips are on the range 172.16.0.0/16

### DIFF
--- a/container-engine-lib/lib/backend_impls/docker/docker_network_allocator/docker_network_allocator.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_network_allocator/docker_network_allocator.go
@@ -140,11 +140,11 @@ func (provider *DockerNetworkAllocator) CreateNewNetwork(
 	)
 }
 
-// This algorithm only picks a network in the 10.0.0.0/20 - 10.255.0.0.0/20 list
+// This algorithm only picks a network in the 172.16.1.0/24 - 17.16.0.255.0/24 list
 // https://github.com/hashicorp/serf/issues/385#issuecomment-208755148 - we try to follow RFC 6890
 // https://www.rfc-editor.org/rfc/rfc6890.html calls 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16 Private-Use (docker usually picks from 172.16.0.0/12)
-// Just with 10.0.0.0/8 we can get 2^24 ips; if we limit services per APIC to 4096(/20) we can get 4096 per docker engine
-// For simplicity we limit it to 256 APICs and allow networks 10.1.0.0/20 - 10.255.0.0.0/20
+// Just with this range we can get 256 APICs; if we limit services per APIC to 256(/24)
+// For simplicity we limit it to 256 APICs and allow networks 172.16.1.0/24 - 17.16.0.255.0/24
 func findRandomFreeNetwork(networks []*net.IPNet) (*net.IPNet, error) {
 	for secondOctet := secondOctetLowestPossibleValue; secondOctet <= secondOctetMaximumPossibleValue; secondOctet++ {
 		ipAddressString := fmt.Sprintf("%v.16.%v.0", allowedNetworkFirstOctet, secondOctet)

--- a/container-engine-lib/lib/backend_impls/docker/docker_network_allocator/docker_network_allocator.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_network_allocator/docker_network_allocator.go
@@ -18,6 +18,7 @@ const (
 
 	// We hardcode this because the algorithm for finding slots for variable-sized networks is MUCH more complex
 	// This will give 256 IPs per address; if this isn't enough we can up it in the future
+	// This limits us to 256 Services per APIC
 	networkWidthBits = uint32(8)
 
 	// Docker returns an error with this text when we try to create a network with a CIDR mask
@@ -28,9 +29,10 @@ const (
 
 	timeBetweenNetworkCreationRetries = 1 * time.Second
 
-	allowedNetworkFirstOctet        = 172
-	secondOctetMaximumPossibleValue = 255
-	secondOctetLowestPossibleValue  = 1
+	allowedNetworkFirstOctet       = 172
+	allowedNetworkSecondOctet      = 16
+	thirdOctetHighestPossibleValue = 255
+	thirdOctetLowestPossibleValue  = 1
 )
 
 var networkCidrMask = net.CIDRMask(int(supportedIpAddrBitLength-networkWidthBits), int(supportedIpAddrBitLength))
@@ -146,8 +148,8 @@ func (provider *DockerNetworkAllocator) CreateNewNetwork(
 // Just with this range we can get 256 APICs; if we limit services per APIC to 256(/24)
 // For simplicity we limit it to 256 APICs and allow networks 172.16.1.0/24 - 17.16.0.255.0/24
 func findRandomFreeNetwork(networks []*net.IPNet) (*net.IPNet, error) {
-	for secondOctet := secondOctetLowestPossibleValue; secondOctet <= secondOctetMaximumPossibleValue; secondOctet++ {
-		ipAddressString := fmt.Sprintf("%v.16.%v.0", allowedNetworkFirstOctet, secondOctet)
+	for thirdOctet := thirdOctetLowestPossibleValue; thirdOctet <= thirdOctetHighestPossibleValue; thirdOctet++ {
+		ipAddressString := fmt.Sprintf("%v.%v.%v.0", allowedNetworkFirstOctet, allowedNetworkSecondOctet, thirdOctet)
 		resultNetworkIp := net.ParseIP(ipAddressString)
 		resultNetwork := &net.IPNet{
 			IP:   resultNetworkIp,

--- a/container-engine-lib/lib/backend_impls/docker/docker_network_allocator/docker_network_allocator.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_network_allocator/docker_network_allocator.go
@@ -17,8 +17,8 @@ const (
 	supportedIpAddrBitLength = uint32(32)
 
 	// We hardcode this because the algorithm for finding slots for variable-sized networks is MUCH more complex
-	// This will give 4096 IPs per address; if this isn't enough we can up it in the future
-	networkWidthBits = uint32(12)
+	// This will give 256 IPs per address; if this isn't enough we can up it in the future
+	networkWidthBits = uint32(8)
 
 	// Docker returns an error with this text when we try to create a network with a CIDR mask
 	//  that overlaps with a preexisting network
@@ -147,7 +147,7 @@ func (provider *DockerNetworkAllocator) CreateNewNetwork(
 // For simplicity we limit it to 256 APICs and allow networks 10.1.0.0/20 - 10.255.0.0.0/20
 func findRandomFreeNetwork(networks []*net.IPNet) (*net.IPNet, error) {
 	for secondOctet := secondOctetLowestPossibleValue; secondOctet <= secondOctetMaximumPossibleValue; secondOctet++ {
-		ipAddressString := fmt.Sprintf("%v.%v.0.0", allowedNetworkFirstOctet, secondOctet)
+		ipAddressString := fmt.Sprintf("%v.16.%v.0", allowedNetworkFirstOctet, secondOctet)
 		resultNetworkIp := net.ParseIP(ipAddressString)
 		resultNetwork := &net.IPNet{
 			IP:   resultNetworkIp,

--- a/container-engine-lib/lib/backend_impls/docker/docker_network_allocator/docker_network_allocator.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_network_allocator/docker_network_allocator.go
@@ -28,7 +28,7 @@ const (
 
 	timeBetweenNetworkCreationRetries = 1 * time.Second
 
-	allowedNetworkFirstOctet        = 10
+	allowedNetworkFirstOctet        = 172
 	secondOctetMaximumPossibleValue = 255
 	secondOctetLowestPossibleValue  = 1
 )

--- a/container-engine-lib/lib/backend_impls/docker/docker_network_allocator/docker_network_allocator.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_network_allocator/docker_network_allocator.go
@@ -146,7 +146,7 @@ func (provider *DockerNetworkAllocator) CreateNewNetwork(
 // https://github.com/hashicorp/serf/issues/385#issuecomment-208755148 - we try to follow RFC 6890
 // https://www.rfc-editor.org/rfc/rfc6890.html calls 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16 Private-Use (docker usually picks from 172.16.0.0/12)
 // Just with this range we can get 256 APICs; if we limit services per APIC to 256(/24)
-// For simplicity we limit it to 256 APICs and allow networks 172.16.1.0/24 - 17.16.0.255.0/24
+// For simplicity we limit it to 256 APICs and allow networks 172.16.1.0/24 - 17.16.255.0/24
 func findRandomFreeNetwork(networks []*net.IPNet) (*net.IPNet, error) {
 	for thirdOctet := thirdOctetLowestPossibleValue; thirdOctet <= thirdOctetHighestPossibleValue; thirdOctet++ {
 		ipAddressString := fmt.Sprintf("%v.%v.%v.0", allowedNetworkFirstOctet, allowedNetworkSecondOctet, thirdOctet)

--- a/container-engine-lib/lib/backend_impls/docker/docker_network_allocator/docker_network_allocator_test.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_network_allocator/docker_network_allocator_test.go
@@ -32,7 +32,7 @@ func TestEntireNetworkingSpace(t *testing.T) {
 	takenNetworks := []*net.IPNet{}
 	allPossibleNetworks := []*net.IPNet{}
 	for secondOctet := secondOctetLowestPossibleValue; secondOctet <= secondOctetMaximumPossibleValue; secondOctet++ {
-		ipAddressString := fmt.Sprintf("%v.%v.0.0", allowedNetworkFirstOctet, secondOctet)
+		ipAddressString := fmt.Sprintf("%v.16.%v.0", allowedNetworkFirstOctet, secondOctet)
 		resultNetworkIp := net.ParseIP(ipAddressString)
 		resultNetwork := &net.IPNet{
 			IP:   resultNetworkIp,

--- a/container-engine-lib/lib/backend_impls/docker/docker_network_allocator/docker_network_allocator_test.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_network_allocator/docker_network_allocator_test.go
@@ -31,8 +31,8 @@ func TestErrorOnNoFreeIps(t *testing.T) {
 func TestEntireNetworkingSpace(t *testing.T) {
 	takenNetworks := []*net.IPNet{}
 	allPossibleNetworks := []*net.IPNet{}
-	for secondOctet := secondOctetLowestPossibleValue; secondOctet <= secondOctetMaximumPossibleValue; secondOctet++ {
-		ipAddressString := fmt.Sprintf("%v.16.%v.0", allowedNetworkFirstOctet, secondOctet)
+	for thirdOctet := thirdOctetLowestPossibleValue; thirdOctet <= thirdOctetHighestPossibleValue; thirdOctet++ {
+		ipAddressString := fmt.Sprintf("%v.%v.%v.0", allowedNetworkFirstOctet, allowedNetworkSecondOctet, thirdOctet)
 		resultNetworkIp := net.ParseIP(ipAddressString)
 		resultNetwork := &net.IPNet{
 			IP:   resultNetworkIp,
@@ -42,7 +42,7 @@ func TestEntireNetworkingSpace(t *testing.T) {
 	}
 	i := 0
 	for {
-		if i == secondOctetMaximumPossibleValue {
+		if i == thirdOctetHighestPossibleValue {
 			break
 		}
 		freeIPAddress, err := findRandomFreeNetwork(takenNetworks)


### PR DESCRIPTION
## Description:
Use Dockers Network Range to fix weirdness we are seeing with AVAX tests

This limits us to 256 APICs (like we had earlier)
This limits us to 256 services per APIC

## Is this change user facing?
NO
<!-- If yes, please add the "user facing" label to the PR -->
<!-- If yes, don't forget to include docs changes where relevant -->

## References (if applicable):
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
