### PR TITLE
fix: Kurtosis shell exec panics if stdin is not terminal

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -689,8 +689,8 @@ jobs:
 
       # Shell
       # Emulates GitHub Actions
-      - run: "${KURTOSIS_BINPATH} service shell test-enclave test1 --exec "echo 1" < /dev/null > /dev/null"
-      - run: "${KURTOSIS_BINPATH} service shell test-enclave test1 --exec "echo 1"
+      - run: "${KURTOSIS_BINPATH} service shell test-enclave test1 --exec 'echo 1' < /dev/null > /dev/null"
+      - run: "${KURTOSIS_BINPATH} service shell test-enclave test1 --exec 'echo 1'
 
       # File commands
       - run: "${KURTOSIS_BINPATH} files rendertemplate test-enclave << pipeline.parameters.rendertemplate-cli-test-template-relative-path >> << pipeline.parameters.rendertemplate-cli-test-data-json-relative-path >> ./rendered --name rendered-file"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -688,7 +688,9 @@ jobs:
       - run: "${KURTOSIS_BINPATH} service add test-enclave test2 httpd --ports http=80"
 
       # Shell
-      - run: "${KURTOSIS_BINPATH} service shell test-enclave test1 --exec "echo 1" < /dev/null"
+      # Emulates GitHub Actions
+      - run: "${KURTOSIS_BINPATH} service shell test-enclave test1 --exec "echo 1" < /dev/null > /dev/null"
+      - run: "${KURTOSIS_BINPATH} service shell test-enclave test1 --exec "echo 1"
 
       # File commands
       - run: "${KURTOSIS_BINPATH} files rendertemplate test-enclave << pipeline.parameters.rendertemplate-cli-test-template-relative-path >> << pipeline.parameters.rendertemplate-cli-test-data-json-relative-path >> ./rendered --name rendered-file"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -687,6 +687,10 @@ jobs:
       - run: "${KURTOSIS_BINPATH} service add test-enclave test1 httpd --ports http=80"
       - run: "${KURTOSIS_BINPATH} service add test-enclave test2 httpd --ports http=80"
 
+      # Shell
+      - run: "touch dummy"
+      - run: "${KURTOSIS_BINPATH} service shell test-enclave test1 --exec "cat" < dummy"
+
       # File commands
       - run: "${KURTOSIS_BINPATH} files rendertemplate test-enclave << pipeline.parameters.rendertemplate-cli-test-template-relative-path >> << pipeline.parameters.rendertemplate-cli-test-data-json-relative-path >> ./rendered --name rendered-file"
       - run: "${KURTOSIS_BINPATH} files download test-enclave rendered-file ."

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -688,8 +688,7 @@ jobs:
       - run: "${KURTOSIS_BINPATH} service add test-enclave test2 httpd --ports http=80"
 
       # Shell
-      - run: "touch dummy"
-      - run: "${KURTOSIS_BINPATH} service shell test-enclave test1 --exec "cat" < dummy"
+      - run: "${KURTOSIS_BINPATH} service shell test-enclave test1 --exec "echo 1" < /dev/null"
 
       # File commands
       - run: "${KURTOSIS_BINPATH} files rendertemplate test-enclave << pipeline.parameters.rendertemplate-cli-test-template-relative-path >> << pipeline.parameters.rendertemplate-cli-test-data-json-relative-path >> ./rendered --name rendered-file"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -690,7 +690,7 @@ jobs:
       # Shell
       # Emulates GitHub Actions
       - run: "${KURTOSIS_BINPATH} service shell test-enclave test1 --exec 'echo 1' < /dev/null > /dev/null"
-      - run: "${KURTOSIS_BINPATH} service shell test-enclave test1 --exec 'echo 1'
+      - run: "${KURTOSIS_BINPATH} service shell test-enclave test1 --exec 'echo 1'"
 
       # File commands
       - run: "${KURTOSIS_BINPATH} files rendertemplate test-enclave << pipeline.parameters.rendertemplate-cli-test-template-relative-path >> << pipeline.parameters.rendertemplate-cli-test-data-json-relative-path >> ./rendered --name rendered-file"

--- a/cli/cli/commands/service/shell/shell.go
+++ b/cli/cli/commands/service/shell/shell.go
@@ -123,21 +123,13 @@ func run(
 	// From this point on down, I don't know why it works.... but it does
 	// I just followed the solution here: https://stackoverflow.com/questions/58732588/accept-user-input-os-stdin-to-container-using-golang-docker-sdk-interactive-co
 	// This channel is being used to know the user exited the ContainerExec
-	stdoutChan := make(chan bool)
+	finishChan := make(chan bool)
 	go func() {
 		io.Copy(os.Stdout, newReader)
-		stdoutChan <- true
+		finishChan <- true
 	}()
-	stderrChan := make(chan bool)
-	go func() {
-		io.Copy(os.Stderr, newReader)
-		stderrChan <- true
-	}()
-	stdinChan := make(chan bool)
-	go func() {
-		io.Copy(conn, os.Stdin)
-		stdinChan <- true
-	}()
+	go io.Copy(os.Stderr, newReader)
+	go io.Copy(conn, os.Stdin)
 
 	stdinFd := int(os.Stdin.Fd())
 	var oldState *terminal.State
@@ -150,9 +142,7 @@ func run(
 		defer terminal.Restore(stdinFd, oldState)
 	}
 
-	<-stdoutChan
-	<-stderrChan
-	<-stdinChan
+	<-finishChan
 
 	return nil
 }


