### PR TITLE
feat: Return error on SDK if Starlark run on any step 

### DIFF
--- a/api/golang/core/lib/enclaves/enclave_context.go
+++ b/api/golang/core/lib/enclaves/enclave_context.go
@@ -173,7 +173,8 @@ func (enclaveCtx *EnclaveContext) RunStarlarkRemotePackageBlocking(ctx context.C
 	if err != nil {
 		return nil, stacktrace.Propagate(err, "Error running remote Starlark package")
 	}
-	return ReadStarlarkRunResponseLineBlocking(starlarkRunResponseLineChan), nil
+	starlarkResponse := ReadStarlarkRunResponseLineBlocking(starlarkRunResponseLineChan)
+	return starlarkResponse, getErrFromStarlarkRunResult(starlarkResponse)
 }
 
 // Docs available at https://docs.kurtosis.com/sdk#getservicecontextstring-serviceidentifier---servicecontext-servicecontext

--- a/internal_testsuites/golang/test_helpers/test_helpers.go
+++ b/internal_testsuites/golang/test_helpers/test_helpers.go
@@ -317,7 +317,7 @@ func RunScriptWithDefaultConfig(ctx context.Context, enclaveCtx *enclaves.Enclav
 	return enclaveCtx.RunStarlarkScriptBlocking(ctx, script, emptyParams, defaultDryRun, defaultParallelism)
 }
 
