### PR TITLE
docs: update service delete to service rm

### DIFF
--- a/docs/docs/cli-reference/service-rm.md
+++ b/docs/docs/cli-reference/service-rm.md
@@ -1,7 +1,7 @@
 ---
-title: service delete
-sidebar_label: service delete
-slug: /service-delete
+title: service rm
+sidebar_label: service rm
+slug: /service-rm
 ---
 
 Services can be deleted from an enclave like so:


### PR DESCRIPTION
## Description:
Previously, the cli reference for `service rm` was titled `service delete`. This PR changes the title to `service rm` to match our page on `enclave rm` and also because the actual command is `kurtosis service rm` and not `kurtosis service delete`, so this change ensure that the reference is consistent with the actual command.

## Is this change user facing?
YES

## References (if applicable):
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
