### PR TITLE
fix: Fix user service logs when backend is kubernetes

### DIFF
--- a/cli/cli/commands/service/logs/logs.go
+++ b/cli/cli/commands/service/logs/logs.go
@@ -189,7 +189,7 @@ func run(
 	if clusterType == resolved_config.KurtosisClusterType_Kubernetes {
 		//These Kurtosis primitives came from the backend (container-engine-lib) and this is the reason
 		//why are different from the same defined earlier (which came from the Kurtosis SDK)
-		kurtosisBackendServiceUUID := service.ServiceUUID(serviceIdentifier)
+		kurtosisBackendServiceUUID := service.ServiceUUID(serviceUuid)
 
 		userServiceFilters := &service.ServiceFilters{
 			Names: nil,


### PR DESCRIPTION
## Description:
It was throwing before:
![Screenshot 2023-06-05 at 16 59 58](https://github.com/kurtosis-tech/kurtosis/assets/18011812/28f4d6a4-da45-4ccf-8ec0-cd76cd85ae7c)


## Is this change user facing?
NO
<!-- If yes, please add the "user facing" label to the PR -->
<!-- If yes, don't forget to include docs changes where relevant -->

## References (if applicable):
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
