### PR TITLE
fix: Fix error propagation in context switch

### DIFF
--- a/cli/cli/commands/kurtosis_context/context_switch/switch.go
+++ b/cli/cli/commands/kurtosis_context/context_switch/switch.go
@@ -115,7 +115,7 @@ func run(ctx context.Context, _ *flags.ParsedFlags, args *args.ParsedArgs) error
 
 	_, engineClientCloseFunc, restartEngineErr := engineManager.RestartEngineIdempotently(ctx, logrus.InfoLevel, noEngineVersion, restartEngineOnSameVersionIfAnyRunning)
 	if restartEngineErr != nil {
-		return stacktrace.Propagate(err, "Engine could not be restarted after context was switched. The context"+
+		return stacktrace.Propagate(restartEngineErr, "Engine could not be restarted after context was switched. The context"+
 			"will be rolled back, but it is possible the engine will remain stopped. Its status can be retrieved "+
 			"running 'kurtosis %s %s' and it can potentially be restarted running 'kurtosis %s %s'",
 			command_str_consts.EngineCmdStr, command_str_consts.EngineStatusCmdStr, command_str_consts.EngineCmdStr,


### PR DESCRIPTION
## Description:
`stacktrace.propagate` was using the wrong error in context switch command. Fixing it so that if an error occurs during engine restart, kurtosis does not panic and log the nice error message

## Is this change user facing?
NO

