### PR TITLE
docs: Add highlevel explanation of idempotent runs to "Concepts" section to increase discoverability

### DIFF
--- a/docs/docs/concepts-reference/idempotent-runs.md
+++ b/docs/docs/concepts-reference/idempotent-runs.md
@@ -3,7 +3,7 @@ title: Idempotent Runs
 sidebar_label: Idempotent Runs
 ---
 
-Idempotent runs refers to Kurtosis' ability to make calls of [`kurtosis run`](../cli-reference/run.md) against an [enclave][enclaves] idempotent, meaning that the [plan](./plan.md) being submitted via `kurtosis run` is a declarative state of how the enclave should look and Kurtosis makes it so regardless of the current state of the enclave. In plain English, this means that Kurtosis will diff the plan being submitted via `kurtosis run` against what already exists in the enclave, and make only the changes necessary to get to the desired state.
+Idempotent runs refers to Kurtosis' ability to make calls of [`kurtosis run`](../cli-reference/run-starlark.md) against an [enclave][enclaves] idempotent, meaning that the [plan](./plan.md) being submitted via `kurtosis run` is a declarative state of how the enclave should look and Kurtosis makes it so regardless of the current state of the enclave. In plain English, this means that Kurtosis will diff the plan being submitted via `kurtosis run` against what already exists in the enclave, and make only the changes necessary to get to the desired state.
 
 This has several uses:
 

--- a/docs/docs/concepts-reference/idempotent-runs.md
+++ b/docs/docs/concepts-reference/idempotent-runs.md
@@ -1,0 +1,17 @@
+---
+title: Idempotent Runs
+sidebar_label: Idempotent Runs
+---
+
+Idempotent runs refers to Kurtosis' ability to make calls of [`kurtosis run`](../cli-reference/run.md) against an [enclave][enclaves] idempotent, meaning that the [plan](./plan.md) being submitted via `kurtosis run` is a declarative state of how the enclave should look and Kurtosis makes it so regardless of the current state of the enclave. In plain English, this means that Kurtosis will diff the plan being submitted via `kurtosis run` against what already exists in the enclave, and make only the changes necessary to get to the desired state.
+
+This has several uses:
+
+- **Speed:** when you're running a large [Starlark](./starlark.md) script or package and a step near the end has a bug, you don't want to start over from scratch with a fresh enclave and redo all the previous steps. Idempotent runs allows you to simply fix your bug and resubmit, and Kurtosis will skip all the steps that have already been run. 
+- **Eternal environments:** eternal environments like shared Dev or Staging are instantiated at their start (Day 0), and then receive a constant updates into the future (Days 1+). In order for these environments to live in Kurtosis, Kurtosis needs to be able to handle Days 1+. Idempotent runs allow this, as you to simply update your Starlark script and Kurtosis updates the environment in the enclave to match.
+- **GitOps:** the best DevOps companies in the world use Git to manage changes to environments: each commit updates the environment. This requires idempotency (what happens if the deploy fails for a transient reason? what happens if you need to revert a commit?). Kurtosis' idempotent runs pave the way for a native GitOps experience inside of Kurtosis itself, where the environment infrastructure-as-code is the Starlark itself.
+
+To read in much more detail about how idempotent runs work, see [here](../explanations/how-do-idempotent-runs-work.md).
+
+<!-------------------------- ONLY LINKS BELOW HERE -------------------------------------->
+[enclaves]: ./enclaves.md

--- a/docs/docs/concepts-reference/idempotent-runs.md
+++ b/docs/docs/concepts-reference/idempotent-runs.md
@@ -11,6 +11,8 @@ This has several uses:
 - **Eternal environments:** eternal environments like shared Dev or Staging are instantiated at their start (Day 0), and then receive a constant updates into the future (Days 1+). In order for these environments to live in Kurtosis, Kurtosis needs to be able to handle Days 1+. Idempotent runs allow this, as you to simply update your Starlark script and Kurtosis updates the environment in the enclave to match.
 - **GitOps:** the best DevOps companies in the world use Git to manage changes to environments: each commit updates the environment. This requires idempotency (what happens if the deploy fails for a transient reason? what happens if you need to revert a commit?). Kurtosis' idempotent runs pave the way for a native GitOps experience inside of Kurtosis itself, where the environment infrastructure-as-code is the Starlark itself.
 
+Kurtosis is able to do this because of its [multi-phase approach to running Starlark](./multi-phase-runs.md). Kurtosis constructs an abstract representation of the system you want before running anything (much like Terraform), so Kurtosis can compare the current state of the enclave to the desired state of the enclave and skip any unnecessary changes.
+
 To read in much more detail about how idempotent runs work, see [here](../explanations/how-do-idempotent-runs-work.md).
 
 <!-------------------------- ONLY LINKS BELOW HERE -------------------------------------->

--- a/docs/docs/explanations/how-do-idempotent-runs-work.md
+++ b/docs/docs/explanations/how-do-idempotent-runs-work.md
@@ -6,6 +6,10 @@ sidebar_label: Idempotent Runs
 Background
 ----------
 
+:::tip
+To learn about what idempotent runs are in Kurtosis and the motivation behind this feature, go [here][idempotent-run-concept-reference].
+:::
+
 When running the `kurtosis run` command, you may notice the following message get printed:
 ```console
 SKIPPED - This instruction has already been run in this enclave
@@ -73,3 +77,8 @@ behaviour of considering the _submitted plan_ as a sequence of new instructions.
 Note that in this case, it is possible (and even likely) the execution of the submitted plan will fail. For example, if 
 instruction 1 is an `add_service` instruction, it will fail because the service being added already exist inside the 
 enclave. 
+
+
+
+<!---------------------------------- REFERENCE LINKS ---------------------------------------------------------->
+[idempotent-run-concept-reference]: ../concepts-reference/idempotent-runs.md

--- a/docs/docs/explanations/how-do-idempotent-runs-work.md
+++ b/docs/docs/explanations/how-do-idempotent-runs-work.md
@@ -1,6 +1,6 @@
 ---
-title: Idempotent runs
-sidebar_label: Idempotent runs
+title: How do idempotent runs work?
+sidebar_label: Idempotent Runs
 ---
 
 Background

--- a/docs/docs/home.md
+++ b/docs/docs/home.md
@@ -35,7 +35,7 @@ In Kurtosis, test environments have these properties:
 - Enable debugging and investigation of problems live, as they're happening in your test environment
 - Manage file dependencies to ensure complete portability of test environments across different test runs and backends
 
-#### Try out Kurtosis now
+## Try out Kurtosis now
 
 Try Kurtosis now with our [quickstart](./quickstart.md).
 


### PR DESCRIPTION
## Description:
Retitles the current "idempotent runs" docs to be more explicit about what it is (a deep explanation of how idempotent runs work), and added a higher-level page to the "Concepts" section

## Is this change user facing?
YES
