### PR TITLE
fix: Make printWarningIfArgumentIsDeprecated unit test deterministic

### DIFF
--- a/core/server/api_container/server/startosis_engine/kurtosis_starlark_framework/kurtosis_base_builtin_internal_test.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_starlark_framework/kurtosis_base_builtin_internal_test.go
@@ -95,13 +95,14 @@ func Test_printWarningIfArgumentIsDeprecated(t *testing.T) {
 	require.Len(t, warnings, 2)
 
 	// just checking only one warning to make sure that the string formatting works
-	require.Contains(t, warnings[0],
-		fmt.Sprintf("%q field for %q will be deprecated by %v. %v",
-			"config",
-			"kurtosis_builtin",
-			deprecatedDate.GetFormattedDate(),
-			deprecatedMitigation,
-		))
+	expectedWarning := fmt.Sprintf("[WARN]: %q field for %q will be deprecated by %v. %v",
+		"config",
+		"kurtosis_builtin",
+		deprecatedDate.GetFormattedDate(),
+		deprecatedMitigation,
+	)
+	require.Contains(t, warnings, expectedWarning)
+
 }
 
 func Test_printWarningForBuiltinIsDeprecated(t *testing.T) {


### PR DESCRIPTION
## Description:
<!-- Describe this change, how it works, and the motivation behind it. -->
`printWarningIfArgumentIsDeprecated` is flaky:

https://app.circleci.com/pipelines/github/kurtosis-tech/kurtosis/3488/workflows/72a67e18-3fae-4734-b97b-47f278c39b3a/jobs/42730

This is because the test relies on a given order of iteration of `sync.Map`, that is not deterministic and will yield different order from time to time.

## Is this change user facing?
NO
<!-- If yes, please add the "user facing" label to the PR -->
<!-- If yes, don't forget to include docs changes where relevant -->

## References (if applicable):
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
