### PR TITLE
chore: fix the flaky 'TestStartosis_AddServicesWithReadyConditionsCheckFail' test

### DIFF
--- a/internal_testsuites/golang/testsuite/startosis_add_service_test/startosis_add_services_with_ready_conditions_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_add_service_test/startosis_add_services_with_ready_conditions_test.go
@@ -10,7 +10,7 @@ const (
 	addServicesWithReadyConditionsScript = `
 HTTP_ECHO_IMAGE = "mendhak/http-https-echo:26"
 SERVICE_NAME_PREFIX = "service-%v"
-NUM_SERVICES = 4
+NUM_SERVICES = 2
 
 def run(plan):
     plan.print("Adding {0} services to enclave".format(NUM_SERVICES))
@@ -26,7 +26,7 @@ def run(plan):
         assertion="==",
         target_value=%v,
         interval="1s",
-        timeout="5s"
+        timeout="10s"
     )
 
     config = ServiceConfig(

--- a/internal_testsuites/golang/testsuite/startosis_add_service_test/startosis_add_services_with_ready_conditions_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_add_service_test/startosis_add_services_with_ready_conditions_test.go
@@ -26,7 +26,7 @@ def run(plan):
         assertion="==",
         target_value=%v,
         interval="1s",
-        timeout="3s"
+        timeout="5s"
     )
 
     config = ServiceConfig(


### PR DESCRIPTION
## Description:
fix the flaky 'TestStartosis_AddServicesWithReadyConditionsCheckFail' test by increasing the `ReadyCondition.timeout`

## Is this change user-facing?
NO

## References (if applicable):
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
