### PR TITLE
refactor!: Set CGO_ENABLED=0 for APIC and Engine

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -294,8 +294,6 @@ jobs:
 
       - <<: *abort_job_if_only_docs_changes
 
-      - run: sudo apt-get update -y &&  sudo apt-get install -y musl-dev
-
       # Install proto compiler. To compile startosis proto files on the fly, the APIC needs `protoc`
       - run: |
           sudo apt update
@@ -352,8 +350,6 @@ jobs:
       - checkout
 
       - <<: *abort_job_if_only_docs_changes
-
-      - run: sudo apt-get update -y &&  sudo apt-get install -y musl-dev
 
       # Generate Kurtosis Version
       - run: "<<pipeline.parameters.generate-kurtosis-version-script-path>>"
@@ -869,8 +865,6 @@ jobs:
           # You can preview this template and know more about templates here: https://github.com/CircleCI-Public/slack-orb/wiki#templates
           template: basic_fail_1
 
-      - run: sudo apt-get update -y &&  sudo apt-get install -y musl-dev
-
       # Install proto compiler. To compile startosis proto files on the fly, the APIC needs `protoc`
       - run: |
           sudo apt update
@@ -908,8 +902,6 @@ jobs:
           event: fail
           # You can preview this template and know more about templates here: https://github.com/CircleCI-Public/slack-orb/wiki#templates
           template: basic_fail_1
-
-      - run: sudo apt-get update -y &&  sudo apt-get install -y musl-dev
 
       - checkout
 

--- a/README.md
+++ b/README.md
@@ -158,12 +158,6 @@ brew install protoc-gen-go-grpc
 npm install -g ts-protoc-gen
 npm install -g grpc-tools
 ```
-#### Musl
-
-On MacOS:
-```bash
-brew install filosottile/musl-cross/musl-cross
-```
 
 Build Instructions
 ------------------

--- a/core/server/Dockerfile
+++ b/core/server/Dockerfile
@@ -1,7 +1,7 @@
 FROM --platform=linux/amd64 alpine:3.17
 
 # We need protobut-dev to run protobuf compiler against startosis .proto files
-RUN apk update && apk add --no-cache bash protobuf-dev && apk add musl
+RUN apk update && apk add --no-cache bash protobuf-dev
 
 WORKDIR /run
 

--- a/core/server/scripts/build.sh
+++ b/core/server/scripts/build.sh
@@ -47,7 +47,7 @@ echo "Tests succeeded"
 
 # Build binary for packaging inside an Alpine Linux image
 echo "Building server main.go '${MAIN_GO_FILEPATH}'..."
-if ! GOOS=linux GOARCH=amd64 go build -o "${MAIN_BINARY_OUTPUT_FILEPATH}" "${MAIN_GO_FILEPATH}"; then
+if ! CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o "${MAIN_BINARY_OUTPUT_FILEPATH}" "${MAIN_GO_FILEPATH}"; then
   echo "Error: An error occurred building the server code" >&2
   exit 1
 fi

--- a/core/server/scripts/build.sh
+++ b/core/server/scripts/build.sh
@@ -47,7 +47,7 @@ echo "Tests succeeded"
 
 # Build binary for packaging inside an Alpine Linux image
 echo "Building server main.go '${MAIN_GO_FILEPATH}'..."
-if ! CGO_ENABLED=1 GOOS=linux GOARCH=amd64 CC="x86_64-linux-musl-gcc" CXX="x86_64-linux-musl-g++" go build -o "${MAIN_BINARY_OUTPUT_FILEPATH}" "${MAIN_GO_FILEPATH}"; then
+if ! GOOS=linux GOARCH=amd64 go build -o "${MAIN_BINARY_OUTPUT_FILEPATH}" "${MAIN_GO_FILEPATH}"; then
   echo "Error: An error occurred building the server code" >&2
   exit 1
 fi

--- a/engine/server/Dockerfile
+++ b/engine/server/Dockerfile
@@ -1,6 +1,6 @@
 FROM --platform=linux/amd64 alpine:3.17
 
-RUN apk update && apk add bash && apk add musl
+RUN apk update && apk add bash
 
 WORKDIR /run
 

--- a/engine/server/scripts/build.sh
+++ b/engine/server/scripts/build.sh
@@ -48,7 +48,7 @@ echo "Tests succeeded"
 
 # Build binary for packaging inside an Alpine Linux image
 echo "Building server main.go '${MAIN_GO_FILEPATH}'..."
-if ! CGO_ENABLED=1 CC="x86_64-linux-musl-gcc" CXX="x86_64-linux-musl-g++" GOOS=linux GOARCH=amd64 go build -o "${MAIN_BINARY_OUTPUT_FILEPATH}" "${MAIN_GO_FILEPATH}"; then
+if ! GOOS=linux GOARCH=amd64 go build -o "${MAIN_BINARY_OUTPUT_FILEPATH}" "${MAIN_GO_FILEPATH}"; then
   echo "Error: An error occurred building the server code" >&2
   exit 1
 fi

--- a/engine/server/scripts/build.sh
+++ b/engine/server/scripts/build.sh
@@ -48,7 +48,7 @@ echo "Tests succeeded"
 
 # Build binary for packaging inside an Alpine Linux image
 echo "Building server main.go '${MAIN_GO_FILEPATH}'..."
-if ! GOOS=linux GOARCH=amd64 go build -o "${MAIN_BINARY_OUTPUT_FILEPATH}" "${MAIN_GO_FILEPATH}"; then
+if ! CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o "${MAIN_BINARY_OUTPUT_FILEPATH}" "${MAIN_GO_FILEPATH}"; then
   echo "Error: An error occurred building the server code" >&2
   exit 1
 fi


### PR DESCRIPTION
## Description:
<!-- Describe this change, how it works, and the motivation behind it. -->
We use to set `CGO_ENABLED=1` to allow the dynamic linking of the Kubernetes plugin binary in runtime. Now that Kubernetes code has been merged, we can revert back into shipping a cross compiled single binary of both APIC/Engine that does not depend on a `libc`.

This also reduces:

- the setup burden on people developing Kurtosis
- image size

## Is this change user facing?
NO
<!-- If yes, please add the "user facing" label to the PR -->
<!-- If yes, don't forget to include docs changes where relevant -->

## References (if applicable):
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
