### PR TITLE
feat: make the docker network attachable

### DIFF
--- a/container-engine-lib/lib/backend_impls/docker/docker_manager/docker_manager.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_manager/docker_manager.go
@@ -113,7 +113,6 @@ const (
 
 	emptyNetworkAlias = ""
 
-	// setting this to true to enable "satrian" on Discord to do his workflow
 	isDockerNetworkAttachable = true
 )
 

--- a/container-engine-lib/lib/backend_impls/docker/docker_manager/docker_manager.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_manager/docker_manager.go
@@ -112,6 +112,9 @@ const (
 	successfulExitCode = 0
 
 	emptyNetworkAlias = ""
+
+	// setting this to true to enable "satrian" on Discord to do his workflow
+	isDockerNetworkAttachable = true
 )
 
 /*
@@ -181,7 +184,7 @@ func (manager *DockerManager) CreateNetwork(context context.Context, name string
 			Config:  ipamConfig,
 		},
 		Internal:   false,
-		Attachable: false,
+		Attachable: isDockerNetworkAttachable,
 		Ingress:    false,
 		ConfigOnly: false,
 		ConfigFrom: nil,


### PR DESCRIPTION
## Description:
Sets the docker network to be attachable to allow users to attach local services to the services inside the enclave

## Is this change user facing?
YES

## References (if applicable):
https://discord.com/channels/783719264308953108/783719264308953111/1123504466340098078
