### PR TITLE
fix: pinned go version to 1.19.10 for now

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,7 +98,7 @@ executors:
 parameters:
   go-version:
     type: string
-    default: "1.19"
+    default: "1.19.10"
   container-engine-lib-build-cache-key-prefix:
     type: string
     default: "go-mod-v1"   # Can bump this version to bust the cache
@@ -113,7 +113,7 @@ parameters:
   # the same version as the server
   server-go-version:
     type: string
-    default: "1.19"
+    default: "1.19.10"
   rust-version:
     type: string
     default: 1.68.2
@@ -128,7 +128,7 @@ parameters:
     default: "engine-server-go-mod-v1"   # Can bump this version to bust the cache
   cli-go-version:
     type: string
-    default: "1.19"
+    default: "1.19.10"
   workspace-with-cli-binary-and-images-mountpoint:
     type: string
     default: "/tmp/workspace"

--- a/internal_testsuites/golang/testsuite/startosis_test/startosis_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_test/startosis_test.go
@@ -191,7 +191,8 @@ scrape_configs:
      metrics_path: /foo/path
      static_configs:
        - targets: ['foobar.com']
-   `
+   
+`
 	logrus.Infof("Checking that the file got mounted on " + serviceIdForDependentService)
 	serviceCtx, err = enclaveCtx.GetServiceContext(serviceIdForDependentService)
 	require.Nil(t, err, "Unexpected Error Creating Service Context")


### PR DESCRIPTION
This should fix pipeline failures that we have been saying; will share the blub on it on slack.
