### PR TITLE
fix: Fix typo in the configuration path of the issue labeler workflow

### DIFF
--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -13,6 +13,6 @@ jobs:
     steps:
     - uses: github/issue-labeler@v3.1
       with:
-        configuration-path: .github/issue_labeler.yml
+        configuration-path: .github/issue-labeler.yml
         enable-versioned-regex: 0
         repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description:
The issue labeler workflow config path is pointing to a non-existing filename.  This PR fixes the path.

## Is this change user facing?
NO

## References (if applicable):
#662 