### PR DESCRIPTION
## Description:
<!-- Describe this change, how it works, and the motivation behind it. -->
Fixes a bug where if `os.Stdin` is not a terminal (for example, if you pipe a file) during `kurtosis service shell ...`, we call `terminal.Restore(stdinFd, oldState)` with `oldState` uninitialized.

Repro steps:
```console
$ kurtosis enclave add --name test-enclave
$ kurtosis service add test-enclave test2 httpd --ports http=80
$ kurtosis service shell test-enclave test2 --exec "echo 1" < /dev/null
```

Causing the following error:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x18a0854]

goroutine 1 [running]:
golang.org/x/term.restore(...)
	/go/pkg/mod/golang.org/x/term@v0.6.0/term_unix.go:57
golang.org/x/term.Restore(...)
	/go/pkg/mod/golang.org/x/term@v0.6.0/term.go:45
golang.org/x/crypto/ssh/terminal.Restore(0xc0001d1dd0?, 0x0?)
	/go/pkg/mod/golang.org/x/crypto@v0.7.0/ssh/terminal/terminal.go:64 +0x14
github.com/kurtosis-tech/kurtosis/cli/cli/commands/service/shell.run({0x20e01a0, 0xc00032a420}, {0x20f6388, 0xc000361420}, {0x1?, 0xa?}, {0xc0000cbaa0?, 0xc0000cba70?}, 0xc0000cbad0?, 0xc000360b60)
	/root/project/cli/cli/commands/service/shell/shell.go:147 +0x68a
github.com/kurtosis-tech/kurtosis/cli/cli/command_framework/highlevel/engine_consuming_kurtosis_command.(*EngineConsumingKurtosisCommand).getRunFunc.func1({0x20e01a0, 0xc00032a420}, 0x0?, 0xc000[13](https://github.com/victorcolombo/sei-chain/actions/runs/5201948897/jobs/9382840002?pr=1#step:8:14)9100?)
	/root/project/cli/cli/command_framework/highlevel/engine_consuming_kurtosis_command/engine_consuming_kurtosis_command.go:2[19](https://github.com/victorcolombo/sei-chain/actions/runs/5201948897/jobs/9382840002?pr=1#step:8:20) +0x224
github.com/kurtosis-tech/kurtosis/cli/cli/command_framework/lowlevel.(*LowlevelKurtosisCommand).MustGetCobraCommand.func2(0xc000334c00?, {0xc000139100, 0x2, 0x4})
	/root/project/cli/cli/command_framework/lowlevel/lowlevel_kurtosis_command.go:294 +0x44e
github.com/spf13/cobra.(*Command).execute(0xc000334c00, {0xc0001390c0, 0x4, 0x4})
	/go/pkg/mod/github.com/spf13/cobra@v1.6.1-0.[20](https://github.com/victorcolombo/sei-chain/actions/runs/5201948897/jobs/9382840002?pr=1#step:8:21)230225[21](https://github.com/victorcolombo/sei-chain/actions/runs/5201948897/jobs/9382840002?pr=1#step:8:22)3037-567ea8ebc9b4/command.go:940 +0x862
github.com/spf13/cobra.(*Command).ExecuteC(0x30bc[22](https://github.com/victorcolombo/sei-chain/actions/runs/5201948897/jobs/9382840002?pr=1#step:8:23)0)
	/go/pkg/mod/github.com/spf13/cobra@v1.6.1-0.20[23](https://github.com/victorcolombo/sei-chain/actions/runs/5201948897/jobs/9382840002?pr=1#step:8:24)02[25](https://github.com/victorcolombo/sei-chain/actions/runs/5201948897/jobs/9382840002?pr=1#step:8:26)21[30](https://github.com/victorcolombo/sei-chain/actions/runs/5201948897/jobs/9382840002?pr=1#step:8:31)37-567ea8ebc9b4/command.go:1068 +0x3bd
github.com/spf13/cobra.(*Command).Execute(...)
	/go/pkg/mod/github.com/spf13/cobra@v1.6.1-0.20230225213037-567ea8ebc9b4/command.go:992
main.main()
	/root/project/cli/cli/main.go:52 +0x7d
```

This is *blocking*, given that Github actions does not use a terminal as stdin: https://github.com/victorcolombo/sei-chain/actions/runs/5201948897/jobs/9382840002

## Is this change user facing?
NO
<!-- If yes, please add the "user facing" label to the PR -->
<!-- If yes, don't forget to include docs changes where relevant -->

## References (if applicable):
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
