### PR TITLE
feat: auto assign docs issue to karla

### DIFF
--- a/.github/ISSUE_TEMPLATE/docs-issue.yml
+++ b/.github/ISSUE_TEMPLATE/docs-issue.yml
@@ -3,6 +3,7 @@ description: Report an issue in our documentation
 labels: ["docs"]
 assignees:
   - leeederek
+  - thylocine33
 body:
   - type: input
     id: url-link


### PR DESCRIPTION
## Description:
This PR changes the github workflow rules to auto-assign any docs related issues to Karla 

## Is this change user facing?
NO
<!-- If yes, please add the "user facing" label to the PR -->
<!-- If yes, don't forget to include docs changes where relevant -->

## References (if applicable):
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
