### PR TITLE
fix: truncate output if greater than 64*1024 characters

### DIFF
--- a/core/server/api_container/server/startosis_engine/startosis_executor.go
+++ b/core/server/api_container/server/startosis_engine/startosis_executor.go
@@ -16,8 +16,9 @@ import (
 const (
 	progressMsg      = "Execution in progress"
 	ParallelismParam = "PARALLELISM"
-	// we limit the output to 300 characters
-	outputSizeLimit          = 300
+	// we limit the output to 600 characters
+	// TODO(tedi) get rid of this in favor of streaming
+	outputSizeLimit          = 600
 	outputLimitReachedSuffix = "..."
 )
 

--- a/core/server/api_container/server/startosis_engine/startosis_executor.go
+++ b/core/server/api_container/server/startosis_engine/startosis_executor.go
@@ -16,9 +16,9 @@ import (
 const (
 	progressMsg      = "Execution in progress"
 	ParallelismParam = "PARALLELISM"
-	// we limit the output to 600 characters
+	// we limit the output to 64k characters
 	// TODO(tedi) get rid of this in favor of streaming
-	outputSizeLimit          = 600
+	outputSizeLimit          = 64 * 1024
 	outputLimitReachedSuffix = "..."
 )
 

--- a/core/server/api_container/server/startosis_engine/startosis_executor.go
+++ b/core/server/api_container/server/startosis_engine/startosis_executor.go
@@ -2,6 +2,7 @@ package startosis_engine
 
 import (
 	"context"
+	"fmt"
 	"github.com/kurtosis-tech/kurtosis/api/golang/core/kurtosis_core_rpc_api_bindings"
 	"github.com/kurtosis-tech/kurtosis/api/golang/core/lib/binding_constructors"
 	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/instructions_plan"
@@ -15,6 +16,9 @@ import (
 const (
 	progressMsg      = "Execution in progress"
 	ParallelismParam = "PARALLELISM"
+	// we limit the output to 300 characters
+	outputSizeLimit          = 300
+	outputLimitReachedSuffix = "..."
 )
 
 var (
@@ -91,7 +95,11 @@ func (executor *StartosisExecutor) Execute(ctx context.Context, dryRun bool, par
 					return
 				}
 				if instructionOutput != nil {
-					starlarkRunResponseLineStream <- binding_constructors.NewStarlarkRunResponseLineFromInstructionResult(*instructionOutput)
+					instructionOutputStr := *instructionOutput
+					if len(instructionOutputStr) > outputSizeLimit {
+						instructionOutputStr = fmt.Sprintf("%s%s", instructionOutputStr[0:outputSizeLimit], outputLimitReachedSuffix)
+					}
+					starlarkRunResponseLineStream <- binding_constructors.NewStarlarkRunResponseLineFromInstructionResult(instructionOutputStr)
 				}
 				// mark the instruction as executed and add it to the current instruction plan
 				executor.enclavePlan.AddScheduledInstruction(scheduledInstruction).Executed(true)


### PR DESCRIPTION
## Description:
We would written a lot of data and the client would fail as it wouldn't accept over > 4mb.

going with this limit instead of something lower as a lot of our tests rely on output value matching.