### PR TITLE
fix: stream instruction output in chunks of 3Mb

### DIFF
--- a/api/golang/core/lib/enclaves/starlark_run_blocking.go
+++ b/api/golang/core/lib/enclaves/starlark_run_blocking.go
@@ -45,7 +45,6 @@ func ReadStarlarkRunResponseLineBlocking(starlarkRunResponseLines <-chan *kurtos
 			instructions = append(instructions, responseLine.GetInstruction())
 		} else if responseLine.GetInstructionResult() != nil {
 			scriptOutput.WriteString(responseLine.GetInstructionResult().GetSerializedInstructionResult())
-			scriptOutput.WriteString(starlarkRunOutputLinesSplit)
 		} else if responseLine.GetError() != nil {
 			if responseLine.GetError().GetInterpretationError() != nil {
 				interpretationError = responseLine.GetError().GetInterpretationError()

--- a/cli/cli/helpers/output_printers/kurtosis_instruction_printer.go
+++ b/cli/cli/helpers/output_printers/kurtosis_instruction_printer.go
@@ -165,6 +165,14 @@ func (printer *ExecutionPrinter) printPersistentLineToStdOut(lineToPrint string)
 	return nil
 }
 
+func (printer *ExecutionPrinter) printPersistentLineToStdOutWithoutNewLine(lineToPrint string) error {
+	// If spinner is being used, we have to stop spinner -> print -> start spinner in order to keep the spinner at the bottom of the output
+	printer.stopSpinnerIfUsed()
+	out.PrintOut(lineToPrint)
+	printer.startSpinnerIfUsed()
+	return nil
+}
+
 func FormatError(errorMessage string) string {
 	return colorizeError(errorMessage)
 }

--- a/cli/cli/helpers/output_printers/kurtosis_instruction_printer.go
+++ b/cli/cli/helpers/output_printers/kurtosis_instruction_printer.go
@@ -116,7 +116,7 @@ func (printer *ExecutionPrinter) PrintKurtosisExecutionResponseLineToStdOut(resp
 		}
 	} else if responseLine.GetInstructionResult() != nil {
 		formattedInstructionResult := formatInstructionResult(responseLine.GetInstructionResult())
-		if err := printer.printPersistentLineToStdOut(formattedInstructionResult); err != nil {
+		if err := printer.printPersistentLineToStdOutWithoutNewLine(formattedInstructionResult); err != nil {
 			return stacktrace.Propagate(err, "Error printing Kurtosis instruction result: \n%v", formattedInstructionResult)
 		}
 	} else if responseLine.GetError() != nil {

--- a/cli/cli/out/cli_writers.go
+++ b/cli/cli/out/cli_writers.go
@@ -39,6 +39,15 @@ func GetErr() io.Writer {
 	return std.err
 }
 
+func PrintOut(msg string) {
+	if _, printErr := fmt.Fprint(std.out, msg); printErr != nil {
+		logrus.Errorf("Error printing message to StdOut. Message was:\n%s\nError was:\n%v", msg, printErr.Error())
+	}
+
+	printLogsToFile(msg)
+
+}
+
 func PrintOutLn(msg string) {
 	if _, printErr := fmt.Fprintln(std.out, msg); printErr != nil {
 		logrus.Errorf("Error printing message to StdOut. Message was:\n%s\nError was:\n%v", msg, printErr.Error())

--- a/core/server/api_container/server/startosis_engine/startosis_executor.go
+++ b/core/server/api_container/server/startosis_engine/startosis_executor.go
@@ -107,7 +107,7 @@ func (executor *StartosisExecutor) Execute(ctx context.Context, dryRun bool, par
 						starlarkRunResponseLineStream <- binding_constructors.NewStarlarkRunResponseLineFromInstructionResult(chunk)
 					}
 				}
-				starlarkRunResponseLineStream <- binding_constructors.NewStarlarkRunResponseLineFromRunSuccessEvent(instructionResultSeparator)
+				starlarkRunResponseLineStream <- binding_constructors.NewStarlarkRunResponseLineFromInstructionResult(instructionResultSeparator)
 				// mark the instruction as executed and add it to the current instruction plan
 				executor.enclavePlan.AddScheduledInstruction(scheduledInstruction).Executed(true)
 			}

--- a/core/server/api_container/server/startosis_engine/startosis_executor.go
+++ b/core/server/api_container/server/startosis_engine/startosis_executor.go
@@ -9,7 +9,6 @@ import (
 	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/runtime_value_store"
 	"github.com/kurtosis-tech/stacktrace"
 	"github.com/sirupsen/logrus"
-	"math"
 	"sync"
 )
 
@@ -95,15 +94,12 @@ func (executor *StartosisExecutor) Execute(ctx context.Context, dryRun bool, par
 					return
 				}
 				if instructionOutput != nil {
-					lengthOfInstructionOutput := len(*instructionOutput)
-					totalNumberOfChunks := int(math.Ceil(float64(lengthOfInstructionOutput) / float64(threeMegaByteLimit)))
-					for i := 0; i < totalNumberOfChunks; i++ {
-						start := i * threeMegaByteLimit
-						end := (i + 1) * threeMegaByteLimit
-						if end > lengthOfInstructionOutput {
-							end = lengthOfInstructionOutput
+					for i := 0; i < len(*instructionOutput); i += threeMegaByteLimit {
+						end := i + threeMegaByteLimit
+						if end > len(*instructionOutput) {
+							end = len(*instructionOutput)
 						}
-						chunk := (*instructionOutput)[start:end]
+						chunk := (*instructionOutput)[i:end]
 						starlarkRunResponseLineStream <- binding_constructors.NewStarlarkRunResponseLineFromInstructionResult(chunk)
 					}
 				}

--- a/core/server/api_container/server/startosis_engine/startosis_executor.go
+++ b/core/server/api_container/server/startosis_engine/startosis_executor.go
@@ -17,7 +17,8 @@ const (
 	progressMsg      = "Execution in progress"
 	ParallelismParam = "PARALLELISM"
 	// we put a three megabyte limit here as there is a 4 megabyte limit on what can be recieved
-	threeMegaByteLimit = 3 * 1024 * 1024
+	threeMegaByteLimit         = 3 * 1024 * 1024
+	instructionResultSeparator = "\n"
 )
 
 var (
@@ -106,6 +107,7 @@ func (executor *StartosisExecutor) Execute(ctx context.Context, dryRun bool, par
 						starlarkRunResponseLineStream <- binding_constructors.NewStarlarkRunResponseLineFromInstructionResult(chunk)
 					}
 				}
+				starlarkRunResponseLineStream <- binding_constructors.NewStarlarkRunResponseLineFromRunSuccessEvent(instructionResultSeparator)
 				// mark the instruction as executed and add it to the current instruction plan
 				executor.enclavePlan.AddScheduledInstruction(scheduledInstruction).Executed(true)
 			}

--- a/internal_testsuites/golang/testsuite/starlark_run_python_test/run_python_test.go
+++ b/internal_testsuites/golang/testsuite/starlark_run_python_test/run_python_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"github.com/kurtosis-tech/kurtosis-cli/golang_internal_testsuite/test_helpers"
 	"github.com/stretchr/testify/require"
+	"strings"
 	"testing"
 )
 
@@ -69,5 +70,6 @@ func TestStarlark_RunPythonWithLargeOutputGreaterThan4Mb(t *testing.T) {
 	ctx := context.Background()
 	runResult, err := test_helpers.SetupSimpleEnclaveAndRunScript(t, ctx, runPythonWithGiganticOutputGreaterThan4Mb, runPythonWithLargeOutputGreaterThan4MbScript)
 	require.Nil(t, err)
-	require.Greater(t, len(runResult.RunOutput), 2^20)
+	expectedOuptut := strings.Repeat("hello world", 2^20)
+	require.Contains(t, runResult.RunOutput, expectedOuptut)
 }

--- a/internal_testsuites/golang/testsuite/starlark_run_python_test/run_python_test.go
+++ b/internal_testsuites/golang/testsuite/starlark_run_python_test/run_python_test.go
@@ -37,6 +37,16 @@ print(sys.argv[1])
 		args = ["Kurtosis"]
 	)
 `
+
+	runPythonWithGiganticOutputGreaterThan4Mb    = "run-large-python-output-test"
+	runPythonWithLargeOutputGreaterThan4MbScript = `
+def run(plan):
+    plan.run_python(
+        run = """
+print("hello world"*2**20)
+"""
+    )
+`
 )
 
 func TestStarlark_RunPython(t *testing.T) {
@@ -53,4 +63,11 @@ func TestStarlark_RunPythonWithExternalPacakges(t *testing.T) {
 	require.Nil(t, err)
 	expectedOutput := "Command returned with exit code '0' and the following output:\n--------------------\n200\nKurtosis\n\n--------------------\n"
 	require.Equal(t, expectedOutput, string(runResult.RunOutput))
+}
+
+func TestStarlark_RunPythonWithLargeOutputGreaterThan4Mb(t *testing.T) {
+	ctx := context.Background()
+	runResult, err := test_helpers.SetupSimpleEnclaveAndRunScript(t, ctx, runPythonWithGiganticOutputGreaterThan4Mb, runPythonWithLargeOutputGreaterThan4MbScript)
+	require.Nil(t, err)
+	require.Greater(t, len(runResult.RunOutput), 2^20)
 }


### PR DESCRIPTION
## Description:
Previously we would try to send all of it at once as the max message size is inifnite. User would get something like - 

```
Caused by: rpc error: code = ResourceExhausted desc = grpc: received message larger than max (17391758 vs. 4194304)
```

Barnabas ran into it. I ran into it several times mostly with execs.

## Is this change user facing?
YES
