### PR TITLE
docs: Rename run-starlark.md -> run.md

### DIFF
--- a/docs/docs/cli-reference/run.md
+++ b/docs/docs/cli-reference/run.md
@@ -1,7 +1,7 @@
 ---
 title: run
 sidebar_label: run
-slug: /run-starlark
+slug: /run
 ---
 
 Kurtosis can be used to run a Starlark script or a [runnable package](../concepts-reference/packages.md) in an enclave. 

--- a/docs/docs/concepts-reference/idempotent-runs.md
+++ b/docs/docs/concepts-reference/idempotent-runs.md
@@ -3,7 +3,7 @@ title: Idempotent Runs
 sidebar_label: Idempotent Runs
 ---
 
-Idempotent runs refers to Kurtosis' ability to make calls of [`kurtosis run`](../cli-reference/run-starlark.md) against an [enclave][enclaves] idempotent, meaning that the [plan](./plan.md) being submitted via `kurtosis run` is a declarative state of how the enclave should look and Kurtosis makes it so regardless of the current state of the enclave. In plain English, this means that Kurtosis will diff the plan being submitted via `kurtosis run` against what already exists in the enclave, and make only the changes necessary to get to the desired state.
+Idempotent runs refers to Kurtosis' ability to make calls of [`kurtosis run`](../cli-reference/run.md) against an [enclave][enclaves] idempotent, meaning that the [plan](./plan.md) being submitted via `kurtosis run` is a declarative state of how the enclave should look and Kurtosis makes it so regardless of the current state of the enclave. In plain English, this means that Kurtosis will diff the plan being submitted via `kurtosis run` against what already exists in the enclave, and make only the changes necessary to get to the desired state.
 
 This has several uses:
 

--- a/docs/docs/concepts-reference/idempotent-runs.md
+++ b/docs/docs/concepts-reference/idempotent-runs.md
@@ -3,7 +3,7 @@ title: Idempotent Runs
 sidebar_label: Idempotent Runs
 ---
 
-Idempotent runs refers to Kurtosis' ability to make calls of [`kurtosis run`](../cli-reference/run.md) against an [enclave][enclaves] idempotent, meaning that the [plan](./plan.md) being submitted via `kurtosis run` is a declarative state of how the enclave should look and Kurtosis makes it so regardless of the current state of the enclave. In plain English, this means that Kurtosis will diff the plan being submitted via `kurtosis run` against what already exists in the enclave, and make only the changes necessary to get to the desired state.
+Idempotent runs refers to Kurtosis' ability to make calls of [`kurtosis run`](../cli-reference/run-starlark.md) against an [enclave][enclaves] idempotent, meaning that the [plan](./plan.md) being submitted via `kurtosis run` is a declarative state of how the enclave should look and Kurtosis makes it so regardless of the current state of the enclave. In plain English, this means that Kurtosis will diff the plan being submitted via `kurtosis run` against what already exists in the enclave, and make only the changes necessary to get to the desired state.
 
 This has several uses:
 

--- a/docs/docs/concepts-reference/idempotent-runs.md
+++ b/docs/docs/concepts-reference/idempotent-runs.md
@@ -1,0 +1,17 @@
+---
+title: Idempotent Runs
+sidebar_label: Idempotent Runs
+---
+
+Idempotent runs refers to Kurtosis' ability to make calls of [`kurtosis run`](../cli-reference/run.md) against an [enclave][enclaves] idempotent, meaning that the [plan](./plan.md) being submitted via `kurtosis run` is a declarative state of how the enclave should look and Kurtosis makes it so regardless of the current state of the enclave. In plain English, this means that Kurtosis will diff the plan being submitted via `kurtosis run` against what already exists in the enclave, and make only the changes necessary to get to the desired state.
+
+This has several uses:
+
+- **Speed:** when you're running a large [Starlark](./starlark.md) script or package and a step near the end has a bug, you don't want to start over from scratch with a fresh enclave and redo all the previous steps. Idempotent runs allows you to simply fix your bug and resubmit, and Kurtosis will skip all the steps that have already been run. 
+- **Eternal environments:** eternal environments like shared Dev or Staging are instantiated at their start (Day 0), and then receive a constant updates into the future (Days 1+). In order for these environments to live in Kurtosis, Kurtosis needs to be able to handle Days 1+. Idempotent runs allow this, as you to simply update your Starlark script and Kurtosis updates the environment in the enclave to match.
+- **GitOps:** the best DevOps companies in the world use Git to manage changes to environments: each commit updates the environment. This requires idempotency (what happens if the deploy fails for a transient reason? what happens if you need to revert a commit?). Kurtosis' idempotent runs pave the way for a native GitOps experience inside of Kurtosis itself, where the environment infrastructure-as-code is the Starlark itself.
+
+To read in much more detail about how idempotent runs work, see [here](../explanations/how-do-idempotent-runs-work.md).
+
+<!-------------------------- ONLY LINKS BELOW HERE -------------------------------------->
+[enclaves]: ./enclaves.md

