### PR TITLE
fix: move where logs aggregator is destroyed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -803,9 +803,9 @@ jobs:
             equal: [ "docker", << parameters.cli-cluster-backend >> ]
           steps:
             - run:
-                name: "Verify only the engine container remains after the clean"
+                name: "Verify only the engine container and logs aggregator remains after the clean"
                 command: |
-                  if ! [ "$(docker container ls -a | tail -n+2 | wc -l)" -eq 1 ]; then
+                  if ! [ "$(docker container ls -a | tail -n+2 | wc -l)" -eq 2 ]; then
                     docker container ls -a
                     false
                   fi

--- a/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/engine_functions/destroy_engines.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/engine_functions/destroy_engines.go
@@ -2,7 +2,6 @@ package engine_functions
 
 import (
 	"context"
-	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/logs_aggregator_functions"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_impls/docker/docker_manager"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_impls/docker/docker_operation_parallelizer"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/engine"
@@ -60,14 +59,6 @@ func DestroyEngines(
 			"An error occurred destroying engine '%v'",
 			guidStr,
 		)
-	}
-
-	// This is a small hack so that the log aggregator isn't cleaned while trying to remove stopped engines (eg. kurtosis clean -a)
-	shouldRemoveLogComponents := len(matchingEnginesByContainerId) == 0
-	if shouldRemoveLogComponents {
-		if err := logs_aggregator_functions.DestroyLogsAggregator(ctx, dockerManager); err != nil {
-			return nil, nil, stacktrace.Propagate(err, "An error occurred removing the logging components.")
-		}
 	}
 
 	return successfulGuids, erroredGuids, nil

--- a/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/engine_functions/stop_engines.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/engine_functions/stop_engines.go
@@ -67,6 +67,7 @@ func StopEngines(
 		)
 	}
 
+	// Stop centralized logging components
 	if err := logs_aggregator_functions.DestroyLogsAggregator(ctx, dockerManager); err != nil {
 		return nil, nil, stacktrace.Propagate(err, "An error occurred removing the logging components.")
 	}

--- a/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/engine_functions/stop_engines.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/engine_functions/stop_engines.go
@@ -2,6 +2,7 @@ package engine_functions
 
 import (
 	"context"
+	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/logs_aggregator_functions"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_impls/docker/docker_manager"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_impls/docker/docker_operation_parallelizer"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/engine"
@@ -64,6 +65,10 @@ func StopEngines(
 			"An error occurred stopping engine '%v'",
 			guidStr,
 		)
+	}
+
+	if err := logs_aggregator_functions.DestroyLogsAggregator(ctx, dockerManager); err != nil {
+		return nil, nil, stacktrace.Propagate(err, "An error occurred removing the logging components.")
 	}
 
 	return successfulGuids, erroredGuids, nil


### PR DESCRIPTION
## Description:
This ensures that log aggregator won't be removed by `kurtosis clean -a`, but will be removed when you stop the engines.

## Is this change user facing?
NO (but now users won't have to restart the engine every time they want to add an enclave after doing a `clean`)

