### PR TITLE
chore: Escape [] in docs

### DIFF
--- a/docs/docs/guides/running-in-k8s.md
+++ b/docs/docs/guides/running-in-k8s.md
@@ -72,7 +72,7 @@ To switch back to using Kurtosis locally, simply use: `kurtosis cluster set dock
 :::
 
 
-V. [Optional] Activate the enclave pool to accelerate the enclave creation time
+V. \[Optional] Activate the enclave pool to accelerate the enclave creation time
 --------------------------------
 
 This step is optional, but we recommend taking it as it improves the user experience during the enclave creation, specifically regarding speed.


### PR DESCRIPTION
## Description:
This is currently breaking the docs build, because unescaped [] are treated as references:
https://github.com/kurtosis-tech/kurtosis/actions/runs/5588822721/jobs/10216162058?pr=923

## Is this change user facing?
NO
<!-- If yes, please add the "user facing" label to the PR -->
<!-- If yes, don't forget to include docs changes where relevant -->

## References (if applicable):
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
