### PR TITLE
feat: added ability for folks to copy files from the one time execution task

### DIFF
--- a/core/server/api_container/server/startosis_engine/kurtosis_instruction/run_sh/run_sh.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_instruction/run_sh/run_sh.go
@@ -89,13 +89,13 @@ func NewRunShService(serviceNetwork service_network.ServiceNetwork, runtimeValue
 
 							storeFiles, err := kurtosis_types.SafeCastToStringSlice(storeFilesList, storeFilesKey)
 							if err != nil {
-								return startosis_errors.WrapWithInterpretationError(err, "error occurred while validating %v", storeFilesKey)
+								return startosis_errors.WrapWithInterpretationError(err, "error occurred while validating field: %v", storeFilesKey)
 							}
 
 							for _, file := range storeFiles {
 								if duplicates[file] != 0 {
 									return startosis_errors.NewInterpretationError(
-										"error occurred while validating %v. The file paths in the array must be unique. Found multiple instances of %v", storeFilesKey, file)
+										"error occurred while validating field: %v. The file paths in the array must be unique. Found multiple instances of %v", storeFilesKey, file)
 								}
 								duplicates[file] = 1
 							}
@@ -230,14 +230,18 @@ func (builtin *RunShCapabilities) Interpret(arguments *builtin_argument.Argument
 	artifactNamesList := &starlark.List{}
 	if len(builtin.fileArtifactNames) > 0 {
 		for _, name := range builtin.fileArtifactNames {
+			// purposely not checking error for list because it's mutable so should not throw any errors until this point
 			_ = artifactNamesList.Append(starlark.String(name))
 		}
 	}
-
 	dict.Freeze()
+
 	response := &starlark.List{}
+	// purposely not checking error for list because it's mutable so should not throw any errors until this point
 	_ = response.Append(dict)
+	artifactNamesList.Freeze()
 	_ = response.Append(artifactNamesList)
+	response.Freeze()
 	return response, nil
 }
 

--- a/core/server/api_container/server/startosis_engine/kurtosis_instruction/run_sh/run_sh.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_instruction/run_sh/run_sh.go
@@ -166,13 +166,13 @@ func (builtin *RunShCapabilities) Interpret(arguments *builtin_argument.Argument
 				return nil, interpretationErr
 			}
 			fileArtifactProcessedPaths := map[string]string{}
-			for key, value := range filesArtifactMountDirPaths {
-				processedName := getAbsoluteFilePath(builtin.workdir, key)
+			for pathToFileArtifact, fileArtifactName := range filesArtifactMountDirPaths {
+				processedName := getAbsoluteFilePath(builtin.workdir, pathToFileArtifact)
 				if fileArtifactProcessedPaths[processedName] != "" {
 					return nil, startosis_errors.NewInterpretationError("error occurred because duplicate key was found in files argument. "+
-						"Found multiple occurrence for: %v. This occurred during generating absolute paths from relative path inputs.", key)
+						"Found multiple occurrence for: %v. This occurred during generating absolute paths from relative path inputs.", pathToFileArtifact)
 				}
-				fileArtifactProcessedPaths[processedName] = value
+				fileArtifactProcessedPaths[processedName] = fileArtifactName
 			}
 			builtin.files = fileArtifactProcessedPaths
 		}
@@ -190,8 +190,8 @@ func (builtin *RunShCapabilities) Interpret(arguments *builtin_argument.Argument
 				return nil, interpretationErr
 			}
 
-			for index, value := range storeFilesArray {
-				storeFilesArray[index] = getAbsoluteFilePath(builtin.workdir, value)
+			for index, pathToFileArtifact := range storeFilesArray {
+				storeFilesArray[index] = getAbsoluteFilePath(builtin.workdir, pathToFileArtifact)
 			}
 			builtin.pathToFileArtifacts = storeFilesArray
 

--- a/core/server/api_container/server/startosis_engine/kurtosis_instruction/run_sh/run_sh.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_instruction/run_sh/run_sh.go
@@ -234,15 +234,9 @@ func (builtin *RunShCapabilities) Interpret(arguments *builtin_argument.Argument
 			_ = artifactNamesList.Append(starlark.String(name))
 		}
 	}
