### PR TITLE
fix: fix a sneaky segmentation fault where we were propagating a nil error

### DIFF
--- a/cli/cli/commands/root.go
+++ b/cli/cli/commands/root.go
@@ -314,7 +314,7 @@ func getLatestCLIReleaseVersionFromGitHub() (string, error) {
 
 	latestVersion := strings.TrimLeft(responseObject.TagName, optionalSemverPrefix)
 	if latestVersion == "" {
-		return "", stacktrace.Propagate(err, "The latest release version got from GitHub releases is empty")
+		return "", stacktrace.NewError("The latest release version got from GitHub releases is empty")
 	}
 
 	return latestVersion, nil


### PR DESCRIPTION
## Description:
This is a bug fix where we would attempt to propagate a sneaky segmentation fault that would break the CLI if the GitHub api returned an empty version