### PR TITLE
fix: More flexible context config unmarshaller

### DIFF
--- a/contexts-config-store/store/serde/contexts_config.go
+++ b/contexts-config-store/store/serde/contexts_config.go
@@ -16,7 +16,8 @@ func SerializeKurtosisContextsConfig(kurtosisContextsConfig *generated.KurtosisC
 
 func DeserializeKurtosisContextsConfig(serializedKurtosisContextsConfig []byte) (*generated.KurtosisContextsConfig, error) {
 	kurtosisContextsConfig := new(generated.KurtosisContextsConfig)
-	if err := protojson.Unmarshal(serializedKurtosisContextsConfig, kurtosisContextsConfig); err != nil {
+	unmarshaller := protojson.UnmarshalOptions{DiscardUnknown: true}
+	if err := unmarshaller.Unmarshal(serializedKurtosisContextsConfig, kurtosisContextsConfig); err != nil {
 		return nil, stacktrace.Propagate(err, "Unable to deserialize Kurtosis contexts config object")
 	}
 	return kurtosisContextsConfig, nil

--- a/contexts-config-store/store/serde/contexts_config.go
+++ b/contexts-config-store/store/serde/contexts_config.go
@@ -16,7 +16,7 @@ func SerializeKurtosisContextsConfig(kurtosisContextsConfig *generated.KurtosisC
 
 func DeserializeKurtosisContextsConfig(serializedKurtosisContextsConfig []byte) (*generated.KurtosisContextsConfig, error) {
 	kurtosisContextsConfig := new(generated.KurtosisContextsConfig)
-	unmarshaller := protojson.UnmarshalOptions{DiscardUnknown: true}
+	unmarshaller := protojson.UnmarshalOptions{DiscardUnknown: true} // nolint: exhaustruct
 	if err := unmarshaller.Unmarshal(serializedKurtosisContextsConfig, kurtosisContextsConfig); err != nil {
 		return nil, stacktrace.Propagate(err, "Unable to deserialize Kurtosis contexts config object")
 	}

--- a/contexts-config-store/store/serde/contexts_config_test.go
+++ b/contexts-config-store/store/serde/contexts_config_test.go
@@ -53,7 +53,8 @@ var (
 	}],
 	"currentContextUuid":{
 		"value":"dc2a9471c70649b7aafae2448970dd2e"
-	}
+	},
+    "unknownField": "shouldBeIgnored"
 }`
 )
 

--- a/contexts-config-store/store/serde/contexts_config_test.go
+++ b/contexts-config-store/store/serde/contexts_config_test.go
@@ -70,7 +70,9 @@ func TestSerializeContextsConfig(t *testing.T) {
 	writtenContextsConfig := new(generated.KurtosisContextsConfig)
 	require.NoError(t, protojson.Unmarshal(result, writtenContextsConfig))
 	expectedContextsConfig := new(generated.KurtosisContextsConfig)
-	require.NoError(t, protojson.Unmarshal([]byte(serializedContextsConfig), expectedContextsConfig))
+
+	unmarshaller := protojson.UnmarshalOptions{DiscardUnknown: true} // nolint: exhaustruct
+	require.NoError(t, unmarshaller.Unmarshal([]byte(serializedContextsConfig), expectedContextsConfig))
 
 	require.True(t, proto.Equal(writtenContextsConfig, expectedContextsConfig))
 }


### PR DESCRIPTION
## Description:
Without this it's a massive pain to make changes to the context config shape, as it is also consumed by the portal

## Is this change user facing?
NO
<!-- If yes, please add the "user facing" label to the PR -->
<!-- If yes, don't forget to include docs changes where relevant -->

## References (if applicable):
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
