### PR TITLE
fix!: removed workdir from run_sh and fixed some typos on the doc

### DIFF
--- a/cli/cli/commands/lsp/resource/kurtosis_starlark.json
+++ b/cli/cli/commands/lsp/resource/kurtosis_starlark.json
@@ -183,7 +183,7 @@
       "name": "run_sh",
       "detail": "It executes a one-time execution task. It runs the bash command specified by the mandatory field `run` on an image specified by the optional `image` field",
       "documentation": "",
-      "returnType": "struct(output:string, code:number, file_artifacts:list)",
+      "returnType": "struct(output:string, code:number, files_artifacts:list)",
       "params": [
         {
           "name": "run",

--- a/cli/cli/commands/lsp/resource/kurtosis_starlark.json
+++ b/cli/cli/commands/lsp/resource/kurtosis_starlark.json
@@ -198,12 +198,6 @@
           "detail": "Image the bash command will be run on"
         },
         {
-          "name": "workdir",
-          "type": "string",
-          "content": "workdir?",
-          "detail": "Sets the working dir in which the command will be run and the files will be mounted at"
-        },
-        {
           "name": "files",
           "type": "dict<string, string>",
           "content": "files?",

--- a/core/server/api_container/server/startosis_engine/kurtosis_instruction/run_sh/run_sh.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_instruction/run_sh/run_sh.go
@@ -266,6 +266,13 @@ func (builtin *RunShCapabilities) Execute(ctx context.Context, _ *builtin_argume
 	builtin.runtimeValueStore.SetValue(builtin.resultUuid, result)
 	instructionResult := resultMapToString(result)
 
+	// throw an error as execution of the command failed
+	if createDefaultDirectoryResult.GetExitCode() != 0 {
+		return "", stacktrace.NewError(
+			"error occurred while running shell command: %v with output: %v and code %v",
+			commandRunCommand, createDefaultDirectoryResult.GetOutput(), createDefaultDirectoryResult.GetExitCode())
+	}
+
 	if builtin.fileArtifactNames != nil && builtin.pathToFileArtifacts != nil {
 		err = copyFilesFromTask(ctx, builtin)
 		if err != nil {

--- a/core/server/api_container/server/startosis_engine/kurtosis_instruction/run_sh/run_sh.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_instruction/run_sh/run_sh.go
@@ -94,6 +94,7 @@ func NewRunShService(serviceNetwork service_network.ServiceNetwork, runtimeValue
 			RunArgName:       true,
 			ImageNameArgName: true,
 			FilesAttr:        true,
+			storeFilesKey:    true,
 		},
 	}
 }

--- a/core/server/api_container/server/startosis_engine/kurtosis_instruction/run_sh/run_sh.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_instruction/run_sh/run_sh.go
@@ -37,10 +37,9 @@ const (
 	runshFileArtifactKey = "files_artifacts"
 	newlineChar          = "\n"
 
-	bashCommand = "/bin/sh"
+	shellCommand = "/bin/sh"
 
-	createAndSwitchDirectoryTemplate = "mkdir -p %v && cd %v"
-	storeFilesKey                    = "store"
+	storeFilesKey = "store"
 )
 
 var runTailCommandToPreventContainerToStopOnCreating = []string{"tail", "-f", "/dev/null"}
@@ -234,9 +233,9 @@ func (builtin *RunShCapabilities) Execute(ctx context.Context, _ *builtin_argume
 	// create work directory and cd into that directory
 	commandRunCommand, err := getCommandToRun(builtin)
 	if err != nil {
-		return "", stacktrace.Propagate(err, "error occurred while preparing the bash command to execute on the image")
+		return "", stacktrace.Propagate(err, "error occurred while preparing the sh command to execute on the image")
 	}
-	createDefaultDirectory := []string{bashCommand, "-c", commandRunCommand}
+	createDefaultDirectory := []string{shellCommand, "-c", commandRunCommand}
 	serviceConfigBuilder := services.NewServiceConfigBuilder(builtin.image)
 	serviceConfigBuilder.WithFilesArtifactMountDirpaths(builtin.files)
 	// This make sure that the container does not stop as soon as it starts

--- a/core/server/api_container/server/startosis_engine/kurtosis_instruction/run_sh/run_sh.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_instruction/run_sh/run_sh.go
@@ -269,8 +269,8 @@ func (builtin *RunShCapabilities) Execute(ctx context.Context, _ *builtin_argume
 	// throw an error as execution of the command failed
 	if createDefaultDirectoryResult.GetExitCode() != 0 {
 		return "", stacktrace.NewError(
-			"error occurred while running shell command: %v with output: %v and code %v",
-			commandRunCommand, createDefaultDirectoryResult.GetOutput(), createDefaultDirectoryResult.GetExitCode())
+			"error occurred and shell command: %q exited with code %d with output %q",
+			commandRunCommand, createDefaultDirectoryResult.GetExitCode(), createDefaultDirectoryResult.GetOutput())
 	}
 
 	if builtin.fileArtifactNames != nil && builtin.pathToFileArtifacts != nil {

--- a/core/server/api_container/server/startosis_engine/kurtosis_instruction/run_sh/run_sh.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_instruction/run_sh/run_sh.go
@@ -272,6 +272,9 @@ func (builtin *RunShCapabilities) Validate(_ *builtin_argument.ArgumentValuesSet
 func (builtin *RunShCapabilities) Execute(ctx context.Context, _ *builtin_argument.ArgumentValuesSet) (string, error) {
 	// create work directory and cd into that directory
 	commandRunCommand, err := getCommandToRun(builtin)
+	if err != nil {
+		return "", stacktrace.Propagate(err, "error occurred while preparing the bash command to execute on the image")
+	}
 	createDefaultDirectory := []string{bashCommand, "-c", commandRunCommand}
 	serviceConfigBuilder := services.NewServiceConfigBuilder(builtin.image)
 	serviceConfigBuilder.WithFilesArtifactMountDirpaths(builtin.files)

--- a/core/server/api_container/server/startosis_engine/kurtosis_instruction/run_sh/run_sh.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_instruction/run_sh/run_sh.go
@@ -36,7 +36,7 @@ const (
 
 	runshCodeKey         = "code"
 	runshOutputKey       = "output"
-	runshFileArtifactKey = "file_artifacts"
+	runshFileArtifactKey = "files_artifacts"
 	newlineChar          = "\n"
 
 	bashCommand = "/bin/sh"

--- a/docs/docs/starlark-reference/plan.md
+++ b/docs/docs/starlark-reference/plan.md
@@ -425,7 +425,7 @@ The instruction returns a `struct` with [future references][future-references-re
 ```python
 
     result = plan.run_sh(
-        run = "echo kurtosis > test.txt",
+        run = "mkdir -p task && cd task && echo kurtosis > test.txt",
         store = [
             "/task",
             "/task/test.txt",

--- a/docs/docs/starlark-reference/plan.md
+++ b/docs/docs/starlark-reference/plan.md
@@ -389,12 +389,6 @@ The `run_sh` instruction executes a one-time execution task. It runs the bash co
         # OPTIONAL (Default: badouralix/curl-jq)
         image = "badouralix/curl-jq",
 
-        # Sets the working dir in which:
-        # the command will be run 
-        # and files will be mounted at
-        # OPTIONAL (Default: "")
-        workdir = "/task",
-
         # A mapping of path_on_task_where_contents_will_be_mounted -> files_artifact_id_to_mount
         # For more information about file artifacts, see below.
         # CAUTION: duplicate paths to files or directories to be mounted is not supported, and it will fail

--- a/docs/docs/starlark-reference/plan.md
+++ b/docs/docs/starlark-reference/plan.md
@@ -392,30 +392,27 @@ The `run_sh` instruction executes a one-time execution task. It runs the bash co
         # Sets the working dir in which:
         # the command will be run 
         # and files will be mounted at
-        # OPTIONAL (Default: /task)
+        # OPTIONAL (Default: "")
         workdir = "/task",
 
         # A mapping of path_on_task_where_contents_will_be_mounted -> files_artifact_id_to_mount
-        # The file path can be relative to workdir or absolute paths
         # For more information about file artifacts, see below.
         # CAUTION: duplicate paths to files or directories to be mounted is not supported, and it will fail
         # OPTIONAL (Default: {})
         files = {
             "/path/to/file/1": files_artifact_1,
-            "path/to/file/2": files_artifact_2, # the path will interpreted as /workdir/path/to/file/2
+            "/path/to/file/2": files_artifact_2,
         },
 
         # list of paths to directories or files that will be copied to a file artifact
-        # these can be relative to workdir or absolute paths
         # CAUTION: all the paths in this list must be unique 
         # OPTIONAL (Default:[])
         store = [
             # copies a file into a file artifact
-            # this will be interpreted as /workdir/src/kurtosis.txt
-            "src/kurtosis.txt, 
+            "/src/kurtosis.txt, 
             
             # copies the entire directory into a file artifact
-            "/workdir/src,
+            "/src,
         ],
     )
 
@@ -450,15 +447,15 @@ The instruction returns a `struct` with [future references][future-references-re
     service_one = plan.add_service(
         ..., 
         config=ServiceConfig(
-            name="servce_one", 
-            files={"/src": results.file_artifacts[0]}, # copies the directory task into servce_one 
+            name="service_one", 
+            files={"/src": results.file_artifacts[0]}, # copies the directory task into service_one 
         )
     ) # the path to the file will look like: /src/task/test.txt
 
     service_two = plan.add_service(
         ..., 
         config=ServiceConfig(
-            name="servce_one", 
+            name="service_two", 
             files={"/src": results.file_artifacts[1]}, # copies the file test.txt into service_two
         ),
     ) # the path to the file will look like: /src/test.txt

--- a/docs/docs/starlark-reference/plan.md
+++ b/docs/docs/starlark-reference/plan.md
@@ -403,10 +403,10 @@ The `run_sh` instruction executes a one-time execution task. It runs the bash co
         # OPTIONAL (Default:[])
         store = [
             # copies a file into a file artifact
-            "/src/kurtosis.txt, 
+            "/src/kurtosis.txt", 
             
             # copies the entire directory into a file artifact
-            "/src,
+            "/src",
         ],
     )
 

--- a/docs/docs/starlark-reference/plan.md
+++ b/docs/docs/starlark-reference/plan.md
@@ -426,7 +426,7 @@ The `files` dictionary argument accepts a key value pair, where `key` is the pat
 The instruction returns a `struct` with [future references][future-references-reference] to the ouput and exit code of the command, alongside with future-reference to the file artifact names that were generated. 
    * `result.output` is a future reference to the output of the command
    * `result.code` is a future reference to the exit code
-   *  `result.file_artifacts` is a future reference to the names of the file artifacts that were generated and can be used by the `files` property of `ServiceConfig` or `run_sh` instruction. An example is shown below:-
+   *  `result.files_artifacts` is a future reference to the names of the file artifacts that were generated and can be used by the `files` property of `ServiceConfig` or `run_sh` instruction. An example is shown below:-
 
 ```python
 
@@ -439,7 +439,7 @@ The instruction returns a `struct` with [future references][future-references-re
         ...
     )
 
-    plan.print(result.file_artifacts) # prints ["blue_moon", "green_planet"]
+    plan.print(result.files_artifacts) # prints ["blue_moon", "green_planet"]
     
     # blue_moon is name of the file artifact that contains task directory
     # green_planet is the name of the file artifact that conatins test.txt file

--- a/internal_testsuites/golang/testsuite/startosis_run_sh_task_test/run_task_sh_task_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_run_sh_task_test/run_task_sh_task_test.go
@@ -17,11 +17,11 @@ def run(plan):
 `
 	runshStarlarkFileArtifact = `
 def run(plan):
-  result = plan.run_sh(run="mkdir -p src && echo kurtosis > /task/src/tech.txt", store=["src/tech.txt", "/task/src"])
+  result = plan.run_sh(run="mkdir -p src && echo kurtosis > /src/tech.txt", store=["/src/tech.txt", "/src"])
   file_artifacts = result.file_artifacts
-  result2 = plan.run_sh(run="cat /src/temp/tech.txt", files={"temp": file_artifacts[0]}, workdir="src")
+  result2 = plan.run_sh(run="cat /src/temp/tech.txt", files={"temp": file_artifacts[0]}, workdir="/src")
   plan.assert(result2.output, "==", "kurtosis\n")
-  result3 = plan.run_sh(run="cat ./src/tech.txt", files={"/task": file_artifacts[1]})
+  result3 = plan.run_sh(run="cat ./src/tech.txt", files={"/task": file_artifacts[1]}, workdir="/task")
   plan.assert(result3.output, "==", "kurtosis\n")`
 )
 

--- a/internal_testsuites/golang/testsuite/startosis_run_sh_task_test/run_task_sh_task_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_run_sh_task_test/run_task_sh_task_test.go
@@ -18,10 +18,10 @@ def run(plan):
 	runshStarlarkFileArtifact = `
 def run(plan):
   result = plan.run_sh(run="mkdir -p src && echo kurtosis > /src/tech.txt", store=["/src/tech.txt", "/src"])
-  file_artifacts = result.file_artifacts
+  file_artifacts = result.files_artifacts
   result2 = plan.run_sh(run="cat /src/temp/tech.txt", files={"temp": file_artifacts[0]}, workdir="/src")
   plan.assert(result2.output, "==", "kurtosis\n")
-  result3 = plan.run_sh(run="cat ./src/tech.txt", files={"/task": file_artifacts[1]}, workdir="/task")
+  result3 = plan.run_sh(run="cat ./src/tech.txt", files={"/": file_artifacts[1]}, workdir="/task")
   plan.assert(result3.output, "==", "kurtosis\n")`
 )
 

--- a/internal_testsuites/golang/testsuite/startosis_run_sh_task_test/run_task_sh_task_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_run_sh_task_test/run_task_sh_task_test.go
@@ -20,9 +20,9 @@ def run(plan):
   result = plan.run_sh(run="mkdir -p src && echo kurtosis > /src/tech.txt", store=["/src/tech.txt", "/src"])
   file_artifacts = result.files_artifacts
   result2 = plan.run_sh(run="cat /temp/tech.txt", files={"/temp": file_artifacts[0]})
-  plan.assert(result2.output, "==", "kurtosis\n")
+  plan.assert(result2.output, "==", "kurtosis")
   result3 = plan.run_sh(run="cat /task/src/tech.txt", files={"/task": file_artifacts[1]})
-  plan.assert(result3.output, "==", "kurtosis\n")
+  plan.assert(result3.output, "==", "kurtosis")
 `
 )
 

--- a/internal_testsuites/golang/testsuite/startosis_run_sh_task_test/run_task_sh_task_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_run_sh_task_test/run_task_sh_task_test.go
@@ -19,9 +19,9 @@ def run(plan):
 def run(plan):
   result = plan.run_sh(run="mkdir -p src && echo kurtosis > /src/tech.txt", store=["/src/tech.txt", "/src"])
   file_artifacts = result.files_artifacts
-  result2 = plan.run_sh(run="cat /src/temp/tech.txt", files={"temp": file_artifacts[0]}, workdir="/src")
+  result2 = plan.run_sh(run="cat /temp/tech.txt", files={"/temp": file_artifacts[0]})
   plan.assert(result2.output, "==", "kurtosis\n")
-  result3 = plan.run_sh(run="cat ./src/tech.txt", files={"/task": file_artifacts[1]}, workdir="/task")
+  result3 = plan.run_sh(run="cat /task/src/tech.txt", files={"/task": file_artifacts[1]})
   plan.assert(result3.output, "==", "kurtosis\n")
 `
 )

--- a/internal_testsuites/golang/testsuite/startosis_run_sh_task_test/run_task_sh_task_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_run_sh_task_test/run_task_sh_task_test.go
@@ -12,17 +12,17 @@ const (
 	runshStarlarkSimple = `
 def run(plan):
   result1 = plan.run_sh(run="echo kurtosis")
-  result2 = plan.run_sh(run="mkdir -p {0} && cd {0} && echo $(pwd)".format(result1.output), workdir="src")
-  plan.assert(result2.output, "==", "/src/kurtosis\n")
+  result2 = plan.run_sh(run="mkdir -p {0} && cd {0} && echo $(pwd)".format(result1.output))
+  plan.assert(result2.output, "==", "/src/kurtosis")
 `
 	runshStarlarkFileArtifact = `
 def run(plan):
   result = plan.run_sh(run="mkdir -p src && echo kurtosis > /src/tech.txt", store=["/src/tech.txt", "/src"])
   file_artifacts = result.files_artifacts
   result2 = plan.run_sh(run="cat /temp/tech.txt", files={"/temp": file_artifacts[0]})
-  plan.assert(result2.output, "==", "kurtosis")
-  result3 = plan.run_sh(run="cat /task/src/tech.txt", files={"/task": file_artifacts[1]})
-  plan.assert(result3.output, "==", "kurtosis")
+  plan.assert(result2.output, "==", "kurtosis\n")
+  result3 = plan.run_sh(run="cat /src/tech.txt", files={"/task": file_artifacts[1]})
+  plan.assert(result3.output, "==", "kurtosis\n")
 `
 )
 

--- a/internal_testsuites/golang/testsuite/startosis_run_sh_task_test/run_task_sh_task_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_run_sh_task_test/run_task_sh_task_test.go
@@ -21,8 +21,9 @@ def run(plan):
   file_artifacts = result.files_artifacts
   result2 = plan.run_sh(run="cat /src/temp/tech.txt", files={"temp": file_artifacts[0]}, workdir="/src")
   plan.assert(result2.output, "==", "kurtosis\n")
-  result3 = plan.run_sh(run="cat ./src/tech.txt", files={"/": file_artifacts[1]}, workdir="/task")
-  plan.assert(result3.output, "==", "kurtosis\n")`
+  result3 = plan.run_sh(run="cat ./src/tech.txt", files={"/task": file_artifacts[1]}, workdir="/task")
+  plan.assert(result3.output, "==", "kurtosis\n")
+`
 )
 
 func TestStarlark_RunshTaskSimple(t *testing.T) {

--- a/internal_testsuites/golang/testsuite/startosis_run_sh_task_test/run_task_sh_task_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_run_sh_task_test/run_task_sh_task_test.go
@@ -17,7 +17,7 @@ def run(plan):
 `
 	runshStarlarkFileArtifact = `
 def run(plan):
-  result = plan.run_sh(run="mkdir -p src && echo kurtosis > /src/tech.txt", store=["/src/tech.txt", "/src"])
+  result = plan.run_sh(run="mkdir -p /src && echo kurtosis > /src/tech.txt", store=["/src/tech.txt", "/src"], image="ethpandaops/ethereum-genesis-generator:1.0.14")
   file_artifacts = result.files_artifacts
   result2 = plan.run_sh(run="cat /temp/tech.txt", files={"/temp": file_artifacts[0]})
   plan.assert(result2.output, "==", "kurtosis\n")

--- a/internal_testsuites/golang/testsuite/startosis_run_sh_task_test/run_task_sh_task_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_run_sh_task_test/run_task_sh_task_test.go
@@ -12,8 +12,8 @@ const (
 	runshStarlarkSimple = `
 def run(plan):
   result1 = plan.run_sh(run="echo kurtosis")
-  result2 = plan.run_sh(run="mkdir -p {0} && cd {0} && echo $(pwd)".format(result1.output))
-  plan.assert(result2.output, "==", "/src/kurtosis")
+  result2 = plan.run_sh(run="mkdir -p /src/{0} && cd /src/{0} && echo $(pwd)".format(result1.output))
+  plan.assert(result2.output, "==", "/src/kurtosis\n")
 `
 	runshStarlarkFileArtifact = `
 def run(plan):
@@ -21,7 +21,7 @@ def run(plan):
   file_artifacts = result.files_artifacts
   result2 = plan.run_sh(run="cat /temp/tech.txt", files={"/temp": file_artifacts[0]})
   plan.assert(result2.output, "==", "kurtosis\n")
-  result3 = plan.run_sh(run="cat /src/tech.txt", files={"/task": file_artifacts[1]})
+  result3 = plan.run_sh(run="cat /task/src/tech.txt", files={"/task": file_artifacts[1]})
   plan.assert(result3.output, "==", "kurtosis\n")
 `
 )

--- a/internal_testsuites/golang/testsuite/startosis_run_sh_task_test/run_task_sh_task_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_run_sh_task_test/run_task_sh_task_test.go
@@ -24,6 +24,12 @@ def run(plan):
   result3 = plan.run_sh(run="cat /task/src/tech.txt", files={"/task": file_artifacts[1]})
   plan.assert(result3.output, "==", "kurtosis\n")
 `
+
+	runshStarlarkFileArtifactFailure = `
+def run(plan):
+  result = plan.run_sh(run="cat /tmp/kurtosis.txt")
+  plan.assert(value=result.code, assertion="==", target_value="0")
+`
 )
 
 func TestStarlark_RunshTaskSimple(t *testing.T) {
@@ -38,4 +44,12 @@ func TestStarlark_RunshTaskFileArtifact(t *testing.T) {
 	runResult, _ := test_helpers.SetupSimpleEnclaveAndRunScript(t, ctx, runshTest, runshStarlarkFileArtifact)
 	expectedOutput := "Command returned with exit code '0' with no output\nCommand returned with exit code '0' and the following output:\n--------------------\nkurtosis\n\n--------------------\nAssertion succeeded. Value is '\"kurtosis\\n\"'.\nCommand returned with exit code '0' and the following output:\n--------------------\nkurtosis\n\n--------------------\nAssertion succeeded. Value is '\"kurtosis\\n\"'.\n"
 	require.Equal(t, expectedOutput, string(runResult.RunOutput))
+}
+
+func TestStarlark_RunshTaskFileArtifactFailure(t *testing.T) {
+	ctx := context.Background()
+	runResult, _ := test_helpers.SetupSimpleEnclaveAndRunScript(t, ctx, runshTest, runshStarlarkFileArtifactFailure)
+	expectedErrorMessage := "error occurred and shell command: \"cat /tmp/kurtosis.txt\" exited with code 1 with output \"cat: can't open '/tmp/kurtosis.txt': No such file or directory\\n"
+	require.NotNil(t, runResult.ExecutionError)
+	require.Contains(t, runResult.ExecutionError.GetErrorMessage(), expectedErrorMessage)
 }


### PR DESCRIPTION
I have removed the `workdir` from run_sh task to keep it simple. The shell command will either run from root directory or workdir set in the image now. This also means that file artifacts will be accessed using absolute paths, not relative paths.

Previously, `result = plan.run_sh(...)` would return `result.file_aritifacts` but now I fixed the typo for consistency and it returns `result.files_artifacts` and this can be used to access the files artifacts from the task.