### PR TITLE
feat: re-enabled fluentbit-with-loki

### DIFF
--- a/cli/cli/commands/service/logs/logs.go
+++ b/cli/cli/commands/service/logs/logs.go
@@ -11,7 +11,9 @@ import (
 	"github.com/kurtosis-tech/kurtosis/api/golang/core/lib/services"
 	"github.com/kurtosis-tech/kurtosis/api/golang/engine/kurtosis_engine_rpc_api_bindings"
 	"github.com/kurtosis-tech/kurtosis/api/golang/engine/lib/kurtosis_context"
+	"github.com/kurtosis-tech/kurtosis/cli/cli/command_framework/highlevel/enclave_id_arg"
 	"github.com/kurtosis-tech/kurtosis/cli/cli/command_framework/highlevel/engine_consuming_kurtosis_command"
+	"github.com/kurtosis-tech/kurtosis/cli/cli/command_framework/highlevel/service_identifier_arg"
 	"github.com/kurtosis-tech/kurtosis/cli/cli/command_framework/lowlevel/args"
 	"github.com/kurtosis-tech/kurtosis/cli/cli/command_framework/lowlevel/flags"
 	"github.com/kurtosis-tech/kurtosis/cli/cli/command_str_consts"
@@ -103,18 +105,17 @@ var ServiceLogsCmd = &engine_consuming_kurtosis_command.EngineConsumingKurtosisC
 	Args: []*args.ArgConfig{
 		//TODO disabling enclaveID validation and serviceUUID validation for allowing consuming logs from removed or stopped enclaves
 		//TODO we should enable them when #879 is ready: https://github.com/kurtosis-tech/kurtosis/issues/879
-		{
-			Key:          enclaveIdentifierArgKey,
-			IsOptional:   false,
-			DefaultValue: "",
-			IsGreedy:     false,
-		},
-		{
-			Key:          serviceIdentifierArgKey,
-			IsOptional:   false,
-			DefaultValue: "",
-			IsGreedy:     false,
-		},
+		enclave_id_arg.NewEnclaveIdentifierArg(
+			enclaveIdentifierArgKey,
+			engineClientCtxKey,
+			isEnclaveIdArgOptional,
+			isEnclaveIdArgGreedy,
+		),
+		service_identifier_arg.NewServiceIdentifierArg(
+			serviceIdentifierArgKey,
+			isServiceIdentifierArgGreedy,
+			isServiceIdentifierArgOptional,
+		),
 	},
 	RunFunc: run,
 }

--- a/cli/cli/commands/service/logs/logs.go
+++ b/cli/cli/commands/service/logs/logs.go
@@ -11,9 +11,7 @@ import (
 	"github.com/kurtosis-tech/kurtosis/api/golang/core/lib/services"
 	"github.com/kurtosis-tech/kurtosis/api/golang/engine/kurtosis_engine_rpc_api_bindings"
 	"github.com/kurtosis-tech/kurtosis/api/golang/engine/lib/kurtosis_context"
-	"github.com/kurtosis-tech/kurtosis/cli/cli/command_framework/highlevel/enclave_id_arg"
 	"github.com/kurtosis-tech/kurtosis/cli/cli/command_framework/highlevel/engine_consuming_kurtosis_command"
-	"github.com/kurtosis-tech/kurtosis/cli/cli/command_framework/highlevel/service_identifier_arg"
 	"github.com/kurtosis-tech/kurtosis/cli/cli/command_framework/lowlevel/args"
 	"github.com/kurtosis-tech/kurtosis/cli/cli/command_framework/lowlevel/flags"
 	"github.com/kurtosis-tech/kurtosis/cli/cli/command_str_consts"
@@ -105,17 +103,18 @@ var ServiceLogsCmd = &engine_consuming_kurtosis_command.EngineConsumingKurtosisC
 	Args: []*args.ArgConfig{
 		//TODO disabling enclaveID validation and serviceUUID validation for allowing consuming logs from removed or stopped enclaves
 		//TODO we should enable them when #879 is ready: https://github.com/kurtosis-tech/kurtosis/issues/879
-		enclave_id_arg.NewEnclaveIdentifierArg(
-			enclaveIdentifierArgKey,
-			engineClientCtxKey,
-			isEnclaveIdArgOptional,
-			isEnclaveIdArgGreedy,
-		),
-		service_identifier_arg.NewServiceIdentifierArg(
-			serviceIdentifierArgKey,
-			isServiceIdentifierArgGreedy,
-			isServiceIdentifierArgOptional,
-		),
+		{
+			Key:          enclaveIdentifierArgKey,
+			IsOptional:   false,
+			DefaultValue: "",
+			IsGreedy:     false,
+		},
+		{
+			Key:          serviceIdentifierArgKey,
+			IsOptional:   false,
+			DefaultValue: "",
+			IsGreedy:     false,
+		},
 	},
 	RunFunc: run,
 }

