### PR TITLE
feat: Add `kurtosis service exec` command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -687,10 +687,12 @@ jobs:
       - run: "${KURTOSIS_BINPATH} service add test-enclave test1 httpd --ports http=80"
       - run: "${KURTOSIS_BINPATH} service add test-enclave test2 httpd --ports http=80"
 
-      # Shell
+      # Shell & Exec
       # Emulates GitHub Actions
       - run: "${KURTOSIS_BINPATH} service shell test-enclave test1 --exec 'echo 1' < /dev/null > /dev/null"
       - run: "${KURTOSIS_BINPATH} service shell test-enclave test1 --exec 'echo 1'"
+      - run: "${KURTOSIS_BINPATH} service exec test-enclave test1 'echo hello'"
+      - run: "! ${KURTOSIS_BINPATH} service exec test-enclave test1 'echo hello; exit 1'"
 
       # File commands
       - run: "${KURTOSIS_BINPATH} files rendertemplate test-enclave << pipeline.parameters.rendertemplate-cli-test-template-relative-path >> << pipeline.parameters.rendertemplate-cli-test-data-json-relative-path >> ./rendered --name rendered-file"

--- a/cli/cli/command_str_consts/command_str_consts.go
+++ b/cli/cli/command_str_consts/command_str_consts.go
@@ -52,6 +52,7 @@ const (
 	PortalStopCmdStr        = "stop"
 	ServiceCmdStr           = "service"
 	ServiceAddCmdStr        = "add"
+	ServiceExecCmdStr       = "exec"
 	ServiceLogsCmdStr       = "logs"
 	ServiceRmCmdStr         = "rm"
 	ServiceShellCmdStr      = "shell"

--- a/cli/cli/commands/service/exec/exec.go
+++ b/cli/cli/commands/service/exec/exec.go
@@ -1,0 +1,140 @@
+package exec
+
+import (
+	"context"
+	"fmt"
+	"github.com/kurtosis-tech/kurtosis/api/golang/engine/kurtosis_engine_rpc_api_bindings"
+	"github.com/kurtosis-tech/kurtosis/api/golang/engine/lib/kurtosis_context"
+	"github.com/kurtosis-tech/kurtosis/cli/cli/command_framework/highlevel/enclave_id_arg"
+	"github.com/kurtosis-tech/kurtosis/cli/cli/command_framework/highlevel/engine_consuming_kurtosis_command"
+	"github.com/kurtosis-tech/kurtosis/cli/cli/command_framework/highlevel/service_identifier_arg"
+	"github.com/kurtosis-tech/kurtosis/cli/cli/command_framework/lowlevel/args"
+	"github.com/kurtosis-tech/kurtosis/cli/cli/command_framework/lowlevel/flags"
+	"github.com/kurtosis-tech/kurtosis/cli/cli/command_str_consts"
+	"github.com/kurtosis-tech/kurtosis/cli/cli/out"
+	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface"
+	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/enclave"
+	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/service"
+	metrics_client "github.com/kurtosis-tech/metrics-library/golang/lib/client"
+	"github.com/kurtosis-tech/stacktrace"
+)
+
+const (
+	enclaveIdentifierArgKey = "enclave"
+	isEnclaveIdArgOptional  = false
+	isEnclaveIdArgGreedy    = false
+
+	serviceIdentifierArgKey  = "service"
+	isServiceGuidArgOptional = false
+	isServiceGuidArgGreedy   = false
+
+	execCommandArgKey        = "command"
+	isExecCommandArgOptional = false
+	isExecCommandArgGreedy   = false
+
+	kurtosisBackendCtxKey = "kurtosis-backend"
+	engineClientCtxKey    = "engine-client"
+
+	binShCommand     = "sh"
+	binShCommandFlag = "-c"
+)
+
+var ServiceShellCmd = &engine_consuming_kurtosis_command.EngineConsumingKurtosisCommand{
+	CommandStr:                command_str_consts.ServiceExecCmdStr,
+	ShortDescription:          "Executes a command in a service",
+	LongDescription:           "Execute a command in a service. Note if the command being run is multiple words you should wrap it in quotes",
+	KurtosisBackendContextKey: kurtosisBackendCtxKey,
+	EngineClientContextKey:    engineClientCtxKey,
+	Flags:                     []*flags.FlagConfig{},
+	Args: []*args.ArgConfig{
+		enclave_id_arg.NewEnclaveIdentifierArg(
+			enclaveIdentifierArgKey,
+			engineClientCtxKey,
+			isEnclaveIdArgOptional,
+			isEnclaveIdArgGreedy,
+		),
+		service_identifier_arg.NewServiceIdentifierArg(
+			serviceIdentifierArgKey,
+			isServiceGuidArgOptional,
+			isServiceGuidArgGreedy,
+		),
+		{
+			Key:        execCommandArgKey,
+			IsOptional: isExecCommandArgOptional,
+			IsGreedy:   isExecCommandArgGreedy,
+		},
+	},
+	RunFunc: run,
+}
+
+func run(
+	ctx context.Context,
+	kurtosisBackend backend_interface.KurtosisBackend,
+	_ kurtosis_engine_rpc_api_bindings.EngineServiceClient,
+	_ metrics_client.MetricsClient,
+	flags *flags.ParsedFlags,
+	args *args.ParsedArgs,
+) error {
+	enclaveIdentifier, err := args.GetNonGreedyArg(enclaveIdentifierArgKey)
+	if err != nil {
+		return stacktrace.Propagate(err, "An error occurred getting the enclave identifier using arg key '%v'", enclaveIdentifierArgKey)
+	}
+
+	serviceIdentifier, err := args.GetNonGreedyArg(serviceIdentifierArgKey)
+	if err != nil {
+		return stacktrace.Propagate(err, "An error occurred getting the service identifier using arg key '%v'", serviceIdentifierArgKey)
+	}
+
+	execCommandToRun, err := args.GetNonGreedyArg(execCommandArgKey)
+	if err != nil {
+		return stacktrace.Propagate(err, "An error occurred getting the exec command using arg key '%v'", execCommandArgKey)
+	}
+
+	kurtosisCtx, err := kurtosis_context.NewKurtosisContextFromLocalEngine()
+	if err != nil {
+		return stacktrace.Propagate(err, "An error occurred connecting to the local Kurtosis engine")
+	}
+
+	enclaveCtx, err := kurtosisCtx.GetEnclaveContext(ctx, enclaveIdentifier)
+	if err != nil {
+		return stacktrace.Propagate(err, "An error occurred while getting enclave context for enclave with identifier '%v' exists", enclaveIdentifier)
+	}
+
+	enclaveUuid := enclave.EnclaveUUID(enclaveCtx.GetEnclaveUuid())
+
+	serviceCtx, err := enclaveCtx.GetServiceContext(serviceIdentifier)
+	if err != nil {
+		return stacktrace.Propagate(err, "An error occurred while getting service context for service with identifier '%v'", serviceIdentifier)
+	}
+	serviceUuid := service.ServiceUUID(serviceCtx.GetServiceUUID())
+
+	results, resultErrors, err := kurtosisBackend.RunUserServiceExecCommands(ctx, enclaveUuid, map[service.ServiceUUID][]string{
+		serviceUuid: {
+			binShCommand,
+			binShCommandFlag,
+			execCommandToRun,
+		},
+	})
+
+	if err != nil {
+		return stacktrace.Propagate(err, "An error occurred executing command '%v' in user service with UUID '%v' in enclave '%v'",
+			execCommandToRun, serviceUuid, enclaveIdentifier)
+	}
+
+	if err, found := resultErrors[serviceUuid]; found {
+		return stacktrace.Propagate(err, "An error occurred executing command '%v' in user service with UUID '%v' in enclave '%v'",
+			execCommandToRun, serviceUuid, enclaveIdentifier)
+	}
+
+	successResult, found := results[serviceUuid]
+	if !found {
+		return stacktrace.NewError("The status of the command execution for '%s' in user service with UUID '%s' in enclave '%s' is unknown."+
+			" It wasn't returned neither as a success nor a failure. This is a bug in Kurtosis.", execCommandToRun, serviceUuid, enclaveIdentifier)
+	}
+
+	if successResult.GetExitCode() != 0 {
+		return stacktrace.NewError("The command was successfully executed but returned a non-zero exit code: '%d'. Output was:\n%v", successResult.GetExitCode(), successResult.GetOutput())
+	}
+	out.PrintOutLn(fmt.Sprintf("The command was successfully executed and returned '%d'. Output was:\n%v", successResult.GetExitCode(), successResult.GetOutput()))
+	return nil
+}

--- a/cli/cli/commands/service/service.go
+++ b/cli/cli/commands/service/service.go
@@ -8,6 +8,7 @@ package service
 import (
 	"github.com/kurtosis-tech/kurtosis/cli/cli/command_str_consts"
 	"github.com/kurtosis-tech/kurtosis/cli/cli/commands/service/add"
+	"github.com/kurtosis-tech/kurtosis/cli/cli/commands/service/exec"
 	"github.com/kurtosis-tech/kurtosis/cli/cli/commands/service/logs"
 	"github.com/kurtosis-tech/kurtosis/cli/cli/commands/service/rm"
 	"github.com/kurtosis-tech/kurtosis/cli/cli/commands/service/shell"
@@ -24,6 +25,7 @@ var ServiceCmd = &cobra.Command{
 
 func init() {
 	ServiceCmd.AddCommand(add.ServiceAddCmd.MustGetCobraCommand())
+	ServiceCmd.AddCommand(exec.ServiceShellCmd.MustGetCobraCommand())
 	ServiceCmd.AddCommand(logs.ServiceLogsCmd.MustGetCobraCommand())
 	ServiceCmd.AddCommand(rm.ServiceRmCmd.MustGetCobraCommand())
 	ServiceCmd.AddCommand(shell.ServiceShellCmd.MustGetCobraCommand())


### PR DESCRIPTION
## Description:
Users can now run `kurtosis service exec <ENCLAVE_ID> <SERVICE_ID> 'any sh command'`. The command will be executed inside the designated user service and the result will be printed in the CLI output.

The main different with `kurtosis service shell <ENCLAVE_ID> <SERVICE_ID> --exec 'any sh command'` is that the former expects a zero exit code for the command otherwise throws an exception, whereas the latter returns gracefully whatever the exit code of the command was.

In short, `kurtosis service shell` is designed for interactive sessions and will always return gracefully as long as the session terminated is ended successfully. `kurtosis service exec` provides a way to run a single command and returns immediately, taking the status of the command into account.

Fixes #688 

## Is this change user facing?
YES
<!-- If yes, please add the "user facing" label to the PR -->
<!-- If yes, don't forget to include docs changes where relevant -->

## References (if applicable):
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
