### PR TITLE
refactor: Implemented GetPodsAndServicesByLabels in KuberneteManager

### DIFF
--- a/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/kubernetes_kurtosis_backend_enclave_functions.go
+++ b/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/kubernetes_kurtosis_backend_enclave_functions.go
@@ -540,28 +540,20 @@ func (backend *KubernetesKurtosisBackend) createGetEnclaveResourcesOperation(
 			label_key_consts.EnclaveUUIDKubernetesLabelKey.GetString(): enclaveIdStr,
 		}
 
-		// Pods
-		podsList, err := backend.kubernetesManager.GetPodsByLabels(
+		// Pods and Services
+		podsList, servicesList, err := backend.kubernetesManager.GetPodsAndServicesByLabels(
 			ctx,
 			namespaceName,
 			enclaveWithIDMatchLabels,
 		)
 		if err != nil {
-			return nil, stacktrace.Propagate(err, "An error occurred getting pods matching enclave ID '%v' in namespace '%v'", enclaveIdStr, namespace.GetName())
+			return nil, stacktrace.Propagate(err, "An error occurred getting pods and services matching enclave ID '%v' in namespace '%v'", enclaveIdStr, namespace.GetName())
 		}
+
 		pods := []apiv1.Pod{}
 		pods = append(pods, podsList.Items...)
 
-		// Services
-		servicesList, err := backend.kubernetesManager.GetServicesByLabels(
-			ctx,
-			namespaceName,
-			enclaveWithIDMatchLabels,
-		)
-		if err != nil {
-			return nil, stacktrace.Propagate(err, "An error occurred getting services matching enclave ID '%v' in namespace '%v'", enclaveIdStr, namespace.GetName())
-		}
-		var services []apiv1.Service
+		services := []apiv1.Service{}
 		services = append(services, servicesList.Items...)
 
 		enclaveResources := &enclaveKubernetesResources{


### PR DESCRIPTION
## Description:
 Implemented GetPodsAndServicesByLabels in KuberneteManager in order to run both calls in parallel when these resources are required with the same labels

## Is this change user-facing?
NO

## References (if applicable):
It was detected during the [enclave pool project](https://www.notion.so/kurtosistech/Enclave-Pool-Project-7273552e53e44b0f931a57568cd170a0?d=2f870450d01d4ad7b8af6d0045602a2a#a20862960dad4868b0b9b6eb320b6178)  
