### PR TITLE
feat: added support for resource limit in the backend

### DIFF
--- a/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/user_services_functions/start_user_services.go
+++ b/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/user_services_functions/start_user_services.go
@@ -517,7 +517,7 @@ func getUserServicePodContainerSpecs(
 	memoryAllocationMegabytes uint64,
 	minCpuAllocationMilliCpus uint64,
 	minMemoryAllocationMegabytes uint64,
-) ([]apiv1.Container, error, ) {
+) ([]apiv1.Container, error) {
 
 	var containerEnvVars []apiv1.EnvVar
 	for varName, varValue := range envVarStrs {
@@ -597,7 +597,7 @@ func checkIfResourcesAreSetProperly(
 	resourceRequest uint64,
 	resourceLimit uint64,
 	resourceName apiv1.ResourceName) error {
-	
+
 	if resourceRequest > resourceLimit {
 		return stacktrace.NewError(fmt.Sprintf("Minimum Resource Requirement for the container is set higher than Maximum resource requirement for resource: %v", resourceName))
 	}

--- a/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/user_services_functions/start_user_services.go
+++ b/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/user_services_functions/start_user_services.go
@@ -593,7 +593,11 @@ func getUserServicePodContainerSpecs(
 	return containers, nil
 }
 
-func checkIfResourcesAreSetProperly(resourceRequest uint64, resourceLimit uint64, resourceName apiv1.ResourceName) error {
+func checkIfResourcesAreSetProperly(
+	resourceRequest uint64,
+	resourceLimit uint64,
+	resourceName apiv1.ResourceName) error {
+	
 	if resourceRequest > resourceLimit {
 		return stacktrace.NewError(fmt.Sprintf("Minimum Resource Requirement for the container is set higher than Maximum resource requirement for resource: %v", resourceName))
 	}

--- a/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/user_services_functions/start_user_services.go
+++ b/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/user_services_functions/start_user_services.go
@@ -599,7 +599,7 @@ func checkIfResourcesAreSetProperly(
 	resourceName apiv1.ResourceName) error {
 
 	if resourceRequest > resourceLimit {
-		return stacktrace.NewError(fmt.Sprintf("Minimum Resource Requirement for the container is set higher than Maximum resource requirement for resource: %v", resourceName))
+		return stacktrace.NewError(fmt.Sprintf("Minimum resource requirement for the container is set higher than Maximum resource requirement for resource: %v", resourceName))
 	}
 
 	return nil

--- a/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/user_services_functions/start_user_services.go
+++ b/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/user_services_functions/start_user_services.go
@@ -506,7 +506,19 @@ func updateServiceWhenContainerStarted(
 	return updatedService, undoUpdateFunc, nil
 }
 
-func getUserServicePodContainerSpecs(image string, entrypointArgs []string, cmdArgs []string, envVarStrs map[string]string, privatePorts map[string]*port_spec.PortSpec, containerMounts []apiv1.VolumeMount, cpuAllocationMillicpus uint64, memoryAllocationMegabytes uint64, minCpuAllocationMilliCpus uint64, minMemoryAllocationMegabytes uint64, ) ([]apiv1.Container, error, ) {
+func getUserServicePodContainerSpecs(
+	image string,
+	entrypointArgs []string,
+	cmdArgs []string,
+	envVarStrs map[string]string,
+	privatePorts map[string]*port_spec.PortSpec,
+	containerMounts []apiv1.VolumeMount,
+	cpuAllocationMillicpus uint64,
+	memoryAllocationMegabytes uint64,
+	minCpuAllocationMilliCpus uint64,
+	minMemoryAllocationMegabytes uint64,
+) ([]apiv1.Container, error, ) {
+
 	var containerEnvVars []apiv1.EnvVar
 	for varName, varValue := range envVarStrs {
 		envVar := apiv1.EnvVar{

--- a/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/user_services_functions/start_user_services.go
+++ b/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/user_services_functions/start_user_services.go
@@ -262,6 +262,8 @@ func createStartServiceOperation(
 		cpuAllocationMillicpus := serviceConfig.GetCPUAllocationMillicpus()
 		memoryAllocationMegabytes := serviceConfig.GetMemoryAllocationMegabytes()
 		privateIPAddrPlaceholder := serviceConfig.GetPrivateIPAddrPlaceholder()
+		minCpuAllocationMilliCpus := serviceConfig.GetMinCPUAllocationMillicpus()
+		minMemoryAllocationMegabytes := serviceConfig.GetMinMemoryAllocationMegabytes()
 
 		matchingObjectAndResources, found := servicesObjectsAndResources[serviceUuid]
 		if !found {
@@ -314,12 +316,13 @@ func createStartServiceOperation(
 		podContainers, err := getUserServicePodContainerSpecs(
 			containerImageName,
 			entrypointArgs,
-			cmdArgs,
-			envVars,
+			cmdArgs, envVars,
 			privatePorts,
 			userServiceContainerVolumeMounts,
 			cpuAllocationMillicpus,
 			memoryAllocationMegabytes,
+			minCpuAllocationMilliCpus,
+			minMemoryAllocationMegabytes,
 		)
 		if err != nil {
 			return nil, stacktrace.Propagate(err, "An error occurred creating the container specs for the user service pod with image '%v'", containerImageName)
@@ -502,19 +505,7 @@ func updateServiceWhenContainerStarted(
 	return updatedService, undoUpdateFunc, nil
 }
 
-func getUserServicePodContainerSpecs(
-	image string,
-	entrypointArgs []string,
-	cmdArgs []string,
-	envVarStrs map[string]string,
-	privatePorts map[string]*port_spec.PortSpec,
-	containerMounts []apiv1.VolumeMount,
-	cpuAllocationMillicpus uint64,
-	memoryAllocationMegabytes uint64,
-) (
-	[]apiv1.Container,
-	error,
-) {
+func getUserServicePodContainerSpecs(image string, entrypointArgs []string, cmdArgs []string, envVarStrs map[string]string, privatePorts map[string]*port_spec.PortSpec, containerMounts []apiv1.VolumeMount, cpuAllocationMillicpus uint64, memoryAllocationMegabytes uint64, minCpuAllocationMilliCpus uint64, minMemoryAllocationMegabytes uint64, ) ([]apiv1.Container, error, ) {
 	var containerEnvVars []apiv1.EnvVar
 	for varName, varValue := range envVarStrs {
 		envVar := apiv1.EnvVar{
@@ -535,13 +526,23 @@ func getUserServicePodContainerSpecs(
 	// 0 is considered the empty value (meaning the field was never set), so if either fields are 0, that resource is left unbounded
 	if cpuAllocationMillicpus != 0 {
 		resourceLimitsList[apiv1.ResourceCPU] = *resource.NewMilliQuantity(int64(cpuAllocationMillicpus), resource.DecimalSI)
-		resourceRequestsList[apiv1.ResourceCPU] = *resource.NewMilliQuantity(int64(cpuAllocationMillicpus), resource.DecimalSI)
 	}
+
+	if minCpuAllocationMilliCpus != 0 {
+		resourceRequestsList[apiv1.ResourceCPU] = *resource.NewMilliQuantity(int64(minCpuAllocationMilliCpus), resource.DecimalSI)
+	}
+
 	if memoryAllocationMegabytes != 0 {
 		memoryAllocationInBytes := convertMegabytesToBytes(memoryAllocationMegabytes)
 		resourceLimitsList[apiv1.ResourceMemory] = *resource.NewQuantity(int64(memoryAllocationInBytes), resource.DecimalSI)
 		resourceRequestsList[apiv1.ResourceMemory] = *resource.NewQuantity(int64(memoryAllocationInBytes), resource.DecimalSI)
 	}
+
+	if minMemoryAllocationMegabytes != 0 {
+		minMemoryAllocationInBytes := convertMegabytesToBytes(minMemoryAllocationMegabytes)
+		resourceRequestsList[apiv1.ResourceMemory] = *resource.NewQuantity(int64(minMemoryAllocationInBytes), resource.DecimalSI)
+	}
+
 	resourceRequirements := apiv1.ResourceRequirements{ //nolint:exhaustruct
 		Limits:   resourceLimitsList,
 		Requests: resourceRequestsList,

--- a/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/user_services_functions/start_user_services_test.go
+++ b/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/user_services_functions/start_user_services_test.go
@@ -1,7 +1,9 @@
 package user_services_functions
 
 import (
+	"fmt"
 	"github.com/stretchr/testify/require"
+	apiv1 "k8s.io/api/core/v1"
 	"testing"
 )
 
@@ -10,4 +12,13 @@ func TestConvertMemoryAllocationToBytesReturnsCorrectValue(t *testing.T) {
 
 	memoryAllocationBytes := convertMegabytesToBytes(memoryAllocationMegabytes)
 	require.Equal(t, uint64(400000000), memoryAllocationBytes)
+}
+
+func Test_checkIfResourcesAreSetProperly(t *testing.T) {
+	resourceRequst := uint64(100)
+	resourceLimit := uint64(99)
+
+	err := checkIfResourcesAreSetProperly(resourceRequst, resourceLimit, apiv1.ResourceCPU)
+	require.NotNil(t, err)
+	require.ErrorContains(t, err, fmt.Sprintf("Minimum Resource Requirement for the container is set higher than Maximum resource requirement for resource: %v", apiv1.ResourceCPU))
 }

--- a/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/user_services_functions/start_user_services_test.go
+++ b/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/user_services_functions/start_user_services_test.go
@@ -20,5 +20,5 @@ func Test_checkIfResourcesAreSetProperly(t *testing.T) {
 
 	err := checkIfResourcesAreSetProperly(resourceRequst, resourceLimit, apiv1.ResourceCPU)
 	require.NotNil(t, err)
-	require.ErrorContains(t, err, fmt.Sprintf("Minimum Resource Requirement for the container is set higher than Maximum resource requirement for resource: %v", apiv1.ResourceCPU))
+	require.ErrorContains(t, err, fmt.Sprintf("Minimum resource requirement for the container is set higher than Maximum resource requirement for resource: %v", apiv1.ResourceCPU))
 }

--- a/container-engine-lib/lib/backend_interface/objects/service/service_config.go
+++ b/container-engine-lib/lib/backend_interface/objects/service/service_config.go
@@ -3,7 +3,6 @@ package service
 import (
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/files_artifacts_expansion"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/port_spec"
-	"github.com/sirupsen/logrus"
 )
 
 // Config options for the underlying container of a service
@@ -46,7 +45,6 @@ func NewServiceConfig(
 	memoryAllocationMegabytes uint64,
 	privateIPAddrPlaceholder string) *ServiceConfig {
 
-	logrus.Infof("YOLOLOL %v %v", cpuAllocationMillicpus, memoryAllocationMegabytes)
 	return &ServiceConfig{
 		containerImageName:        containerImageName,
 		privatePorts:              privatePorts,
@@ -59,6 +57,7 @@ func NewServiceConfig(
 		memoryAllocationMegabytes: memoryAllocationMegabytes,
 		privateIPAddrPlaceholder:  privateIPAddrPlaceholder,
 		// TODO: WILL CHANGE THIS IN NEXT PR
+		// The minimum resources specification is only available for kubernetes
 		minCpuAllocationMilliCpus:    cpuAllocationMillicpus,
 		minMemoryAllocationMegabytes: memoryAllocationMegabytes,
 	}

--- a/container-engine-lib/lib/backend_interface/objects/service/service_config.go
+++ b/container-engine-lib/lib/backend_interface/objects/service/service_config.go
@@ -103,10 +103,12 @@ func (serviceConfig *ServiceConfig) GetPrivateIPAddrPlaceholder() string {
 	return serviceConfig.privateIPAddrPlaceholder
 }
 
+// only available for Kubernetes
 func (serviceConfig *ServiceConfig) GetMinCPUAllocationMillicpus() uint64 {
 	return serviceConfig.minCpuAllocationMilliCpus
 }
 
+// only available for Kubernetes
 func (serviceConfig *ServiceConfig) GetMinMemoryAllocationMegabytes() uint64 {
 	return serviceConfig.minMemoryAllocationMegabytes
 }

--- a/container-engine-lib/lib/backend_interface/objects/service/service_config.go
+++ b/container-engine-lib/lib/backend_interface/objects/service/service_config.go
@@ -3,6 +3,7 @@ package service
 import (
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/files_artifacts_expansion"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/port_spec"
+	"github.com/sirupsen/logrus"
 )
 
 // Config options for the underlying container of a service
@@ -27,6 +28,10 @@ type ServiceConfig struct {
 	memoryAllocationMegabytes uint64
 
 	privateIPAddrPlaceholder string
+
+	minCpuAllocationMilliCpus uint64
+
+	minMemoryAllocationMegabytes uint64
 }
 
 func NewServiceConfig(
@@ -40,6 +45,8 @@ func NewServiceConfig(
 	cpuAllocationMillicpus uint64,
 	memoryAllocationMegabytes uint64,
 	privateIPAddrPlaceholder string) *ServiceConfig {
+
+	logrus.Infof("YOLOLOL %v %v", cpuAllocationMillicpus, memoryAllocationMegabytes)
 	return &ServiceConfig{
 		containerImageName:        containerImageName,
 		privatePorts:              privatePorts,
@@ -51,6 +58,9 @@ func NewServiceConfig(
 		cpuAllocationMillicpus:    cpuAllocationMillicpus,
 		memoryAllocationMegabytes: memoryAllocationMegabytes,
 		privateIPAddrPlaceholder:  privateIPAddrPlaceholder,
+		// TODO: WILL CHANGE THIS IN NEXT PR
+		minCpuAllocationMilliCpus:    cpuAllocationMillicpus,
+		minMemoryAllocationMegabytes: memoryAllocationMegabytes,
 	}
 }
 
@@ -92,4 +102,12 @@ func (serviceConfig *ServiceConfig) GetMemoryAllocationMegabytes() uint64 {
 
 func (serviceConfig *ServiceConfig) GetPrivateIPAddrPlaceholder() string {
 	return serviceConfig.privateIPAddrPlaceholder
+}
+
+func (serviceConfig *ServiceConfig) GetMinCPUAllocationMillicpus() uint64 {
+	return serviceConfig.minCpuAllocationMilliCpus
+}
+
+func (serviceConfig *ServiceConfig) GetMinMemoryAllocationMegabytes() uint64 {
+	return serviceConfig.minMemoryAllocationMegabytes
 }


### PR DESCRIPTION
This PR #1 for this ticket:- https://github.com/kurtosis-tech/kurtosis/issues/675

We used to use one variable to assign both resource request and limits; added a support where they both can have different values.

In the next PR(s) - will hook the backend with starlark.