-func SetupSimpleEnclaveAndRunScript(t *testing.T, ctx context.Context, testName string, script string) *enclaves.StarlarkRunResult {
+func SetupSimpleEnclaveAndRunScript(t *testing.T, ctx context.Context, testName string, script string) (*enclaves.StarlarkRunResult, error) {
 
 	// ------------------------------------- ENGINE SETUP ----------------------------------------------
 	enclaveCtx, _, destroyEnclaveFunc, err := CreateEnclave(t, ctx, testName, partitioningDisabled)
@@ -328,9 +328,7 @@ func SetupSimpleEnclaveAndRunScript(t *testing.T, ctx context.Context, testName 
 	logrus.Infof("Executing Startosis script...")
 	logrus.Debugf("Startosis script content: \n%v", script)
 
-	runResult, err := RunScriptWithDefaultConfig(ctx, enclaveCtx, script)
-
-	return runResult
+	return RunScriptWithDefaultConfig(ctx, enclaveCtx, script)
 }
 
 func WaitForHealthy(ctx context.Context, client GrpcAvailabilityChecker, retries uint32, retriesDelayMilliseconds uint32) error {

--- a/internal_testsuites/golang/test_helpers/test_helpers.go
+++ b/internal_testsuites/golang/test_helpers/test_helpers.go
@@ -329,7 +329,6 @@ func SetupSimpleEnclaveAndRunScript(t *testing.T, ctx context.Context, testName 
 	logrus.Debugf("Startosis script content: \n%v", script)
 
 	runResult, err := RunScriptWithDefaultConfig(ctx, enclaveCtx, script)
-	require.NoError(t, err, "Unexpected error executing startosis script")
 
 	return runResult
 }

--- a/internal_testsuites/golang/testsuite/startosis_add_service_test/startosis_add_service_invalid_name_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_add_service_test/startosis_add_service_invalid_name_test.go
@@ -48,7 +48,7 @@ func TestAddServiceWithInvalidServiceNameFailsValidation(t *testing.T) {
 	logrus.Infof("Executing Starlark script...")
 	logrus.Debugf("Starlark script contents: \n%v", fmt.Sprintf(addServiceInvalidServiceNameTestScript, invalidServiceName))
 
-	runResult, err := test_helpers.RunScriptWithDefaultConfig(ctx, enclaveCtx, fmt.Sprintf(addServiceInvalidServiceNameTestScript, invalidServiceName))
+	runResult, _ := test_helpers.RunScriptWithDefaultConfig(ctx, enclaveCtx, fmt.Sprintf(addServiceInvalidServiceNameTestScript, invalidServiceName))
 
 	require.Nil(t, runResult.InterpretationError, "Unexpected interpretation error.")
 	require.NotEmpty(t, runResult.ValidationErrors, "Expected some validation errors")

--- a/internal_testsuites/golang/testsuite/startosis_add_service_test/startosis_add_service_invalid_name_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_add_service_test/startosis_add_service_invalid_name_test.go
@@ -49,7 +49,6 @@ func TestAddServiceWithInvalidServiceNameFailsValidation(t *testing.T) {
 	logrus.Debugf("Starlark script contents: \n%v", fmt.Sprintf(addServiceInvalidServiceNameTestScript, invalidServiceName))
 
 	runResult, err := test_helpers.RunScriptWithDefaultConfig(ctx, enclaveCtx, fmt.Sprintf(addServiceInvalidServiceNameTestScript, invalidServiceName))
-	require.NoError(t, err, "Unexpected error executing Starlark script")
 
 	require.Nil(t, runResult.InterpretationError, "Unexpected interpretation error.")
 	require.NotEmpty(t, runResult.ValidationErrors, "Expected some validation errors")

--- a/internal_testsuites/golang/testsuite/startosis_add_service_test/startosis_add_service_with_ready_conditions_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_add_service_test/startosis_add_service_with_ready_conditions_test.go
@@ -47,11 +47,8 @@ func TestStartosis_AddServiceWithReadyConditionsCheck(t *testing.T) {
 
 	script := fmt.Sprintf(addServiceWithReadyConditionsScript, okStatusCode)
 
-	runResult := test_helpers.SetupSimpleEnclaveAndRunScript(t, ctx, addServiceWithReadyConditionsTestName, script)
-
-	require.Nil(t, runResult.InterpretationError, "Unexpected interpretation error")
-	require.Empty(t, runResult.ValidationErrors, "Unexpected validation error")
-	require.Empty(t, runResult.ExecutionError, "Unexpected execution error")
+	_, err := test_helpers.SetupSimpleEnclaveAndRunScript(t, ctx, addServiceWithReadyConditionsTestName, script)
+	require.Nil(t, err)
 }
 
 func TestStartosis_AddServiceWithReadyConditionsCheckFail(t *testing.T) {
@@ -61,7 +58,7 @@ func TestStartosis_AddServiceWithReadyConditionsCheckFail(t *testing.T) {
 
 	script := fmt.Sprintf(addServiceWithReadyConditionsScript, serverErrorStatusCode)
 
-	runResult := test_helpers.SetupSimpleEnclaveAndRunScript(t, ctx, addServiceWithReadyConditionsTestName, script)
+	runResult, _ := test_helpers.SetupSimpleEnclaveAndRunScript(t, ctx, addServiceWithReadyConditionsTestName, script)
 
 	require.Nil(t, runResult.InterpretationError, "Unexpected interpretation error")
 	require.Empty(t, runResult.ValidationErrors, "Unexpected validation error")

--- a/internal_testsuites/golang/testsuite/startosis_add_service_test/startosis_add_services_with_ready_conditions_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_add_service_test/startosis_add_services_with_ready_conditions_test.go
@@ -54,11 +54,9 @@ func TestStartosis_AddServicesWithReadyConditionsCheck(t *testing.T) {
 
 	script := fmt.Sprintf(addServicesWithReadyConditionsScript, okStatusCode)
 
-	runResult := test_helpers.SetupSimpleEnclaveAndRunScript(t, ctx, addServicesWithReadyConditionsTestName, script)
+	_, err := test_helpers.SetupSimpleEnclaveAndRunScript(t, ctx, addServicesWithReadyConditionsTestName, script)
 
-	require.Nil(t, runResult.InterpretationError, "Unexpected interpretation error")
-	require.Empty(t, runResult.ValidationErrors, "Unexpected validation error")
-	require.Empty(t, runResult.ExecutionError, "Unexpected execution error")
+	require.Nil(t, err)
 }
 
 func TestStartosis_AddServicesWithReadyConditionsCheckFail(t *testing.T) {
@@ -68,7 +66,7 @@ func TestStartosis_AddServicesWithReadyConditionsCheckFail(t *testing.T) {
 
 	script := fmt.Sprintf(addServicesWithReadyConditionsScript, serverErrorStatusCode)
 
-	runResult := test_helpers.SetupSimpleEnclaveAndRunScript(t, ctx, addServicesWithReadyConditionsTestName, script)
+	runResult, _ := test_helpers.SetupSimpleEnclaveAndRunScript(t, ctx, addServicesWithReadyConditionsTestName, script)
 
 	require.Nil(t, runResult.InterpretationError, "Unexpected interpretation error")
 	require.Empty(t, runResult.ValidationErrors, "Unexpected validation error")

--- a/internal_testsuites/golang/testsuite/startosis_package_test/startosis_no_main_file_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_package_test/startosis_no_main_file_test.go
@@ -38,8 +38,7 @@ func TestStartosisPackage_NoMainFile(t *testing.T) {
 
 	expectedErrorContents := `An error occurred while verifying that 'main.star' exists in the package 'github.com/sample/sample-kurtosis-package' at '/kurtosis-data/startosis-packages/sample/sample-kurtosis-package/main.star'
 	Caused by: stat /kurtosis-data/startosis-packages/sample/sample-kurtosis-package/main.star: no such file or directory`
-	runResult, err := enclaveCtx.RunStarlarkPackageBlocking(ctx, packageDirpath, emptyRunParams, defaultDryRun, defaultParallelism)
-	require.Nil(t, err, "Unexpected error executing package")
+	runResult, _ := enclaveCtx.RunStarlarkPackageBlocking(ctx, packageDirpath, emptyRunParams, defaultDryRun, defaultParallelism)
 	require.NotNil(t, runResult.InterpretationError)
 	require.Equal(t, runResult.InterpretationError.GetErrorMessage(), expectedErrorContents)
 	require.Empty(t, runResult.ValidationErrors)

--- a/internal_testsuites/golang/testsuite/startosis_package_test/startosis_no_run_in_main_star_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_package_test/startosis_no_run_in_main_star_test.go
@@ -34,8 +34,7 @@ func TestStartosisPackage_NoMainInMainStar(t *testing.T) {
 	logrus.Infof("Starlark package path: \n%v", packageDirpath)
 
 	expectedInterpretationErr := "No 'run' function found in file 'github.com/sample/sample-kurtosis-package/main.star'; a 'run' entrypoint function with the signature `run(args)` or `run()` is required in the main.star file of any Kurtosis package"
-	runResult, err := enclaveCtx.RunStarlarkPackageBlocking(ctx, packageDirpath, emptyRunParams, defaultDryRun, defaultParallelism)
-	require.Nil(t, err, "Unexpected error executing Starlark package")
+	runResult, _ := enclaveCtx.RunStarlarkPackageBlocking(ctx, packageDirpath, emptyRunParams, defaultDryRun, defaultParallelism)
 	require.NotNil(t, runResult.InterpretationError)
 	require.Contains(t, runResult.InterpretationError.GetErrorMessage(), expectedInterpretationErr)
 	require.Empty(t, runResult.ValidationErrors)

--- a/internal_testsuites/golang/testsuite/startosis_package_test/startosis_valid_package_with_input_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_package_test/startosis_valid_package_with_input_test.go
@@ -72,7 +72,7 @@ func TestStartosisPackage_ValidPackageWithInput_MissingKeyInParams(t *testing.T)
 	logrus.Infof("Startosis module path: \n%v", moduleDirpath)
 
 	params := `{"hello": "world"}` // expecting key 'greetings' here
-	runResult, err := enclaveCtx.RunStarlarkPackageBlocking(ctx, moduleDirpath, params, defaultDryRun, defaultParallelism)
+	runResult, _ := enclaveCtx.RunStarlarkPackageBlocking(ctx, moduleDirpath, params, defaultDryRun, defaultParallelism)
 
 	require.NotNil(t, runResult.InterpretationError, "Unexpected interpretation error")
 	require.Contains(t, runResult.InterpretationError.GetErrorMessage(), "Evaluation error: key \"greetings\" not in dict")

--- a/internal_testsuites/golang/testsuite/startosis_package_test/startosis_valid_package_with_input_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_package_test/startosis_valid_package_with_input_test.go
@@ -73,7 +73,6 @@ func TestStartosisPackage_ValidPackageWithInput_MissingKeyInParams(t *testing.T)
 
 	params := `{"hello": "world"}` // expecting key 'greetings' here
 	runResult, err := enclaveCtx.RunStarlarkPackageBlocking(ctx, moduleDirpath, params, defaultDryRun, defaultParallelism)
-	require.NoError(t, err, "Unexpected error executing startosis module")
 
 	require.NotNil(t, runResult.InterpretationError, "Unexpected interpretation error")
 	require.Contains(t, runResult.InterpretationError.GetErrorMessage(), "Evaluation error: key \"greetings\" not in dict")

--- a/internal_testsuites/golang/testsuite/startosis_ports_wait_test/startosis_ports_wait_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_ports_wait_test/startosis_ports_wait_test.go
@@ -51,16 +51,14 @@ def run(plan):
 
 func TestStartosis_AssertSuccessPortChecks(t *testing.T) {
 	ctx := context.Background()
-	runResult := test_helpers.SetupSimpleEnclaveAndRunScript(t, ctx, assertSuccessTestName, assertSuccessScript)
+	_, err := test_helpers.SetupSimpleEnclaveAndRunScript(t, ctx, assertSuccessTestName, assertSuccessScript)
 
-	require.Nil(t, runResult.InterpretationError, "Unexpected interpretation error")
-	require.Empty(t, runResult.ValidationErrors, "Unexpected validation error")
-	require.Empty(t, runResult.ExecutionError, "Unexpected execution error")
+	require.Nil(t, err)
 }
 
 func TestStartosis_AssertFailBecausePortIsNotOpen(t *testing.T) {
 	ctx := context.Background()
-	runResult := test_helpers.SetupSimpleEnclaveAndRunScript(t, ctx, assertFailTestName, assertFailScript)
+	runResult, _ := test_helpers.SetupSimpleEnclaveAndRunScript(t, ctx, assertFailTestName, assertFailScript)
 
 	require.Nil(t, runResult.InterpretationError, "Unexpected interpretation error")
 	require.Empty(t, runResult.ValidationErrors, "Unexpected validation error")
@@ -69,7 +67,7 @@ func TestStartosis_AssertFailBecausePortIsNotOpen(t *testing.T) {
 
 func TestStartosis_AssertFailBecauseEmptyStringIsNotValid(t *testing.T) {
 	ctx := context.Background()
-	runResult := test_helpers.SetupSimpleEnclaveAndRunScript(t, ctx, assertFailTestName2, assertFailScript2)
+	runResult, _ := test_helpers.SetupSimpleEnclaveAndRunScript(t, ctx, assertFailTestName2, assertFailScript2)
 
 	require.NotNil(t, runResult.InterpretationError, "Expected interpretation error coming from wait validation")
 	require.Empty(t, runResult.ValidationErrors, "Unexpected validation error")

--- a/internal_testsuites/golang/testsuite/startosis_request_wait_assert_test/starlark_validation_failure_invalid_port_id_request_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_request_wait_assert_test/starlark_validation_failure_invalid_port_id_request_test.go
@@ -32,7 +32,7 @@ def run(plan):
 
 func TestStarlark_InvalidPortIdRequest(t *testing.T) {
 	ctx := context.Background()
-	runResult := test_helpers.SetupSimpleEnclaveAndRunScript(t, ctx, requestInvalidPortIDTest, requestInvalidPortIDFailScript)
+	runResult, _ := test_helpers.SetupSimpleEnclaveAndRunScript(t, ctx, requestInvalidPortIDTest, requestInvalidPortIDFailScript)
 
 	require.Nil(t, runResult.InterpretationError, "Unexpected interpretation error")
 	require.NotEmpty(t, runResult.ValidationErrors, "Expected validation errors")

--- a/internal_testsuites/golang/testsuite/startosis_request_wait_assert_test/starlark_validation_failure_invalid_port_id_wait_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_request_wait_assert_test/starlark_validation_failure_invalid_port_id_wait_test.go
@@ -32,7 +32,7 @@ def run(plan):
 
 func TestStarlark_InvalidPortIdWait(t *testing.T) {
 	ctx := context.Background()
-	runResult := test_helpers.SetupSimpleEnclaveAndRunScript(t, ctx, waitInvalidPortIDTest, waitInvalidPortIDFailScript)
+	runResult, _ := test_helpers.SetupSimpleEnclaveAndRunScript(t, ctx, waitInvalidPortIDTest, waitInvalidPortIDFailScript)
 
 	require.Nil(t, runResult.InterpretationError, "Unexpected interpretation error")
 	require.NotEmpty(t, runResult.ValidationErrors, "Expected validation error")

--- a/internal_testsuites/golang/testsuite/startosis_request_wait_assert_test/starlark_validation_failure_invalid_service_name_request_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_request_wait_assert_test/starlark_validation_failure_invalid_service_name_request_test.go
@@ -32,7 +32,7 @@ def run(plan):
 
 func TestStarlark_InvalidServiceRequest(t *testing.T) {
 	ctx := context.Background()
-	runResult := test_helpers.SetupSimpleEnclaveAndRunScript(t, ctx, requestInvalidServiceName, requestInvalidServiceNameScript)
+	runResult, _ := test_helpers.SetupSimpleEnclaveAndRunScript(t, ctx, requestInvalidServiceName, requestInvalidServiceNameScript)
 
 	require.Nil(t, runResult.InterpretationError, "Unexpected interpretation error")
 	require.NotEmpty(t, runResult.ValidationErrors, "Expected validation error")

--- a/internal_testsuites/golang/testsuite/startosis_request_wait_assert_test/starlark_validation_failure_invalid_service_wait_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_request_wait_assert_test/starlark_validation_failure_invalid_service_wait_test.go
@@ -32,7 +32,7 @@ def run(plan):
 
 func TestStarlark_InvalidServiceWait(t *testing.T) {
 	ctx := context.Background()
-	runResult := test_helpers.SetupSimpleEnclaveAndRunScript(t, ctx, waitInvalidServiceTest, waitInvalidServiceTestScript)
+	runResult, _ := test_helpers.SetupSimpleEnclaveAndRunScript(t, ctx, waitInvalidServiceTest, waitInvalidServiceTestScript)
 
 	require.Nil(t, runResult.InterpretationError, "Unexpected interpretation error")
 	require.NotEmpty(t, runResult.ValidationErrors, "Expected validation error")

--- a/internal_testsuites/golang/testsuite/startosis_request_wait_assert_test/startosis_assert_fail_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_request_wait_assert_test/startosis_assert_fail_test.go
@@ -36,7 +36,7 @@ def run(plan):
 
 func TestStartosis_AssertFail(t *testing.T) {
 	ctx := context.Background()
-	runResult := test_helpers.SetupSimpleEnclaveAndRunScript(t, ctx, assertFailTestName, assertFailScript)
+	runResult, _ := test_helpers.SetupSimpleEnclaveAndRunScript(t, ctx, assertFailTestName, assertFailScript)
 
 	require.Nil(t, runResult.InterpretationError, "Unexpected interpretation error")
 	require.Empty(t, runResult.ValidationErrors, "Unexpected validation error")

--- a/internal_testsuites/golang/testsuite/startosis_request_wait_assert_test/startosis_complex_request_wait_assert_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_request_wait_assert_test/startosis_complex_request_wait_assert_test.go
@@ -85,10 +85,8 @@ def run(plan):
 
 func TestStartosis_ComplexRequestWaitAssert(t *testing.T) {
 	ctx := context.Background()
-	runResult := test_helpers.SetupSimpleEnclaveAndRunScript(t, ctx, complexRequestWaitAssertTestName, complexRequestWaitAssertStartosisScript)
+	_, err := test_helpers.SetupSimpleEnclaveAndRunScript(t, ctx, complexRequestWaitAssertTestName, complexRequestWaitAssertStartosisScript)
 
-	require.Nil(t, runResult.InterpretationError, "Unexpected interpretation error")
-	require.Empty(t, runResult.ValidationErrors, "Unexpected validation error")
-	require.Nil(t, runResult.ExecutionError, "Unexpected execution error")
+	require.Nil(t, err)
 	logrus.Infof("Successfully ran Startosis script")
 }

--- a/internal_testsuites/golang/testsuite/startosis_request_wait_assert_test/startosis_timeout_wait_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_request_wait_assert_test/startosis_timeout_wait_test.go
@@ -32,7 +32,7 @@ def run(plan):
 
 func TestStartosis_TimeoutWait(t *testing.T) {
 	ctx := context.Background()
-	runResult := test_helpers.SetupSimpleEnclaveAndRunScript(t, ctx, timeoutWaitTestName, timeoutWaitStartosisScript)
+	runResult, _ := test_helpers.SetupSimpleEnclaveAndRunScript(t, ctx, timeoutWaitTestName, timeoutWaitStartosisScript)
 
 	require.Nil(t, runResult.InterpretationError, "Unexpected interpretation error")
 	require.Empty(t, runResult.ValidationErrors, "Unexpected validation error")


### PR DESCRIPTION
## Description:
Currently Starlark run remote package, run package and run script blocking calls on the SDK have the following behavior:
1. If an error happens on the APIC side, we return `(*StarlarkRunResult == nil, error != nil)`
2. If an error happens on the Starlark side, we return `(*StarlarkRunResult != nil, error == nil)`, with either `StarlarkRunResult.[InterpretationError, ValidationErrors, ExecutionError] != nil`
3. If no errors happen on the Starlark side, we return `(*StarlarkRunResult != nil, error == nil)` with all `StarlarkRunResult.[InterpretationError, ValidationErrors, ExecutionError] == nil`

This behavior is not very ergonomic, given that most people are only interested if the Starlark succeeded or not, they should be able to do this with a simple `err != nil` check, which is the Go idiomatic way of dong it.

If the user wants to investigate further the interpreted instructions, the breakdown of which phase failed, etc, this will still be accessible via the `StarlarkRunResult`.

## Is this change user facing?
YES
<!-- If yes, please add the "user facing" label to the PR -->
<!-- If yes, don't forget to include docs changes where relevant -->

## References (if applicable):
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
https://github.com/ava-labs/subnet-evm/pull/649