### PR TITLE
fix: Fix broken link in docs causing CI build to fail

### DIFF
--- a/docs/docs/cli-reference/config-path.md
+++ b/docs/docs/cli-reference/config-path.md
@@ -5,3 +5,9 @@ slug: /config-path
 ---
 
 The `kurtosis config path` command displays the path to the Kurtosis CLI config YAML file. This file is used to configure Kurtosis CLI behaviour.
+
+To see the full set of configuration values available:
+
+1. Open [the directory containing the versions of Kurtosis config](https://github.com/kurtosis-tech/kurtosis/tree/main/cli/cli/kurtosis_config/overrides_objects)
+2. Select the most recent (highest) version
+3. Explore the various config objects inside, starting with the `kurtosis_config_vX.go` top-level object (each `struct` represents a YAML object inside the configuration)

--- a/docs/docs/guides/how-to-compose-your-own-testnet.md
+++ b/docs/docs/guides/how-to-compose-your-own-testnet.md
@@ -70,12 +70,12 @@ lighthouse = import_module("github.com/kurtosis-tech/lighthouse-package/lib/ligh
 
 # Again, replacing $YOUR_GITHUB_USERNAME with your Github username
 network_params = json.decode(read_file("github.com/$YOUR_GITHUB_USERNAME/my-testnet/network_params.json"))
-``` 
+```
 
 In the first two lines, you're using [Locators](../concepts-reference/locators.md) to import in `geth.star` and `lighthouse.star` files from Github, making them available to use in your testnet definition. These files themselves are environment definitions that can be used to bootstrap and start up a Geth execution layer client and a Lighthouse consensus layer client as part of your testnet - which is exactly what you will do next.
 
 :::note
-Feel free to check out the [`geth.star`]((https://github.com/kurtosis-tech/geth-package/blob/main/lib/geth.star) and ['lighthouse.star`](https://github.com/kurtosis-tech/lighthouse-package/blob/main/lib/lighthouse.star) to understand how they work. At a high level, the definition instructions Kurtosis to generate genesis data, set up pre-funded accounts, and then launches the client using the client container images.
+Feel free to check out the [`geth.star`](https://github.com/kurtosis-tech/geth-package/blob/main/lib/geth.star) and [`lighthouse.star`](https://github.com/kurtosis-tech/lighthouse-package/blob/main/lib/lighthouse.star) to understand how they work. At a high level, the definition instructions Kurtosis to generate genesis data, set up pre-funded accounts, and then launches the client using the client container images.
 :::
 
 Finally, we are converting the `network_params.json` file into a format that can be used in your environment definition using [`json.decode()`](https://bazel.build/rules/lib/core/json#decode) and [`read_file()`](../starlark-reference/read-file.md).

--- a/docs/docs/guides/how-to-compose-your-own-testnet.md
+++ b/docs/docs/guides/how-to-compose-your-own-testnet.md
@@ -75,7 +75,7 @@ network_params = json.decode(read_file("github.com/$YOUR_GITHUB_USERNAME/my-test
 In the first two lines, you're using [Locators](../concepts-reference/locators.md) to import in `geth.star` and `lighthouse.star` files from Github, making them available to use in your testnet definition. These files themselves are environment definitions that can be used to bootstrap and start up a Geth execution layer client and a Lighthouse consensus layer client as part of your testnet - which is exactly what you will do next.
 
 :::note
-Feel free to check out the [`geth.star`](https://github.com/kurtosis-tech/geth-package/blob/main/lib/geth.star) and [`lighthouse.star`](https://github.com/kurtosis-tech/lighthouse-package/blob/main/lib/lighthouse.star) to understand how they work. At a high level, the definition instructions Kurtosis to generate genesis data, set up pre-funded accounts, and then launches the client using the client container images.
+Feel free to check out the [`geth.star`](https://github.com/kurtosis-tech/geth-package/blob/main/lib/geth.star) and [`lighthouse.star`](https://github.com/kurtosis-tech/lighthouse-package/blob/main/lib/lighthouse.star) to understand how they work. At a high level, the definition instructs Kurtosis to generate genesis data, set up pre-funded accounts, and then launches the client using the client container images.
 :::
 
 Finally, we are converting the `network_params.json` file into a format that can be used in your environment definition using [`json.decode()`](https://bazel.build/rules/lib/core/json#decode) and [`read_file()`](../starlark-reference/read-file.md).


### PR DESCRIPTION
## Description:
https://github.com/kurtosis-tech/kurtosis/pull/1067 has a failing CI check, but because the Cloudflare Publish wasn't listed as a required check it didn't get caught, got merged into `main`, and started `main` failing. This fixes the issue (and I've already updated the monorepo with the Cloudflare Publish to be required)

## Is this change user facing?
NO
