### PR TITLE
fix: display service name in exec

### DIFF
--- a/core/server/api_container/server/startosis_engine/kurtosis_instruction/exec/exec.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_instruction/exec/exec.go
@@ -81,7 +81,8 @@ func NewExec(serviceNetwork service_network.ServiceNetwork, runtimeValueStore *r
 		},
 
 		DefaultDisplayArguments: map[string]bool{
-			RecipeArgName: true,
+			RecipeArgName:      true,
+			ServiceNameArgName: true,
 		},
 	}
 }


### PR DESCRIPTION
## Description:
Exec didn't show service name in terminal; now it does

## Is this change user facing?
YES