--- a/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/backend_creator/backend_creator.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/backend_creator/backend_creator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"github.com/docker/docker/client"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend"
+	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/logs_collector_functions"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_impls/docker/docker_manager"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_impls/docker/object_attributes_provider/label_key_consts"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_impls/docker/object_attributes_provider/label_value_consts"
@@ -196,10 +197,16 @@ func getDockerKurtosisBackend(
 		networkIp := network.GetIpAndMask().IP
 		apiContainerIp := optionalApiContainerModeArgs.APIContainerIP
 
+		logsCollectorObj, err := logs_collector_functions.GetLogsCollectorForEnclave(ctx, enclaveUuid, dockerManager)
+		if err != nil {
+			return nil, stacktrace.Propagate(err, "An error occurred while getting the logs collector object for enclave '%v'; This is a bug in Kurtosis", enclaveUuid)
+		}
+
 		alreadyTakenIps := map[string]bool{
 			networkIp.String():      true,
 			network.GetGatewayIp():  true,
 			apiContainerIp.String(): true,
+			logsCollectorObj.GetEnclaveNetworkIpAddress().String(): true,
 		}
 
 		freeIpAddrProvider, err := free_ip_addr_tracker.GetOrCreateNewFreeIpAddrTracker(

--- a/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/docker_kurtosis_backend_api_container_functions.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/docker_kurtosis_backend_api_container_functions.go
@@ -68,10 +68,16 @@ func (backend *DockerKurtosisBackend) CreateAPIContainer(
 		return nil, stacktrace.Propagate(err, "An error occurred getting enclave network by enclave UUID '%v'", enclaveUuid)
 	}
 
+	enclaveLogsCollector, err := backend.GetLogsCollectorForEnclave(ctx, enclaveUuid)
+	if err != nil {
+		return nil, stacktrace.Propagate(err, "An error occurred while getting the logs collector for enclave '%v; This is a bug in Kurtosis'", enclaveUuid)
+	}
+
 	networkCidr := enclaveNetwork.GetIpAndMask()
 	alreadyTakenIps := map[string]bool{
-		networkCidr.IP.String():       true,
-		enclaveNetwork.GetGatewayIp(): true,
+		networkCidr.IP.String():                                    true,
+		enclaveNetwork.GetGatewayIp():                              true,
+		enclaveLogsCollector.GetEnclaveNetworkIpAddress().String(): true,
 	}
 
 	ipAddr, err := network_helpers.GetFreeIpAddrFromSubnet(alreadyTakenIps, networkCidr)

--- a/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/docker_kurtosis_backend_enclave_functions.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/docker_kurtosis_backend_enclave_functions.go
@@ -21,6 +21,9 @@ const (
 	shouldFetchStoppedContainersWhenGettingEnclaveStatus = true
 
 	shouldFetchStoppedContainersWhenDumpingEnclave = true
+
+	defaultHttpLogsCollectorPortNum = uint16(9712)
+	defaultTcpLogsCollectorPortNum  = uint16(9713)
 )
 
 // TODO: MIGRATE THIS FOLDER TO USE STRUCTURE OF USER_SERVICE_FUNCTIONS MODULE
@@ -142,6 +145,21 @@ func (backend *DockerKurtosisBackend) CreateEnclave(ctx context.Context, enclave
 
 	newEnclave := enclave.NewEnclave(enclaveUuid, enclaveName, enclave.EnclaveStatus_Empty, &creationTime)
 
+	// TODO the logs collector has a random private ip address in the enclave network that must be tracked
+	if _, err := backend.CreateLogsCollectorForEnclave(ctx, enclaveUuid, defaultTcpLogsCollectorPortNum, defaultHttpLogsCollectorPortNum); err != nil {
+		return nil, stacktrace.Propagate(err, "An error occurred creating the logs collector with TCP port number '%v' and HTTP port number '%v'", defaultTcpLogsCollectorPortNum, defaultHttpLogsCollectorPortNum)
+	}
+	shouldDeleteLogsCollector := true
+	defer func() {
+		if shouldDeleteLogsCollector {
+			err = backend.DestroyLogsCollectorForEnclave(ctx, enclaveUuid)
+			if err != nil {
+				logrus.Errorf("Couldn't cleanup logs collector for enclave '%v' as the following error was thrown:\n%v", enclaveUuid, err)
+			}
+		}
+	}()
+
+	shouldDeleteLogsCollector = false
 	shouldDeleteNetwork = false
 	shouldDeleteVolume = false
 	return newEnclave, nil

--- a/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/logs_collector_functions/destroy_deprecated_centralized_logs_collectors.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/logs_collector_functions/destroy_deprecated_centralized_logs_collectors.go
@@ -1,0 +1,50 @@
+package logs_collector_functions
+
+import (
+	"context"
+	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_impls/docker/docker_manager"
+)
+
+const (
+	deprecatedLogsCollectorVolumeNameSuffix = "kurtosis-logs-collector-vol"
+)
+
+// TODO(centralized-logs-collectors-deprecation) remove this entire function after enough people are on > 0.68.0
+func DestroyDeprecatedCentralizedLogsCollectors(
+	ctx context.Context,
+	dockerManager *docker_manager.DockerManager,
+) error {
+
+	//logsCollectorContainerSearchLabels := map[string]string{
+	//	label_key_consts.AppIDDockerLabelKey.GetString():         label_value_consts.AppIDDockerLabelValue.GetString(),
+	//	label_key_consts.ContainerTypeDockerLabelKey.GetString(): label_value_consts.LogsCollectorTypeDockerLabelValue.GetString(),
+	//}
+	//
+	//matchingLogsCollectorContainers, err := dockerManager.GetContainersByLabels(ctx, logsCollectorContainerSearchLabels, shouldShowStoppedLogsCollectorContainers)
+	//if err != nil {
+	//	return stacktrace.Propagate(err, "An error occurred fetching logs collector containers using labels: %+v", logsCollectorContainerSearchLabels)
+	//}
+	//
+	//for _, logsCollectorContainer := range matchingLogsCollectorContainers {
+	//	if err := dockerManager.StopContainer(ctx, logsCollectorContainer.GetId(), stopLogsCollectorContainersTimeout); err != nil {
+	//		return stacktrace.Propagate(err, "An error occurred stopping the logs collector container with ID '%v'", logsCollectorContainer.GetId())
+	//	}
+	//
+	//	if err := dockerManager.RemoveContainer(ctx, logsCollectorContainer.GetId()); err != nil {
+	//		return stacktrace.Propagate(err, "An error occurred removing the logs collector container with ID '%v'", logsCollectorContainer.GetId())
+	//	}
+	//}
+	//
+	//volumes, err := dockerManager.GetVolumesByName(ctx, deprecatedLogsCollectorVolumeNameSuffix)
+	//if err != nil {
+	//	return stacktrace.Propagate(err, "Attempted to fetch volumes to get the volumes of the deprecated centralized logs collectors but failed")
+	//}
+	//
+	//for _, volumeName := range volumes {
+	//	if err := dockerManager.RemoveVolume(ctx, volumeName); err != nil {
+	//		return stacktrace.Propagate(err, "An error occurred removing the deprecated centralized logs collector volume with volume name '%v'", volumeName)
+	//	}
+	//}
+
+	return nil
+}

--- a/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/logs_database_functions/destroy_deprecated_logs_database.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/logs_database_functions/destroy_deprecated_logs_database.go
@@ -1,0 +1,35 @@
+package logs_database_functions
+
+import (
+	"context"
+	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_impls/docker/docker_manager"
+)
+
+const (
+	deprecatedLogsDatabaseVolumeName = "kurtosis-logs-db-vol"
+)
+
+// TODO(centralized-logs-database-deprecation) remove this entire function after enough people are on > 0.68.0
+func DestroyDeprecatedCentralizedLogsDatabase(
+	ctx context.Context,
+	dockerManager *docker_manager.DockerManager,
+) error {
+
+	//It stops and removes the container
+	//if err := DestroyLogsDatabase(ctx, dockerManager); err != nil {
+	//	return stacktrace.Propagate(err, "An error occurred while destroying the deprecated centralized logs database")
+	//}
+	//
+	//volumes, err := dockerManager.GetVolumesByName(ctx, deprecatedLogsDatabaseVolumeName)
+	//if err != nil {
+	//	return stacktrace.Propagate(err, "Attempted to fetch volumes to get the volumes of the deprecated centralized logs database but failed")
+	//}
+	//
+	//for _, volumeName := range volumes {
+	//	if err := dockerManager.RemoveVolume(ctx, volumeName); err != nil {
+	//		return stacktrace.Propagate(err, "An error occurred removing the deprecated centralized logs database volume with volume name '%v'", volumeName)
+	//	}
+	//}
+
+	return nil
+}

--- a/engine/server/engine/centralized_logs/client_implementations/loki/loki_logs_database_client.go
+++ b/engine/server/engine/centralized_logs/client_implementations/loki/loki_logs_database_client.go
@@ -326,6 +326,7 @@ func (client *lokiLogsDatabaseClient) getUserServiceLogs(
 		Response:         nil,
 	}
 
+	logrus.Infof("YOLO: %+v", httpRequest)
 	ctxWithCancel, cancelCtxFunc := context.WithCancel(ctx)
 	defer cancelCtxFunc()
 

--- a/engine/server/engine/main.go
+++ b/engine/server/engine/main.go
@@ -17,7 +17,7 @@ import (
 	"github.com/kurtosis-tech/kurtosis/core/launcher/api_container_launcher"
 	"github.com/kurtosis-tech/kurtosis/engine/launcher/args"
 	"github.com/kurtosis-tech/kurtosis/engine/launcher/args/kurtosis_backend_config"
-	"github.com/kurtosis-tech/kurtosis/engine/server/engine/centralized_logs/client_implementations/kurtosis_backend"
+	"github.com/kurtosis-tech/kurtosis/engine/server/engine/centralized_logs/client_implementations/loki"
 	"github.com/kurtosis-tech/kurtosis/engine/server/engine/enclave_manager"
 	"github.com/kurtosis-tech/kurtosis/engine/server/engine/server"
 	minimal_grpc_server "github.com/kurtosis-tech/minimal-grpc-server/golang/server"
@@ -134,8 +134,7 @@ func runMain() error {
 		return stacktrace.Propagate(err, "Failed to create an enclave manager for backend type '%v' and config '%+v'", serverArgs.KurtosisBackendType, backendConfig)
 	}
 
-	logsDatabaseClient := kurtosis_backend.NewKurtosisBackendLogsDatabaseClient(kurtosisBackend)
-
+	logsDatabaseClient := loki.NewLokiLogsDatabaseClientWithDefaultHttpClient("192.168.2.33:9714")
 	engineServerService := server.NewEngineServerService(
 		serverArgs.ImageVersionTag,
 		enclaveManager,

--- a/engine/server/engine/main.go
+++ b/engine/server/engine/main.go
@@ -14,9 +14,12 @@ import (
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/configs"
+	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/container_status"
 	"github.com/kurtosis-tech/kurtosis/core/launcher/api_container_launcher"
 	"github.com/kurtosis-tech/kurtosis/engine/launcher/args"
 	"github.com/kurtosis-tech/kurtosis/engine/launcher/args/kurtosis_backend_config"
+	"github.com/kurtosis-tech/kurtosis/engine/server/engine/centralized_logs"
+	"github.com/kurtosis-tech/kurtosis/engine/server/engine/centralized_logs/client_implementations/kurtosis_backend"
 	"github.com/kurtosis-tech/kurtosis/engine/server/engine/centralized_logs/client_implementations/loki"
 	"github.com/kurtosis-tech/kurtosis/engine/server/engine/enclave_manager"
 	"github.com/kurtosis-tech/kurtosis/engine/server/engine/server"
@@ -134,7 +137,28 @@ func runMain() error {
 		return stacktrace.Propagate(err, "Failed to create an enclave manager for backend type '%v' and config '%+v'", serverArgs.KurtosisBackendType, backendConfig)
 	}
 
-	logsDatabaseClient := loki.NewLokiLogsDatabaseClientWithDefaultHttpClient("192.168.2.33:9714")
+	var logsDatabaseClient centralized_logs.LogsDatabaseClient
+
+	if serverArgs.KurtosisBackendType == args.KurtosisBackendType_Docker {
+		logsDatabase, err := kurtosisBackend.GetLogsDatabase(ctx)
+		if err != nil {
+			return stacktrace.Propagate(err, "An error occurred getting the logs database")
+		}
+		if logsDatabase == nil || logsDatabase.GetStatus() == container_status.ContainerStatus_Stopped {
+			return stacktrace.NewError("The engine server cannot be run because the logs database container is not running")
+		}
+
+		if logsDatabase.GetMaybePrivateIpAddr() == nil {
+			return stacktrace.NewError("The engine server cannot be run because the private IP address of the logs database is nil")
+		}
+
+		privateLogsDatabaseAddress := fmt.Sprintf("%v:%v", logsDatabase.GetMaybePrivateIpAddr(), logsDatabase.GetPrivateHttpPort().GetNumber())
+
+		logsDatabaseClient = loki.NewLokiLogsDatabaseClientWithDefaultHttpClient(privateLogsDatabaseAddress)
+	} else {
+		logsDatabaseClient = kurtosis_backend.NewKurtosisBackendLogsDatabaseClient(kurtosisBackend)
+	}
+
 	engineServerService := server.NewEngineServerService(
 		serverArgs.ImageVersionTag,
 		enclaveManager,

--- a/engine/server/engine/main.go
+++ b/engine/server/engine/main.go
@@ -14,13 +14,10 @@ import (
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/configs"
-	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/container_status"
 	"github.com/kurtosis-tech/kurtosis/core/launcher/api_container_launcher"
 	"github.com/kurtosis-tech/kurtosis/engine/launcher/args"
 	"github.com/kurtosis-tech/kurtosis/engine/launcher/args/kurtosis_backend_config"
-	"github.com/kurtosis-tech/kurtosis/engine/server/engine/centralized_logs"
 	"github.com/kurtosis-tech/kurtosis/engine/server/engine/centralized_logs/client_implementations/kurtosis_backend"
-	"github.com/kurtosis-tech/kurtosis/engine/server/engine/centralized_logs/client_implementations/loki"
 	"github.com/kurtosis-tech/kurtosis/engine/server/engine/enclave_manager"
 	"github.com/kurtosis-tech/kurtosis/engine/server/engine/server"
 	minimal_grpc_server "github.com/kurtosis-tech/minimal-grpc-server/golang/server"
@@ -137,28 +134,8 @@ func runMain() error {
 		return stacktrace.Propagate(err, "Failed to create an enclave manager for backend type '%v' and config '%+v'", serverArgs.KurtosisBackendType, backendConfig)
 	}
 
-	var logsDatabaseClient centralized_logs.LogsDatabaseClient
-
-	if serverArgs.KurtosisBackendType == args.KurtosisBackendType_Docker {
-		logsDatabase, err := kurtosisBackend.GetLogsDatabase(ctx)
-		if err != nil {
-			return stacktrace.Propagate(err, "An error occurred getting the logs database")
-		}
-		if logsDatabase == nil || logsDatabase.GetStatus() == container_status.ContainerStatus_Stopped {
-			return stacktrace.NewError("The engine server cannot be run because the logs database container is not running")
-		}
-
-		if logsDatabase.GetMaybePrivateIpAddr() == nil {
-			return stacktrace.NewError("The engine server cannot be run because the private IP address of the logs database is nil")
-		}
-
-		privateLogsDatabaseAddress := fmt.Sprintf("%v:%v", logsDatabase.GetMaybePrivateIpAddr(), logsDatabase.GetPrivateHttpPort().GetNumber())
-
-		logsDatabaseClient = loki.NewLokiLogsDatabaseClientWithDefaultHttpClient(privateLogsDatabaseAddress)
-	} else {
-		logsDatabaseClient = kurtosis_backend.NewKurtosisBackendLogsDatabaseClient(kurtosisBackend)
-	}
-
+	// TODO: replace with persistent client so that we can get logs even after enclave is stopped.
+	logsDatabaseClient := kurtosis_backend.NewKurtosisBackendLogsDatabaseClient(kurtosisBackend)
 	engineServerService := server.NewEngineServerService(
 		serverArgs.ImageVersionTag,
 		enclaveManager,

--- a/engine/server/engine/server/engine_server_service.go
+++ b/engine/server/engine/server/engine_server_service.go
@@ -261,7 +261,7 @@ func newLogsResponse(
 	notFoundServiceUuids map[string]bool,
 ) *kurtosis_engine_rpc_api_bindings.GetServiceLogsResponse {
 	serviceLogLinesByUuid := make(map[string]*kurtosis_engine_rpc_api_bindings.LogLine, len(serviceLogsByServiceUuid))
-
+	logrus.Infof("YOLOL HEHEH")
 	for serviceUuid := range requestedServiceUuids {
 		serviceUuidStr := string(serviceUuid)
 		_, isInNotFoundUuidList := notFoundServiceUuids[serviceUuidStr]


### PR DESCRIPTION
MERGE THIS ONLY WHEN LOKI IS REPLACED BY VECTOR @tedim52 
## Description:
re-enabled the fluentbit code to propagate logs from enclaves to loki database

## Is this change user facing?
NO
