### PR TITLE
feat: Update bucket user folder to also suffix it with enclave UUID

### DIFF
--- a/core/server/api_container/server/service_network/default_service_network.go
+++ b/core/server/api_container/server/service_network/default_service_network.go
@@ -841,6 +841,10 @@ func (network *DefaultServiceNetwork) GetApiContainerInfo() *ApiContainerInfo {
 	return network.apiContainerInfo
 }
 
+func (network *DefaultServiceNetwork) GetEnclaveUuid() enclave.EnclaveUUID {
+	return network.enclaveUuid
+}
+
 // ====================================================================================================
 //
 //	Private helper methods

--- a/core/server/api_container/server/service_network/mock_service_network.go
+++ b/core/server/api_container/server/service_network/mock_service_network.go
@@ -5,8 +5,10 @@ package service_network
 import (
 	context "context"
 
-	exec_result "github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/exec_result"
+	enclave "github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/enclave"
 	enclave_data_directory "github.com/kurtosis-tech/kurtosis/core/server/commons/enclave_data_directory"
+
+	exec_result "github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/exec_result"
 
 	http "net/http"
 
@@ -301,6 +303,47 @@ func (_c *MockServiceNetwork_GetApiContainerInfo_Call) Return(_a0 *ApiContainerI
 }
 
 func (_c *MockServiceNetwork_GetApiContainerInfo_Call) RunAndReturn(run func() *ApiContainerInfo) *MockServiceNetwork_GetApiContainerInfo_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetEnclaveUuid provides a mock function with given fields:
+func (_m *MockServiceNetwork) GetEnclaveUuid() enclave.EnclaveUUID {
+	ret := _m.Called()
+
+	var r0 enclave.EnclaveUUID
+	if rf, ok := ret.Get(0).(func() enclave.EnclaveUUID); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(enclave.EnclaveUUID)
+	}
+
+	return r0
+}
+
+// MockServiceNetwork_GetEnclaveUuid_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetEnclaveUuid'
+type MockServiceNetwork_GetEnclaveUuid_Call struct {
+	*mock.Call
+}
+
+// GetEnclaveUuid is a helper method to define mock.On call
+func (_e *MockServiceNetwork_Expecter) GetEnclaveUuid() *MockServiceNetwork_GetEnclaveUuid_Call {
+	return &MockServiceNetwork_GetEnclaveUuid_Call{Call: _e.mock.On("GetEnclaveUuid")}
+}
+
+func (_c *MockServiceNetwork_GetEnclaveUuid_Call) Run(run func()) *MockServiceNetwork_GetEnclaveUuid_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockServiceNetwork_GetEnclaveUuid_Call) Return(_a0 enclave.EnclaveUUID) *MockServiceNetwork_GetEnclaveUuid_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockServiceNetwork_GetEnclaveUuid_Call) RunAndReturn(run func() enclave.EnclaveUUID) *MockServiceNetwork_GetEnclaveUuid_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/core/server/api_container/server/service_network/service_network.go
+++ b/core/server/api_container/server/service_network/service_network.go
@@ -2,6 +2,7 @@ package service_network
 
 import (
 	"context"
+	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/enclave"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/exec_result"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/service"
 	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/service_network/render_templates"
@@ -114,4 +115,6 @@ type ServiceNetwork interface {
 	GetUniqueNameForFileArtifact() (string, error)
 
 	GetApiContainerInfo() *ApiContainerInfo
+
+	GetEnclaveUuid() enclave.EnclaveUUID
 }

--- a/core/server/api_container/server/startosis_engine/kurtosis_starlark_framework/test_engine/starlark_framework_engine_test.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_starlark_framework/test_engine/starlark_framework_engine_test.go
@@ -150,7 +150,7 @@ func testKurtosisTypeConstructor(t *testing.T, builtin KurtosisTypeConstructorBa
 }
 
 func getBasePredeclaredDict(t *testing.T, thread *starlark.Thread) starlark.StringDict {
-	kurtosisModule, err := builtins.KurtosisModule(thread, "")
+	kurtosisModule, err := builtins.KurtosisModule(thread, "", "")
 	require.Nil(t, err)
 	// TODO: refactor this with the one we have in the interpreter
 	predeclared := starlark.StringDict{

--- a/core/server/api_container/server/startosis_engine/startosis_interpreter.go
+++ b/core/server/api_container/server/startosis_engine/startosis_interpreter.go
@@ -342,7 +342,7 @@ func (interpreter *StartosisInterpreter) buildBindings(thread *starlark.Thread, 
 		return result, nil
 	}
 
-	kurtosisModule, interpretationErr := builtins.KurtosisModule(thread, interpreter.enclaveEnvVars)
+	kurtosisModule, interpretationErr := builtins.KurtosisModule(thread, interpreter.serviceNetwork.GetEnclaveUuid(), interpreter.enclaveEnvVars)
 	if interpretationErr != nil {
 		return nil, interpretationErr
 	}

--- a/core/server/api_container/server/startosis_engine/startosis_interpreter_idempotent_test.go
+++ b/core/server/api_container/server/startosis_engine/startosis_interpreter_idempotent_test.go
@@ -2,6 +2,7 @@ package startosis_engine
 
 import (
 	"context"
+	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/enclave"
 	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/service_network"
 	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/enclave_structure"
 	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/instructions_plan/resolver"
@@ -15,6 +16,8 @@ import (
 )
 
 const (
+	enclaveUuid = enclave.EnclaveUUID("enclave-uuid")
+
 	noInputParams = "{}"
 )
 
@@ -31,6 +34,7 @@ func (suite *StartosisInterpreterIdempotentTestSuite) SetupTest() {
 	serviceNetwork.EXPECT().GetApiContainerInfo().Maybe().Return(
 		service_network.NewApiContainerInfo(net.IPv4(0, 0, 0, 0), uint16(1234), "0.0.0"),
 	)
+	serviceNetwork.EXPECT().GetEnclaveUuid().Maybe().Return(enclaveUuid)
 	suite.interpreter = NewStartosisInterpreter(serviceNetwork, suite.packageContentProvider, runtimeValueStore, "")
 }
 

--- a/core/server/api_container/server/startosis_engine/startosis_interpreter_test.go
+++ b/core/server/api_container/server/startosis_engine/startosis_interpreter_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/kurtosis-tech/kurtosis/api/golang/core/lib/binding_constructors"
+	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/enclave"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/service"
 	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/service_network"
 	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/builtins/print_builtin"
@@ -72,6 +73,7 @@ func (suite *StartosisInterpreterTestSuite) SetupTest() {
 		string(testServiceName),
 	)
 	suite.serviceNetwork.EXPECT().GetUniqueNameForFileArtifact().Maybe().Return(mockFileArtifactName, nil)
+	suite.serviceNetwork.EXPECT().GetEnclaveUuid().Maybe().Return(enclave.EnclaveUUID(mockEnclaveUuid))
 	suite.serviceNetwork.EXPECT().ExistServiceRegistration(testServiceName).Maybe().Return(true, nil)
 }
 


### PR DESCRIPTION
## Description:
Enclave name is now accessible in Starlark via the `kurtosis` global module: `kurtosis.enclave_name`

## Is this change user facing?
YES
<!-- If yes, please add the "user facing" label to the PR -->
<!-- If yes, don't forget to include docs changes where relevant -->

## References (if applicable):
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
