### PR TITLE
chore: pass the name of the package instead of the path when using a local package

### DIFF
--- a/api/golang/core/lib/enclaves/enclave_context.go
+++ b/api/golang/core/lib/enclaves/enclave_context.go
@@ -449,7 +449,7 @@ func (enclaveCtx *EnclaveContext) assembleRunStartosisPackageArg(
 ) (*kurtosis_core_rpc_api_bindings.RunStarlarkPackageArgs, error) {
 	kurtosisYamlFilepath := path.Join(packageRootPath, kurtosisYamlFilename)
 
-	kurtosisYaml, err := parseKurtosisYaml(kurtosisYamlFilepath)
+	kurtosisYaml, err := ParseKurtosisYaml(kurtosisYamlFilepath)
 	if err != nil {
 		return nil, stacktrace.Propagate(err, "There was an error parsing the '%v' at '%v'", kurtosisYamlFilename, packageRootPath)
 	}

--- a/api/golang/core/lib/enclaves/kurtosis_yaml.go
+++ b/api/golang/core/lib/enclaves/kurtosis_yaml.go
@@ -16,7 +16,7 @@ type KurtosisYaml struct {
 	PackageName string `yaml:"name"`
 }
 
-func parseKurtosisYaml(kurtosisYamlFilepath string) (*KurtosisYaml, error) {
+func ParseKurtosisYaml(kurtosisYamlFilepath string) (*KurtosisYaml, error) {
 	kurtosisYamlContents, err := ioutil.ReadFile(kurtosisYamlFilepath)
 	if err != nil {
 		if os.IsNotExist(err) {


### PR DESCRIPTION
## Description:
We would send `.` or `./` or others while we could send hashed `packageNames`. We're doing that now

## Is this change user facing?
NO