### PR TITLE
fix: enclave name validation to support valid DNS-1035 label rules

### DIFF
--- a/api/golang/engine/lib/enclave/consts.go
+++ b/api/golang/engine/lib/enclave/consts.go
@@ -1,4 +1,5 @@
 package enclave
 
 // We restrict enclave names to 60 characters bc K8s doesn't allow names beyond 63 chars so 63 - 3 ("kt-" prefix) = 60
-const AllowedEnclaveNameCharsRegexStr = `^[-A-Za-z0-9._]{1,60}$`
+// The enclave name has to be a valid DNS-1035 value ("." and "_"  are not allowed) because it's mandatory for creating K8s resources like the namespace name
+const AllowedEnclaveNameCharsRegexStr = `^[-A-Za-z0-9]{1,60}$`

--- a/engine/server/engine/enclave_manager/enclave_name_validator_test.go
+++ b/engine/server/engine/enclave_manager/enclave_name_validator_test.go
@@ -1,19 +1,14 @@
 package enclave_manager
 
 import (
-	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/enclave"
 	"github.com/stretchr/testify/require"
 	"testing"
 )
 
 const (
-	firstEnclaveUuidForTest  = "first-enclave-uuid"
 	firstEnclaveNameForTest  = "first-enclave-name"
-	secondEnclaveUuidForTest = "second-enclave-uuid"
 	secondEnclaveNameForTest = "second-enclave-name"
-	theirEnclaveUuidForTest  = "their-enclave-uuid"
 	theirEnclaveNameForTest  = "their-enclave-name"
-	runningEnclaveStatus     = enclave.EnclaveStatus_Running
 )
 
 var (
@@ -25,11 +20,19 @@ var (
 )
 
 func TestValidateEnclaveId_success(t *testing.T) {
-	err := validateEnclaveName("valid.enclave.id-1234567")
+	err := validateEnclaveName("valid-enclave-id-1234567")
 	require.Nil(t, err)
 
-	err = validateEnclaveName("go-testsuite.startosis_remove_service_test.1668628850670949")
+	err = validateEnclaveName("go-testsuite-startosis-remove-service-test-1668628850670949")
 	require.Nil(t, err)
+}
+
+func TestValidateEnclaveId_failureForDotsAndUnderscore(t *testing.T) {
+	err := validateEnclaveName("valid.enclave.id-1234567")
+	require.Error(t, err)
+
+	err = validateEnclaveName("go-testsuite.startosis_remove_service_test.1668628850670949")
+	require.Error(t, err)
 }
 
 func TestValidateEnclaveId_failureInvalidChar(t *testing.T) {

--- a/internal_testsuites/golang/testsuite/starlark_public_ports_test/starlark_public_ports_test.go
+++ b/internal_testsuites/golang/testsuite/starlark_public_ports_test/starlark_public_ports_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	testName = "starlark_public_ports_test"
+	testName = "starlark-public-ports-test"
 
 	serviceName         = "example-datastore-server-1"
 	portId              = "grpc"


### PR DESCRIPTION
## Description:
enclave name validation to support valid DNS-1035 label rules

## Is this change user facing?
YES

## References (if applicable):
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
