### PR TITLE
refactor: Making StopEngines equivalent to DestroyEngines in Kurtosis backend

### DIFF
--- a/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/engine_functions/destroy_engines.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/engine_functions/destroy_engines.go
@@ -3,9 +3,7 @@ package engine_functions
 import (
 	"context"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_impls/docker/docker_manager"
-	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_impls/docker/docker_operation_parallelizer"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/engine"
-	"github.com/kurtosis-tech/stacktrace"
 )
 
 func DestroyEngines(
@@ -18,48 +16,5 @@ func DestroyEngines(
 	resultErr error,
 ) {
 
-	matchingEnginesByContainerId, err := getMatchingEngines(ctx, filters, dockerManager)
-	if err != nil {
-		return nil, nil, stacktrace.Propagate(err, "An error occurred getting engines matching the following filters: %+v", filters)
-	}
-
-	var removeEngineOperation docker_operation_parallelizer.DockerOperation = func(
-		ctx context.Context,
-		dockerManager *docker_manager.DockerManager,
-		dockerObjectId string,
-	) error {
-		engineContainerId := dockerObjectId
-		if err := dockerManager.RemoveContainer(ctx, engineContainerId); err != nil {
-			return stacktrace.Propagate(err, "An error occurred removing engine container with ID '%v'", engineContainerId)
-		}
-
-		return nil
-	}
-
-	successfulEngineGuidStrs, erroredEngineGuidStrs, err := docker_operation_parallelizer.RunDockerOperationInParallelForKurtosisObjects(
-		ctx,
-		matchingEnginesByContainerId,
-		dockerManager,
-		extractEngineGuidFromEngine,
-		removeEngineOperation,
-	)
-	if err != nil {
-		return nil, nil, stacktrace.Propagate(err, "An error occurred removing engine containers matching filters '%+v'", filters)
-	}
-
-	successfulGuids := map[engine.EngineGUID]bool{}
-	for guidStr := range successfulEngineGuidStrs {
-		successfulGuids[engine.EngineGUID(guidStr)] = true
-	}
-
-	erroredGuids := map[engine.EngineGUID]error{}
-	for guidStr, err := range erroredEngineGuidStrs {
-		erroredGuids[engine.EngineGUID(guidStr)] = stacktrace.Propagate(
-			err,
-			"An error occurred destroying engine '%v'",
-			guidStr,
-		)
-	}
-
-	return successfulGuids, erroredGuids, nil
+	return destroyEngines(ctx, filters, dockerManager)
 }

--- a/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/engine_functions/shared_helpers.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/engine_functions/shared_helpers.go
@@ -7,6 +7,7 @@ import (
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/shared_helpers"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_impls/docker/docker_manager"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_impls/docker/docker_manager/types"
+	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_impls/docker/docker_operation_parallelizer"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_impls/docker/object_attributes_provider/docker_port_spec_serializer"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_impls/docker/object_attributes_provider/label_key_consts"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_impls/docker/object_attributes_provider/label_value_consts"
@@ -225,4 +226,60 @@ func deserialize_pre_2022_03_02_PortSpecs(specsStr string) (map[string]*port_spe
 
 func extractEngineGuidFromEngine(engine *engine.Engine) string {
 	return string(engine.GetGUID())
+}
+
+func destroyEngines(
+	ctx context.Context,
+	filters *engine.EngineFilters,
+	dockerManager *docker_manager.DockerManager,
+) (
+	resultSuccessfulEngineGuids map[engine.EngineGUID]bool,
+	resultErroredEngineGuids map[engine.EngineGUID]error,
+	resultErr error,
+) {
+
+	matchingEnginesByContainerId, err := getMatchingEngines(ctx, filters, dockerManager)
+	if err != nil {
+		return nil, nil, stacktrace.Propagate(err, "An error occurred getting engines matching the following filters: %+v", filters)
+	}
+
+	var removeEngineOperation docker_operation_parallelizer.DockerOperation = func(
+		ctx context.Context,
+		dockerManager *docker_manager.DockerManager,
+		dockerObjectId string,
+	) error {
+		engineContainerId := dockerObjectId
+		if err := dockerManager.RemoveContainer(ctx, engineContainerId); err != nil {
+			return stacktrace.Propagate(err, "An error occurred removing engine container with ID '%v'", engineContainerId)
+		}
+
+		return nil
+	}
+
+	successfulEngineGuidStrs, erroredEngineGuidStrs, err := docker_operation_parallelizer.RunDockerOperationInParallelForKurtosisObjects(
+		ctx,
+		matchingEnginesByContainerId,
+		dockerManager,
+		extractEngineGuidFromEngine,
+		removeEngineOperation,
+	)
+	if err != nil {
+		return nil, nil, stacktrace.Propagate(err, "An error occurred removing engine containers matching filters '%+v'", filters)
+	}
+
+	successfulGuids := map[engine.EngineGUID]bool{}
+	for guidStr := range successfulEngineGuidStrs {
+		successfulGuids[engine.EngineGUID(guidStr)] = true
+	}
+
+	erroredGuids := map[engine.EngineGUID]error{}
+	for guidStr, err := range erroredEngineGuidStrs {
+		erroredGuids[engine.EngineGUID(guidStr)] = stacktrace.Propagate(
+			err,
+			"An error occurred destroying engine '%v'",
+			guidStr,
+		)
+	}
+
+	return successfulGuids, erroredGuids, nil
 }

--- a/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/engine_functions/destroy_engines.go
+++ b/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/engine_functions/destroy_engines.go
@@ -7,7 +7,7 @@ import (
 	"github.com/kurtosis-tech/stacktrace"
 )
 
-func DestroyEngines(
+func destroyEngines(
 	ctx context.Context,
 	filters *engine.EngineFilters,
 	kubernetesManager *kubernetes_manager.KubernetesManager,

--- a/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/engine_functions/shared_helpers.go
+++ b/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/engine_functions/shared_helpers.go
@@ -312,3 +312,16 @@ func getEngineMatchLabels() map[string]string {
 	}
 	return engineMatchLabels
 }
+
+func DestroyEngines(
+	ctx context.Context,
+	filters *engine.EngineFilters,
+	kubernetesManager *kubernetes_manager.KubernetesManager,
+) (
+	resultSuccessfulEngineGuids map[engine.EngineGUID]bool,
+	resultErroredEngineGuids map[engine.EngineGUID]error,
+	resultErr error,
+) {
+
+	return destroyEngines(ctx, filters, kubernetesManager)
+}

--- a/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/engine_functions/stop_engines.go
+++ b/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/engine_functions/stop_engines.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_manager"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/engine"
-	"github.com/kurtosis-tech/stacktrace"
-	applyconfigurationsv1 "k8s.io/client-go/applyconfigurations/core/v1"
 )
 
 func StopEngines(
@@ -17,56 +15,5 @@ func StopEngines(
 	resultErroredEngineGuids map[engine.EngineGUID]error,
 	resultErr error,
 ) {
-	_, matchingKubernetesResources, err := getMatchingEngineObjectsAndKubernetesResources(ctx, filters, kubernetesManager)
-	if err != nil {
-		return nil, nil, stacktrace.Propagate(err, "An error occurred getting engines and Kubernetes resources matching filters '%+v'", filters)
-	}
-
-	successfulEngineGuids := map[engine.EngineGUID]bool{}
-	erroredEngineGuids := map[engine.EngineGUID]error{}
-	for engineGuid, resources := range matchingKubernetesResources {
-		if resources.namespace == nil {
-			// No namespace means nothing needs stopping
-			successfulEngineGuids[engineGuid] = true
-			continue
-		}
-		namespaceName := resources.namespace.Name
-
-		if resources.pod != nil {
-			podName := resources.pod.Name
-			if err := kubernetesManager.RemovePod(ctx, resources.pod); err != nil {
-				erroredEngineGuids[engineGuid] = stacktrace.Propagate(
-					err,
-					"An error occurred removing pod '%v' in namespace '%v' for engine '%v'",
-					podName,
-					namespaceName,
-					engineGuid,
-				)
-				continue
-			}
-		}
-
-		kubernetesService := resources.service
-		if kubernetesService != nil {
-			serviceName := kubernetesService.Name
-			updateConfigurator := func(updatesToApply *applyconfigurationsv1.ServiceApplyConfiguration) {
-				specUpdates := applyconfigurationsv1.ServiceSpec().WithSelector(nil)
-				updatesToApply.WithSpec(specUpdates)
-			}
-			if _, err := kubernetesManager.UpdateService(ctx, namespaceName, serviceName, updateConfigurator); err != nil {
-				erroredEngineGuids[engineGuid] = stacktrace.Propagate(
-					err,
-					"An error occurred removing selectors from service '%v' in namespace '%v' for engine '%v'",
-					kubernetesService.Name,
-					namespaceName,
-					engineGuid,
-				)
-				continue
-			}
-		}
-
-		successfulEngineGuids[engineGuid] = true
-	}
-
-	return successfulEngineGuids, erroredEngineGuids, nil
+	return destroyEngines(ctx, filters, kubernetesManager)
 }

--- a/container-engine-lib/lib/backend_interface/kurtosis_backend.go
+++ b/container-engine-lib/lib/backend_interface/kurtosis_backend.go
@@ -42,6 +42,10 @@ type KurtosisBackend interface {
 	// Gets engines using the given filters, returning a map of matched engines identified by their engine GUID
 	GetEngines(ctx context.Context, filters *engine.EngineFilters) (map[engine.EngineGUID]*engine.Engine, error)
 
+	// TODO remove this endpoint because now it's equivalent to DestroyEngines
+	// TODO this method left some backend resources (like the engine's container for the Docker version) in the previous version
+	// TODO for debugging purposes (get the engine logs after the engine was stopped) but this feat wasn't used
+	// TODO and it's not relevant, so was it better to remove it and remove the resources
 	// Stops the engines matching the given filters
 	StopEngines(
 		ctx context.Context,


### PR DESCRIPTION
## Description:
Making StopEngines equivalent to DestroyEngines on the Kurtosis backend in order to remove the engine's namespace and service when the engine was stopped (for the K8s version) and the engine's container (for the Docker version).

The Kurtosis backend was prepared for managing several engines at the same time, but since we decided to have a single engine instance we can remove this legacy code that was prepared for several engines.

We had left the service and the namespace to infer which engines are stopped and which engines are running, but it doesn't make any sense since we decided to have a single Kurtosis engine. And we had left the engine's container stopped in the Docker version for getting the logs after the engine was stopped, but this feature is really not used and we can do without this.

## Is this change user-facing?
NO

## References (if applicable):
[Single engine ticket](https://github.com/kurtosis-tech/kurtosis-private/issues/4)
