### PR TITLE
feat: added run_sh instruction; users can run one time bash task

### DIFF
--- a/core/server/api_container/server/startosis_engine/kurtosis_builtins.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_builtins.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/kurtosis_instruction/remove_service"
 	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/kurtosis_instruction/render_templates"
 	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/kurtosis_instruction/request"
+	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/kurtosis_instruction/run_sh"
 	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/kurtosis_instruction/set_connection"
 	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/kurtosis_instruction/start_service"
 	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/kurtosis_instruction/stop_service"
@@ -53,6 +54,7 @@ func KurtosisPlanInstructions(serviceNetwork service_network.ServiceNetwork, run
 		request.NewRequest(serviceNetwork, runtimeValueStore),
 		set_connection.NewSetConnection(serviceNetwork),
 		start_service.NewStartService(serviceNetwork),
+		run_sh.NewRunShService(serviceNetwork),
 		stop_service.NewStopService(serviceNetwork),
 		store_service_files.NewStoreServiceFiles(serviceNetwork),
 		update_service.NewUpdateService(serviceNetwork),

--- a/core/server/api_container/server/startosis_engine/kurtosis_builtins.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_builtins.go
@@ -54,7 +54,7 @@ func KurtosisPlanInstructions(serviceNetwork service_network.ServiceNetwork, run
 		request.NewRequest(serviceNetwork, runtimeValueStore),
 		set_connection.NewSetConnection(serviceNetwork),
 		start_service.NewStartService(serviceNetwork),
-		run_sh.NewRunShService(serviceNetwork),
+		run_sh.NewRunShService(serviceNetwork, runtimeValueStore),
 		stop_service.NewStopService(serviceNetwork),
 		store_service_files.NewStoreServiceFiles(serviceNetwork),
 		update_service.NewUpdateService(serviceNetwork),

--- a/core/server/api_container/server/startosis_engine/kurtosis_instruction/run_sh/run_sh.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_instruction/run_sh/run_sh.go
@@ -4,16 +4,22 @@ import (
 	"context"
 	"fmt"
 	"github.com/kurtosis-tech/kurtosis/api/golang/core/lib/services"
+	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/service"
 	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/service_network"
+	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/kurtosis_instruction/shared_helpers/magic_string_helper"
 	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/kurtosis_starlark_framework"
 	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/kurtosis_starlark_framework/builtin_argument"
 	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/kurtosis_starlark_framework/kurtosis_plan_instruction"
 	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/kurtosis_types"
-	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/starlark_warning"
+	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/runtime_value_store"
 	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/startosis_errors"
 	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/startosis_validator"
+	"github.com/kurtosis-tech/stacktrace"
 	"github.com/sirupsen/logrus"
+	"github.com/xtgo/uuid"
 	"go.starlark.net/starlark"
+	"reflect"
+	"strings"
 )
 
 const (
@@ -23,11 +29,16 @@ const (
 	WorkDirArgName   = "workdir"
 	RunArgName       = "run"
 
-	defaultWorkDir = "task"
-	FilesAttr      = "files"
+	DefaultWorkDir   = "task"
+	DefaultImageName = "badouralix/curl-jq"
+	FilesAttr        = "files"
+
+	runshCodeKey   = "code"
+	runshOutputKey = "output"
+	newlineChar    = "\n"
 )
 
-func NewRunShService(serviceNetwork service_network.ServiceNetwork) *kurtosis_plan_instruction.KurtosisPlanInstruction {
+func NewRunShService(serviceNetwork service_network.ServiceNetwork, runtimeValueStore *runtime_value_store.RuntimeValueStore) *kurtosis_plan_instruction.KurtosisPlanInstruction {
 	return &kurtosis_plan_instruction.KurtosisPlanInstruction{
 		KurtosisBaseBuiltin: &kurtosis_starlark_framework.KurtosisBaseBuiltin{
 			Name: RunShBuiltinName,
@@ -35,7 +46,7 @@ func NewRunShService(serviceNetwork service_network.ServiceNetwork) *kurtosis_pl
 			Arguments: []*builtin_argument.BuiltinArgument{
 				{
 					Name:              RunArgName,
-					IsOptional:        true,
+					IsOptional:        false,
 					ZeroValueProvider: builtin_argument.ZeroValueProvider[starlark.String],
 				},
 				{
@@ -58,12 +69,13 @@ func NewRunShService(serviceNetwork service_network.ServiceNetwork) *kurtosis_pl
 
 		Capabilities: func() kurtosis_plan_instruction.KurtosisPlanInstructionCapabilities {
 			return &RunShCapabilities{
-				serviceNetwork: serviceNetwork,
-
-				image:   "badouralix/curl-jq", // populated at interpretation time
-				run:     "",                   // populated at interpretation time
-				workdir: "",                   // populated at interpretation time
-				files:   nil,
+				serviceNetwork:    serviceNetwork,
+				runtimeValueStore: runtimeValueStore,
+				name:              "",
+				image:             DefaultImageName, // populated at interpretation time
+				run:               "",               // populated at interpretation time
+				workdir:           DefaultWorkDir,   // populated at interpretation time
+				files:             nil,
 			}
 		},
 
@@ -77,8 +89,11 @@ func NewRunShService(serviceNetwork service_network.ServiceNetwork) *kurtosis_pl
 }
 
 type RunShCapabilities struct {
-	serviceNetwork service_network.ServiceNetwork
+	runtimeValueStore *runtime_value_store.RuntimeValueStore
+	serviceNetwork    service_network.ServiceNetwork
+	resultUuid        string
 
+	name    string
 	run     string
 	image   string
 	workdir string
@@ -90,8 +105,23 @@ func (builtin *RunShCapabilities) Interpret(arguments *builtin_argument.Argument
 	if err != nil {
 		return nil, startosis_errors.WrapWithInterpretationError(err, "Unable to extract value for '%s' argument", RunArgName)
 	}
-
 	builtin.run = runCommand.GoString()
+
+	if arguments.IsSet(ImageNameArgName) {
+		imageStarlark, err := builtin_argument.ExtractArgumentValue[starlark.String](arguments, ImageNameArgName)
+		if err != nil {
+			return nil, startosis_errors.WrapWithInterpretationError(err, "Unable to extract value for '%s' argument", ImageNameArgName)
+		}
+		builtin.image = imageStarlark.GoString()
+	}
+
+	if arguments.IsSet(WorkDirArgName) {
+		workDirStarlark, err := builtin_argument.ExtractArgumentValue[starlark.String](arguments, WorkDirArgName)
+		if err != nil {
+			return nil, startosis_errors.WrapWithInterpretationError(err, "Unable to extract value for '%s' argument", WorkDirArgName)
+		}
+		builtin.workdir = workDirStarlark.GoString()
+	}
 
 	if arguments.IsSet(FilesAttr) {
 		filesStarlark, err := builtin_argument.ExtractArgumentValue[*starlark.Dict](arguments, FilesAttr)
@@ -107,7 +137,25 @@ func (builtin *RunShCapabilities) Interpret(arguments *builtin_argument.Argument
 		}
 	}
 
-	return starlark.None, nil
+	resultUuid, err := builtin.runtimeValueStore.CreateValue()
+	if err != nil {
+		return nil, startosis_errors.NewInterpretationError("An error occurred while generating UUID for future reference for %v instruction", RunShBuiltinName)
+	}
+	builtin.resultUuid = resultUuid
+	randomUuid := uuid.NewRandom()
+	builtin.name = fmt.Sprintf("task-%v", randomUuid.String())
+
+	dict := &starlark.Dict{}
+	err = dict.SetKey(starlark.String(runshCodeKey), starlark.String(fmt.Sprintf(magic_string_helper.RuntimeValueReplacementPlaceholderFormat, builtin.resultUuid, runshCodeKey)))
+	if err != nil {
+		return nil, startosis_errors.WrapWithInterpretationError(err, "An error happened while creating exec return value, setting field '%v'", runshCodeKey)
+	}
+	err = dict.SetKey(starlark.String(runshOutputKey), starlark.String(fmt.Sprintf(magic_string_helper.RuntimeValueReplacementPlaceholderFormat, builtin.resultUuid, runshOutputKey)))
+	if err != nil {
+		return nil, startosis_errors.WrapWithInterpretationError(err, "An error happened while creating exec return value, setting field '%v'", runshOutputKey)
+	}
+	dict.Freeze()
+	return dict, nil
 }
 
 func (builtin *RunShCapabilities) Validate(_ *builtin_argument.ArgumentValuesSet, validatorEnvironment *startosis_validator.ValidatorEnvironment) *startosis_errors.ValidationError {
@@ -116,26 +164,57 @@ func (builtin *RunShCapabilities) Validate(_ *builtin_argument.ArgumentValuesSet
 
 func (builtin *RunShCapabilities) Execute(ctx context.Context, _ *builtin_argument.ArgumentValuesSet) (string, error) {
 	// cmd string for default workdir
-	createAndSwitchTheDirectory := fmt.Sprintf("mkdir -p %v && cd %v", defaultWorkDir, defaultWorkDir)
-	completeRunCommand := fmt.Sprintf("%v && %v", createAndSwitchTheDirectory, builtin.run)
+	createAndSwitchTheDirectory := fmt.Sprintf("mkdir -p %v && cd %v", builtin.workdir, builtin.workdir)
+	maybeSubCommandWithRuntimeValues, err := magic_string_helper.ReplaceRuntimeValueInString(builtin.run, builtin.runtimeValueStore)
+	if err != nil {
+		return "", stacktrace.Propagate(err, "An error occurred while replacing runtime values in the command of the exec recipe")
+	}
 
+	cleanString := strings.ReplaceAll(maybeSubCommandWithRuntimeValues, "\n", " ")
+	completeRunCommand := fmt.Sprintf("%v && %v", createAndSwitchTheDirectory, cleanString)
 	createDefaultDirectory := []string{"/bin/sh", "-c", completeRunCommand}
 	serviceConfigBuilder := services.NewServiceConfigBuilder(builtin.image)
 	serviceConfigBuilder.WithFilesArtifactMountDirpaths(builtin.files)
 
 	serviceConfig := serviceConfigBuilder.Build()
-	_, err := builtin.serviceNetwork.AddService(ctx, "task", serviceConfig)
+	_, err = builtin.serviceNetwork.AddService(ctx, service.ServiceName(builtin.name), serviceConfig)
 
 	if err != nil {
-		logrus.Errorf("some error happened %v", err)
+		return "", err
 	}
 
-	//starlark_warning.PrintOnceAtTheEndOfExecutionf("Cmd %+v", createDefaultDirectory)
-	code, output, err := builtin.serviceNetwork.ExecCommand(ctx, "task", createDefaultDirectory)
+	code, output, err := builtin.serviceNetwork.ExecCommand(ctx, builtin.name, createDefaultDirectory)
 	if err != nil {
-		logrus.Errorf("some error happened %v", err)
+		return "", err
 	}
 
-	starlark_warning.PrintOnceAtTheEndOfExecutionf("Ouput Code: %v , Output: %v", code, output)
-	return "", err
+	result := map[string]starlark.Comparable{
+		runshOutputKey: starlark.String(output),
+		runshCodeKey:   starlark.MakeInt(int(code)),
+	}
+	builtin.runtimeValueStore.SetValue(builtin.resultUuid, result)
+
+	instructionResult := resultMapToString(result)
+	return instructionResult, err
+}
+
+func resultMapToString(resultMap map[string]starlark.Comparable) string {
+	exitCode := resultMap[runshCodeKey]
+	rawOutput := resultMap[runshOutputKey]
+	outputStarlarkStr, ok := rawOutput.(starlark.String)
+	if !ok {
+		logrus.Errorf("Result of an exec recipe was not a string (was: '%v' of type '%s'). This is not fatal but the object might be malformed in CLI output. It is very unexpected and hides a Kurtosis internal bug. This issue should be reported", rawOutput, reflect.TypeOf(rawOutput))
+		outputStarlarkStr = starlark.String(outputStarlarkStr.String())
+	}
+	outputStr := outputStarlarkStr.GoString()
+	if outputStr == "" {
+		return fmt.Sprintf("Command returned with exit code '%v' with no output", exitCode)
+	}
+	if strings.Contains(outputStr, newlineChar) {
+		return fmt.Sprintf(`Command returned with exit code '%v' and the following output:
+--------------------
+%v
+--------------------`, exitCode, outputStr)
+	}
+	return fmt.Sprintf("Command returned with exit code '%v' and the following output: %v", exitCode, outputStr)
 }

--- a/core/server/api_container/server/startosis_engine/kurtosis_instruction/run_sh/run_sh.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_instruction/run_sh/run_sh.go
@@ -1,0 +1,110 @@
+package run_sh
+
+import (
+	"context"
+	"github.com/kurtosis-tech/kurtosis/api/golang/core/lib/services"
+	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/service_network"
+	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/kurtosis_starlark_framework"
+	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/kurtosis_starlark_framework/builtin_argument"
+	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/kurtosis_starlark_framework/kurtosis_plan_instruction"
+	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/starlark_warning"
+	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/startosis_errors"
+	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/startosis_validator"
+	"github.com/sirupsen/logrus"
+	"go.starlark.net/starlark"
+)
+
+const (
+	RunShBuiltinName = "run_sh"
+
+	ImageNameArgName = "image"
+	WorkDirArgName   = "workdir"
+	RunArgName       = "run"
+)
+
+func NewRunShService(serviceNetwork service_network.ServiceNetwork) *kurtosis_plan_instruction.KurtosisPlanInstruction {
+	return &kurtosis_plan_instruction.KurtosisPlanInstruction{
+		KurtosisBaseBuiltin: &kurtosis_starlark_framework.KurtosisBaseBuiltin{
+			Name: RunShBuiltinName,
+
+			Arguments: []*builtin_argument.BuiltinArgument{
+				{
+					Name:              RunArgName,
+					IsOptional:        true,
+					ZeroValueProvider: builtin_argument.ZeroValueProvider[starlark.String],
+				},
+				{
+					Name:              ImageNameArgName,
+					IsOptional:        true,
+					ZeroValueProvider: builtin_argument.ZeroValueProvider[starlark.String],
+				},
+				{
+					Name:              WorkDirArgName,
+					IsOptional:        true,
+					ZeroValueProvider: builtin_argument.ZeroValueProvider[starlark.String],
+				},
+			},
+		},
+
+		Capabilities: func() kurtosis_plan_instruction.KurtosisPlanInstructionCapabilities {
+			return &RunShCapabilities{
+				serviceNetwork: serviceNetwork,
+
+				image:   "badouralix/curl-jq", // populated at interpretation time
+				run:     "",                   // populated at interpretation time
+				workdir: "",                   // populated at interpretation time
+			}
+		},
+
+		DefaultDisplayArguments: map[string]bool{
+			RunArgName:       true,
+			ImageNameArgName: true,
+			WorkDirArgName:   true,
+		},
+	}
+}
+
+type RunShCapabilities struct {
+	serviceNetwork service_network.ServiceNetwork
+
+	run     string
+	image   string
+	workdir string
+}
+
+func (builtin *RunShCapabilities) Interpret(arguments *builtin_argument.ArgumentValuesSet) (starlark.Value, *startosis_errors.InterpretationError) {
+	runCommand, err := builtin_argument.ExtractArgumentValue[starlark.String](arguments, RunArgName)
+	if err != nil {
+		return nil, startosis_errors.WrapWithInterpretationError(err, "Unable to extract value for '%s' argument", RunArgName)
+	}
+
+	builtin.run = runCommand.GoString()
+	return starlark.None, nil
+}
+
+func (builtin *RunShCapabilities) Validate(_ *builtin_argument.ArgumentValuesSet, validatorEnvironment *startosis_validator.ValidatorEnvironment) *startosis_errors.ValidationError {
+	return nil
+}
+
+func (builtin *RunShCapabilities) Execute(ctx context.Context, _ *builtin_argument.ArgumentValuesSet) (string, error) {
+	// create default workdir
+	createDefaultDirectory := []string{"/bin/sh", "-c", "mkdir -p task && cd task && echo $(pwd)"}
+	serviceConfigBuilder := services.NewServiceConfigBuilder(builtin.image)
+	// serviceConfigBuilder.WithEntryPointArgs(entryPoint)
+	// serviceConfigBuilder.WithCmdArgs(entryPoint)
+
+	serviceConfig := serviceConfigBuilder.Build()
+	_, err := builtin.serviceNetwork.AddService(ctx, "task", serviceConfig)
+
+	if err != nil {
+		logrus.Errorf("some error happened %v", err)
+	}
+
+	code, output, err := builtin.serviceNetwork.ExecCommand(ctx, "task", createDefaultDirectory)
+	if err != nil {
+		logrus.Errorf("some error happened %v", err)
+	}
+
+	starlark_warning.PrintOnceAtTheEndOfExecutionf("Ouput Code: %v , Output: %v", code, output)
+	return "", err
+}

--- a/core/server/api_container/server/startosis_engine/kurtosis_instruction/run_sh/run_sh.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_instruction/run_sh/run_sh.go
@@ -76,6 +76,7 @@ func NewRunShService(serviceNetwork service_network.ServiceNetwork, runtimeValue
 				run:               "",               // populated at interpretation time
 				workdir:           DefaultWorkDir,   // populated at interpretation time
 				files:             nil,
+				resultUuid:        "", // populated at interpretation time
 			}
 		},
 
@@ -91,13 +92,13 @@ func NewRunShService(serviceNetwork service_network.ServiceNetwork, runtimeValue
 type RunShCapabilities struct {
 	runtimeValueStore *runtime_value_store.RuntimeValueStore
 	serviceNetwork    service_network.ServiceNetwork
-	resultUuid        string
 
-	name    string
-	run     string
-	image   string
-	workdir string
-	files   map[string]string
+	resultUuid string
+	name       string
+	run        string
+	image      string
+	workdir    string
+	files      map[string]string
 }
 
 func (builtin *RunShCapabilities) Interpret(arguments *builtin_argument.ArgumentValuesSet) (starlark.Value, *startosis_errors.InterpretationError) {

--- a/internal_testsuites/golang/testsuite/startosis_run_sh_task_test/run_task_sh_task_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_run_sh_task_test/run_task_sh_task_test.go
@@ -20,6 +20,6 @@ def run(plan):
 func TestStarlark_RunshTask(t *testing.T) {
 	ctx := context.Background()
 	runResult, _ := test_helpers.SetupSimpleEnclaveAndRunScript(t, ctx, runshTest, runshStarlark)
-	expectedOutput := "Command returned with exit code '0' and the following output:\n--------------------\nkurtosis\n\n--------------------\nCommand returned with exit code '0' and the following output:\n--------------------\n/src/kurtosis\n\n--------------------\nAssertion succeeded. Value is '\"/task/kurtosis\\n\"'.\n"
+	expectedOutput := "Command returned with exit code '0' and the following output:\n--------------------\nkurtosis\n\n--------------------\nCommand returned with exit code '0' and the following output:\n--------------------\n/src/kurtosis\n\n--------------------\nAssertion succeeded. Value is '\"/src/kurtosis\\n\"'.\n"
 	require.Equal(t, expectedOutput, string(runResult.RunOutput))
 }

--- a/internal_testsuites/golang/testsuite/startosis_run_sh_task_test/run_task_sh_task_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_run_sh_task_test/run_task_sh_task_test.go
@@ -1,0 +1,25 @@
+package startosis_run_sh_task_test
+
+import (
+	"context"
+	"github.com/kurtosis-tech/kurtosis-cli/golang_internal_testsuite/test_helpers"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+const (
+	runshTest     = "run-sh-test"
+	runshStarlark = `
+def run(plan):
+  result1 = plan.run_sh(run="echo kurtosis")
+  result2 = plan.run_sh(run="mkdir -p {0} && cd {0} && echo $(pwd)".format(result1["output"]))
+  plan.assert(result2["output"], "==", "/task/kurtosis\n")
+`
+)
+
+func TestStarlark_RunshTask(t *testing.T) {
+	ctx := context.Background()
+	runResult, _ := test_helpers.SetupSimpleEnclaveAndRunScript(t, ctx, runshTest, runshStarlark)
+	expectedOutput := "Command returned with exit code '0' and the following output:\n--------------------\nkurtosis\n\n--------------------\nCommand returned with exit code '0' and the following output:\n--------------------\n/task/kurtosis\n\n--------------------\nAssertion succeeded. Value is '\"/task/kurtosis\\n\"'.\n"
+	require.Equal(t, expectedOutput, string(runResult.RunOutput))
+}

--- a/internal_testsuites/golang/testsuite/startosis_run_sh_task_test/run_task_sh_task_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_run_sh_task_test/run_task_sh_task_test.go
@@ -11,15 +11,15 @@ const (
 	runshTest     = "run-sh-test"
 	runshStarlark = `
 def run(plan):
-  result1 = plan.run_sh(run="echo kurtosis")
+  result1 = plan.run_sh(run="echo kurtosis", workdir="src")
   result2 = plan.run_sh(run="mkdir -p {0} && cd {0} && echo $(pwd)".format(result1["output"]))
-  plan.assert(result2["output"], "==", "/task/kurtosis\n")
+  plan.assert(result2["output"], "==", "/src/kurtosis\n")
 `
 )
 
 func TestStarlark_RunshTask(t *testing.T) {
 	ctx := context.Background()
 	runResult, _ := test_helpers.SetupSimpleEnclaveAndRunScript(t, ctx, runshTest, runshStarlark)
-	expectedOutput := "Command returned with exit code '0' and the following output:\n--------------------\nkurtosis\n\n--------------------\nCommand returned with exit code '0' and the following output:\n--------------------\n/task/kurtosis\n\n--------------------\nAssertion succeeded. Value is '\"/task/kurtosis\\n\"'.\n"
+	expectedOutput := "Command returned with exit code '0' and the following output:\n--------------------\nkurtosis\n\n--------------------\nCommand returned with exit code '0' and the following output:\n--------------------\n/src/kurtosis\n\n--------------------\nAssertion succeeded. Value is '\"/task/kurtosis\\n\"'.\n"
 	require.Equal(t, expectedOutput, string(runResult.RunOutput))
 }

--- a/internal_testsuites/golang/testsuite/startosis_run_sh_task_test/run_task_sh_task_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_run_sh_task_test/run_task_sh_task_test.go
@@ -11,8 +11,8 @@ const (
 	runshTest     = "run-sh-test"
 	runshStarlark = `
 def run(plan):
-  result1 = plan.run_sh(run="echo kurtosis", workdir="src")
-  result2 = plan.run_sh(run="mkdir -p {0} && cd {0} && echo $(pwd)".format(result1["output"]))
+  result1 = plan.run_sh(run="echo kurtosis")
+  result2 = plan.run_sh(run="mkdir -p {0} && cd {0} && echo $(pwd)".format(result1["output"]), workdir="src")
   plan.assert(result2["output"], "==", "/src/kurtosis\n")
 `
 )


### PR DESCRIPTION
This is the first PR for this project. In this PR, I have added run_sh task, which borrow logic from `add_service` and `exec` to execute one time task. A sample output looks like this:

<img width="1296" alt="Screen Shot 2023-06-13 at 11 54 22 AM" src="https://github.com/kurtosis-tech/kurtosis/assets/15133250/a4775319-288a-4737-9ccc-fcd4ea875274">

There are few todos on here, which will be tackling -- ( the first 4 are high priority)
1.  add ability to copy files from this task
2.  add wait to run_sh task
3. remove/stop this task once it is completed ( I am leaning towards stop)
4. file mounts can be absolute and relative ( in this PR only absolute is being supported)
5. maybe show task as separate entity, it is treated as service atm.

Here is the design spec: https://www.notion.so/kurtosistech/run_sh-Design-Spec-b7f7660fe7004cfe92fb0f8884453cfe?pvs=4
