### PR TITLE
fix: accept run as the default main function

### DIFF
--- a/core/server/api_container/server/startosis_engine/startosis_interpreter.go
+++ b/core/server/api_container/server/startosis_engine/startosis_interpreter.go
@@ -98,7 +98,8 @@ func (interpreter *StartosisInterpreter) Interpret(
 
 	var isUsingDefaultMainFunction bool
 	var shouldInjectPlanArg bool
-	if mainFunctionName == "" {
+	// if the user sends "" or "run" we isUsingDefaultMainFunction to true
+	if mainFunctionName == "" || mainFunctionName == runFunctionName {
 		mainFunctionName = runFunctionName
 		isUsingDefaultMainFunction = true
 	} else {


### PR DESCRIPTION
## Description:
runRemoteStarlarkPackage would break if a user passed "run" as the mainFunctionName instead of ""
This fixes it

## Is this change user facing?
YES