+	_ = dict.SetKey(starlark.String(runshFileArtifactKey), artifactNamesList)
 	dict.Freeze()
-
-	response := &starlark.List{}
-	// purposely not checking error for list because it's mutable so should not throw any errors until this point
-	_ = response.Append(dict)
-	artifactNamesList.Freeze()
-	_ = response.Append(artifactNamesList)
-	response.Freeze()
-	return response, nil
+	return dict, nil
 }
 
 func (builtin *RunShCapabilities) Validate(_ *builtin_argument.ArgumentValuesSet, validatorEnvironment *startosis_validator.ValidatorEnvironment) *startosis_errors.ValidationError {

--- a/core/server/api_container/server/startosis_engine/kurtosis_instruction/run_sh/run_sh.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_instruction/run_sh/run_sh.go
@@ -239,6 +239,11 @@ func (builtin *RunShCapabilities) Interpret(arguments *builtin_argument.Argument
 
 func (builtin *RunShCapabilities) Validate(_ *builtin_argument.ArgumentValuesSet, validatorEnvironment *startosis_validator.ValidatorEnvironment) *startosis_errors.ValidationError {
 	if builtin.fileArtifactNames != nil {
+		if len(builtin.fileArtifactNames) != len(builtin.pathToFileArtifacts) {
+			return startosis_errors.NewValidationError("error occurred while validating file artifact name for each file in store array. "+
+				"This seems to be a bug, please create a ticket for it. names: %v paths: %v", len(builtin.fileArtifactNames), len(builtin.pathToFileArtifacts))
+		}
+
 		for _, name := range builtin.fileArtifactNames {
 			validatorEnvironment.AddArtifactName(name)
 		}

--- a/core/server/api_container/server/startosis_engine/kurtosis_instruction/run_sh/run_sh.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_instruction/run_sh/run_sh.go
@@ -195,7 +195,7 @@ func (builtin *RunShCapabilities) Interpret(arguments *builtin_argument.Argument
 
 			// generate unique names
 			var uniqueNames []string
-			for _ = range storeFilesArray {
+			for range storeFilesArray {
 				uniqueNameForArtifact, err := builtin.serviceNetwork.GetUniqueNameForFileArtifact()
 				if err != nil {
 					return nil, startosis_errors.WrapWithInterpretationError(err, "error occurred while generating unique name for file artifact")

--- a/core/server/api_container/server/startosis_engine/kurtosis_instruction/run_sh/run_sh.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_instruction/run_sh/run_sh.go
@@ -167,7 +167,12 @@ func (builtin *RunShCapabilities) Interpret(arguments *builtin_argument.Argument
 			}
 			fileArtifactProcessedPaths := map[string]string{}
 			for key, value := range filesArtifactMountDirPaths {
-				fileArtifactProcessedPaths[getAbsoluteFilePath(builtin.workdir, key)] = value
+				processedName := getAbsoluteFilePath(builtin.workdir, key)
+				if fileArtifactProcessedPaths[processedName] != "" {
+					return nil, startosis_errors.NewInterpretationError("error occurred because duplicate key was found in files argument. "+
+						"Found multiple occurrence for: %v. This occurred during generating absolute paths from relative path inputs.", key)
+				}
+				fileArtifactProcessedPaths[processedName] = value
 			}
 			builtin.files = fileArtifactProcessedPaths
 		}
@@ -256,6 +261,8 @@ func (builtin *RunShCapabilities) Validate(_ *builtin_argument.ArgumentValuesSet
 			}
 		}
 	}
+
+	validatorEnvironment.AppendRequiredContainerImage(builtin.image)
 	return nil
 }
 

--- a/docs/docs/starlark-reference/plan.md
+++ b/docs/docs/starlark-reference/plan.md
@@ -400,15 +400,61 @@ The `run_sh` instruction executes a one-time execution task. It runs the bash co
             "/path/to/file/1": files_artifact_1,
             "/path/to/file/2": files_artifact_2,
         },
+
+        # list of paths to directories or files that will be copied to a file artifact
+        # OPTIONAL (Default:[])
+        # CAUTION: paths in this list must be unique
+        store = [
+            # copies a file into a file artifact
+            "/src/kurtosis.txt,
+            
+            # copies the entire directory into a file artifact
+            "/src
+        ]
     )
 
-    plan.print(result["code"])
-    plan.print(result["output"])
+    plan.print(result.code)  # returns the future reference to the code
+    plan.print(result.output) # returns the future reference to the output
+    plan.print(result.file_artifacts) # returns the file artifact names that can be referenced later
 ```
 
 The `files` dictionary argument accepts a key value pair, where `key` is the path where the contents of the artifact will be mounted to and `value` is a [file artifact][files-artifacts-reference] name.
 
-The instruction returns a `dict` whose values are [future reference][future-references-reference] to the output and exit code of the command. `result["output"]` is a future reference to the output of the command, and `result["code"]` is a future reference to the exit code.
+The instruction returns a `struct` with [future references][future-references-reference] to the ouput and exit code of the command, alongside with future-reference to the file artifact names that were generated. 
+   * `result.output` is a future reference to the output of the command
+   * `result.code` is a future reference to the exit code
+   *  `result.file_artifacts` is a future reference to file artifact names that was generated and can be used by the `files` property of `ServiceConfig` or `run_sh` instruction. An example is shown below:-
+
+```python
+
+    result = plan.run_sh(
+        run = "echo kurtosis > test.txt",
+        store = [
+            "/task",
+            "/task/test.txt",
+        ],
+        ...
+    )
+
+    plan.print(result.file_artifacts) # prints ["blue_moon", "green_planet"]
+    
+    # blue_moon is file artifact name that contains task directory
+    # green_planet is the file artifact name that conatins test.txt file
+
+    service_one = plan.add_service(..., 
+        ServiceConfig(
+            name="servce_one", 
+            files={"src": results.file_artifacts[0]}, # copies the directory task into servce_one 
+        )
+    )
+
+    service_two = plan.add_service(..., 
+        ServiceConfig(
+            name="servce_one", 
+            files={"src": results.file_artifacts[1]}, # copies the file test.txt into service_two
+        )
+    ) 
+```
 
 set_connection
 --------------

--- a/docs/docs/starlark-reference/plan.md
+++ b/docs/docs/starlark-reference/plan.md
@@ -390,27 +390,31 @@ The `run_sh` instruction executes a one-time execution task. It runs the bash co
         image = "badouralix/curl-jq",
 
         # Sets the working dir in which the command will be run
-        # OPTIONAL (Default: task)
-        workdir = "task",
+        # OPTIONAL (Default: /task)
+        workdir = "/task",
 
         # A mapping of path_on_task_where_contents_will_be_mounted -> files_artifact_id_to_mount
-        # For more information about file artifacts, see below: 
+        # The file path can be relative to workdir or absolute paths
+        # For more information about file artifacts, see below.
+        # CAUTION: duplicate paths to files or directories to be mounted is not supported, and it will fail
         # OPTIONAL (Default: {})
         files = {
             "/path/to/file/1": files_artifact_1,
-            "/path/to/file/2": files_artifact_2,
+            "path/to/file/2": files_artifact_2, # the path will interpreted as /workdir/path/to/file/2
         },
 
         # list of paths to directories or files that will be copied to a file artifact
+        # these can be relative to workdir or absolute paths
+        # CAUTION: all the paths in this list must be unique 
         # OPTIONAL (Default:[])
-        # CAUTION: paths in this list must be unique
         store = [
             # copies a file into a file artifact
-            "/src/kurtosis.txt,
+            # this will be interpreted as /workdir/src/kurtosis.txt
+            "src/kurtosis.txt, 
             
             # copies the entire directory into a file artifact
-            "/src
-        ]
+            "/workdir/src,
+        ],
     )
 
     plan.print(result.code)  # returns the future reference to the code
@@ -441,19 +445,21 @@ The instruction returns a `struct` with [future references][future-references-re
     # blue_moon is file artifact name that contains task directory
     # green_planet is the file artifact name that conatins test.txt file
 
-    service_one = plan.add_service(..., 
-        ServiceConfig(
+    service_one = plan.add_service(
+        ..., 
+        config=ServiceConfig(
             name="servce_one", 
-            files={"src": results.file_artifacts[0]}, # copies the directory task into servce_one 
+            files={"/src": results.file_artifacts[0]}, # copies the directory task into servce_one 
         )
-    )
+    ) # the path to the file will look like: /src/task/test.txt
 
-    service_two = plan.add_service(..., 
-        ServiceConfig(
+    service_two = plan.add_service(
+        ..., 
+        config=ServiceConfig(
             name="servce_one", 
-            files={"src": results.file_artifacts[1]}, # copies the file test.txt into service_two
-        )
-    ) 
+            files={"/src": results.file_artifacts[1]}, # copies the file test.txt into service_two
+        ),
+    ) # the path to the file will look like: /src/test.txt
 ```
 
 set_connection

--- a/docs/docs/starlark-reference/plan.md
+++ b/docs/docs/starlark-reference/plan.md
@@ -389,7 +389,9 @@ The `run_sh` instruction executes a one-time execution task. It runs the bash co
         # OPTIONAL (Default: badouralix/curl-jq)
         image = "badouralix/curl-jq",
 
-        # Sets the working dir in which the command will be run
+        # Sets the working dir in which:
+        # the command will be run 
+        # and files will be mounted at
         # OPTIONAL (Default: /task)
         workdir = "/task",
 
@@ -427,7 +429,7 @@ The `files` dictionary argument accepts a key value pair, where `key` is the pat
 The instruction returns a `struct` with [future references][future-references-reference] to the ouput and exit code of the command, alongside with future-reference to the file artifact names that were generated. 
    * `result.output` is a future reference to the output of the command
    * `result.code` is a future reference to the exit code
-   *  `result.file_artifacts` is a future reference to file artifact names that was generated and can be used by the `files` property of `ServiceConfig` or `run_sh` instruction. An example is shown below:-
+   *  `result.file_artifacts` is a future reference to the names of the file artifacts that were generated and can be used by the `files` property of `ServiceConfig` or `run_sh` instruction. An example is shown below:-
 
 ```python
 
@@ -442,8 +444,8 @@ The instruction returns a `struct` with [future references][future-references-re
 
     plan.print(result.file_artifacts) # prints ["blue_moon", "green_planet"]
     
-    # blue_moon is file artifact name that contains task directory
-    # green_planet is the file artifact name that conatins test.txt file
+    # blue_moon is name of the file artifact that contains task directory
+    # green_planet is the name of the file artifact that conatins test.txt file
 
     service_one = plan.add_service(
         ..., 

--- a/go.work.sum
+++ b/go.work.sum
@@ -1,3 +1,2 @@
 github.com/bwesterb/go-ristretto v1.2.3/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
-golang.org/x/crypto v0.3.1-0.20221117191849-2c476679df9a/go.mod h1:hebNnKkNXi2UzZN1eVRvBB7co0a+JxK6XbPiWVs/3J4=
-golang.org/x/sys v0.3.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=

--- a/internal_testsuites/golang/testsuite/startosis_run_sh_task_test/run_task_sh_task_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_run_sh_task_test/run_task_sh_task_test.go
@@ -11,15 +11,16 @@ const (
 	runshTest           = "run-sh-test"
 	runshStarlarkSimple = `
 def run(plan):
-  result1, _ = plan.run_sh(run="echo kurtosis")
-  result2, _ = plan.run_sh(run="mkdir -p {0} && cd {0} && echo $(pwd)".format(result1["output"]), workdir="src")
-  plan.assert(result2["output"], "==", "/src/kurtosis\n")
+  result1 = plan.run_sh(run="echo kurtosis")
+  result2 = plan.run_sh(run="mkdir -p {0} && cd {0} && echo $(pwd)".format(result1.output), workdir="src")
+  plan.assert(result2.output, "==", "/src/kurtosis\n")
 `
-	runshStarlarkFileArtifact = `def run(plan):
-  result = plan.run_sh(run="echo kurtosis > tech.txt", store=["/task", "/task"])
-  file_artifacts = result["file_artifacts"]
-  result2, _ = plan.run_sh(run="cat ./task/tech.txt", files={"/src": file_artifacts[0]}, workdir="src")
-  plan.assert(result2["output"], "==", "kurtosis\n")`
+	runshStarlarkFileArtifact = `
+def run(plan):
+  result = plan.run_sh(run="echo kurtosis > tech.txt", store=["/task"])
+  file_artifacts = result.file_artifacts
+  result2 = plan.run_sh(run="cat ./task/tech.txt", files={"/src": file_artifacts[0]}, workdir="src")
+  plan.assert(result2.output, "==", "kurtosis\n")`
 )
 
 func TestStarlark_RunshTaskSimple(t *testing.T) {
@@ -32,6 +33,6 @@ func TestStarlark_RunshTaskSimple(t *testing.T) {
 func TestStarlark_RunshTaskFileArtifact(t *testing.T) {
 	ctx := context.Background()
 	runResult, _ := test_helpers.SetupSimpleEnclaveAndRunScript(t, ctx, runshTest, runshStarlarkFileArtifact)
-	expectedOutput := "Command returned with exit code '0' and the following output:\n--------------------\nkurtosis\n\n--------------------\nCommand returned with exit code '0' and the following output:\n--------------------\nkurtosis\n\n--------------------\nAssertion succeeded. Value is '\"kurtosis\\n\"'.\n"
+	expectedOutput := "Command returned with exit code '0' with no output\nCommand returned with exit code '0' and the following output:\n--------------------\nkurtosis\n\n--------------------\nAssertion succeeded. Value is '\"kurtosis\\n\"'.\n"
 	require.Equal(t, expectedOutput, string(runResult.RunOutput))
 }

--- a/internal_testsuites/golang/testsuite/startosis_run_sh_task_test/run_task_sh_task_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_run_sh_task_test/run_task_sh_task_test.go
@@ -17,10 +17,12 @@ def run(plan):
 `
 	runshStarlarkFileArtifact = `
 def run(plan):
-  result = plan.run_sh(run="echo kurtosis > tech.txt", store=["/task"])
+  result = plan.run_sh(run="mkdir -p src && echo kurtosis > /task/src/tech.txt", store=["src/tech.txt", "/task/src"])
   file_artifacts = result.file_artifacts
-  result2 = plan.run_sh(run="cat ./task/tech.txt", files={"/src": file_artifacts[0]}, workdir="src")
-  plan.assert(result2.output, "==", "kurtosis\n")`
+  result2 = plan.run_sh(run="cat /src/temp/tech.txt", files={"temp": file_artifacts[0]}, workdir="src")
+  plan.assert(result2.output, "==", "kurtosis\n")
+  result3 = plan.run_sh(run="cat ./src/tech.txt", files={"/task": file_artifacts[1]})
+  plan.assert(result3.output, "==", "kurtosis\n")`
 )
 
 func TestStarlark_RunshTaskSimple(t *testing.T) {
@@ -33,6 +35,6 @@ func TestStarlark_RunshTaskSimple(t *testing.T) {
 func TestStarlark_RunshTaskFileArtifact(t *testing.T) {
 	ctx := context.Background()
 	runResult, _ := test_helpers.SetupSimpleEnclaveAndRunScript(t, ctx, runshTest, runshStarlarkFileArtifact)
-	expectedOutput := "Command returned with exit code '0' with no output\nCommand returned with exit code '0' and the following output:\n--------------------\nkurtosis\n\n--------------------\nAssertion succeeded. Value is '\"kurtosis\\n\"'.\n"
+	expectedOutput := "Command returned with exit code '0' with no output\nCommand returned with exit code '0' and the following output:\n--------------------\nkurtosis\n\n--------------------\nAssertion succeeded. Value is '\"kurtosis\\n\"'.\nCommand returned with exit code '0' and the following output:\n--------------------\nkurtosis\n\n--------------------\nAssertion succeeded. Value is '\"kurtosis\\n\"'.\n"
 	require.Equal(t, expectedOutput, string(runResult.RunOutput))
 }

--- a/internal_testsuites/golang/testsuite/startosis_run_sh_task_test/run_task_sh_task_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_run_sh_task_test/run_task_sh_task_test.go
@@ -8,18 +8,29 @@ import (
 )
 
 const (
-	runshTest     = "run-sh-test"
-	runshStarlark = `
+	runshTest           = "run-sh-test"
+	runshStarlarkSimple = `
 def run(plan):
-  result1 = plan.run_sh(run="echo kurtosis")
-  result2 = plan.run_sh(run="mkdir -p {0} && cd {0} && echo $(pwd)".format(result1["output"]), workdir="src")
+  result1, _ = plan.run_sh(run="echo kurtosis")
+  result2, _ = plan.run_sh(run="mkdir -p {0} && cd {0} && echo $(pwd)".format(result1["output"]), workdir="src")
   plan.assert(result2["output"], "==", "/src/kurtosis\n")
 `
+	runshStarlarkFileArtifact = `def run(plan):
+  result, file_artifacts = plan.run_sh(run="echo kurtosis > tech.txt", store=["/task", "/task"])
+  result2, _ = plan.run_sh(run="cat ./task/tech.txt", files={"/src": file_artifacts[0]}, workdir="src")
+  plan.assert(result2["output"], "==", "kurtosis\n")`
 )
 
-func TestStarlark_RunshTask(t *testing.T) {
+func TestStarlark_RunshTaskSimple(t *testing.T) {
 	ctx := context.Background()
-	runResult, _ := test_helpers.SetupSimpleEnclaveAndRunScript(t, ctx, runshTest, runshStarlark)
+	runResult, _ := test_helpers.SetupSimpleEnclaveAndRunScript(t, ctx, runshTest, runshStarlarkSimple)
 	expectedOutput := "Command returned with exit code '0' and the following output:\n--------------------\nkurtosis\n\n--------------------\nCommand returned with exit code '0' and the following output:\n--------------------\n/src/kurtosis\n\n--------------------\nAssertion succeeded. Value is '\"/src/kurtosis\\n\"'.\n"
+	require.Equal(t, expectedOutput, string(runResult.RunOutput))
+}
+
+func TestStarlark_RunshTaskFileArtifact(t *testing.T) {
+	ctx := context.Background()
+	runResult, _ := test_helpers.SetupSimpleEnclaveAndRunScript(t, ctx, runshTest, runshStarlarkFileArtifact)
+	expectedOutput := "Command returned with exit code '0' and the following output:\n--------------------\nkurtosis\n\n--------------------\nCommand returned with exit code '0' and the following output:\n--------------------\nkurtosis\n\n--------------------\nAssertion succeeded. Value is '\"kurtosis\\n\"'.\n"
 	require.Equal(t, expectedOutput, string(runResult.RunOutput))
 }

--- a/internal_testsuites/golang/testsuite/startosis_run_sh_task_test/run_task_sh_task_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_run_sh_task_test/run_task_sh_task_test.go
@@ -16,7 +16,8 @@ def run(plan):
   plan.assert(result2["output"], "==", "/src/kurtosis\n")
 `
 	runshStarlarkFileArtifact = `def run(plan):
-  result, file_artifacts = plan.run_sh(run="echo kurtosis > tech.txt", store=["/task", "/task"])
+  result = plan.run_sh(run="echo kurtosis > tech.txt", store=["/task", "/task"])
+  file_artifacts = result["file_artifacts"]
   result2, _ = plan.run_sh(run="cat ./task/tech.txt", files={"/src": file_artifacts[0]}, workdir="src")
   plan.assert(result2["output"], "==", "kurtosis\n")`
 )


### PR DESCRIPTION
Change the response type ( instead of returning a dict, I am returning a struct) . It is a breaking change but no one really is using it atm so should not have any impact.

Added some validations and importantly we can copy files from a one-time task to a file-artifact.