--- a/docs/docs/concepts-reference/idempotent-runs.md
+++ b/docs/docs/concepts-reference/idempotent-runs.md
@@ -11,6 +11,8 @@ This has several uses:
 - **Eternal environments:** eternal environments like shared Dev or Staging are instantiated at their start (Day 0), and then receive a constant updates into the future (Days 1+). In order for these environments to live in Kurtosis, Kurtosis needs to be able to handle Days 1+. Idempotent runs allow this, as you to simply update your Starlark script and Kurtosis updates the environment in the enclave to match.
 - **GitOps:** the best DevOps companies in the world use Git to manage changes to environments: each commit updates the environment. This requires idempotency (what happens if the deploy fails for a transient reason? what happens if you need to revert a commit?). Kurtosis' idempotent runs pave the way for a native GitOps experience inside of Kurtosis itself, where the environment infrastructure-as-code is the Starlark itself.
 
+Kurtosis is able to do this because of its [multi-phase approach to running Starlark](./multi-phase-runs.md). Kurtosis constructs an abstract representation of the system you want before running anything (much like Terraform), so Kurtosis can compare the current state of the enclave to the desired state of the enclave and skip any unnecessary changes.
+
 To read in much more detail about how idempotent runs work, see [here](../explanations/how-do-idempotent-runs-work.md).
 
 <!-------------------------- ONLY LINKS BELOW HERE -------------------------------------->

--- a/docs/docs/explanations/how-do-idempotent-runs-work.md
+++ b/docs/docs/explanations/how-do-idempotent-runs-work.md
@@ -1,6 +1,6 @@
 ---
-title: Idempotent runs
-sidebar_label: Idempotent runs
+title: How do idempotent runs work?
+sidebar_label: Idempotent Runs
 ---
 
 Background

--- a/docs/docs/home.md
+++ b/docs/docs/home.md
@@ -35,7 +35,7 @@ In Kurtosis, test environments have these properties:
 - Enable debugging and investigation of problems live, as they're happening in your test environment
 - Manage file dependencies to ensure complete portability of test environments across different test runs and backends
 
-#### Try out Kurtosis now
+## Try out Kurtosis now
 
 Try Kurtosis now with our [quickstart](./quickstart.md).
 

--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -928,7 +928,7 @@ Thank you for trying our quickstart. We hope you enjoyed it.
 <!--------------------------- Reference ------------------------------------>
 <!-- CLI Commands Reference -->
 [cli-reference]: /cli
-[kurtosis-run-reference]: ./cli-reference/run-starlark.md
+[kurtosis-run-reference]: ./cli-reference/run.md
 [kurtosis-clean-reference]: ./cli-reference/clean.md
 [kurtosis-enclave-inspect-reference]: ./cli-reference/enclave-inspect.md
 [kurtosis-files-upload-reference]: ./cli-reference/files-upload.md

--- a/docs/docs/starlark-reference/plan.md
+++ b/docs/docs/starlark-reference/plan.md
@@ -685,7 +685,7 @@ plan.print(recipe_result["code"])
 [stop-service]: #stop_service
 [wait]: #wait
 
-[cli-run-reference]: ../cli-reference/run-starlark.md
+[cli-run-reference]: ../cli-reference/run.md
 
 [files-artifacts-reference]: ../concepts-reference/files-artifacts.md
 [future-references-reference]: ../concepts-reference/future-references.md


### PR DESCRIPTION
MERGE #844 FIRST 

## Description:
The command is called `run` but the file is called `run-starlark.md` (inconsistent with all the other commands). Drives me nuts, so I'm fixing it.

## Is this change user facing?
NO