### PR TITLE
refactor: Idempotent run small refactor

### DIFF
--- a/core/server/api_container/server/startosis_engine/instructions_plan/instructions_plan.go
+++ b/core/server/api_container/server/startosis_engine/instructions_plan/instructions_plan.go
@@ -15,6 +15,8 @@ import (
 // The only read method is GeneratePlan unwraps the plan into an actual list of instructions that can be submitted to
 // the executor.
 type InstructionsPlan struct {
+	indexOfFirstInstruction int
+
 	scheduledInstructionsIndex map[ScheduledInstructionUuid]*ScheduledInstruction
 
 	instructionsSequence []ScheduledInstructionUuid
@@ -22,9 +24,33 @@ type InstructionsPlan struct {
 
 func NewInstructionsPlan() *InstructionsPlan {
 	return &InstructionsPlan{
+		indexOfFirstInstruction:    0,
 		scheduledInstructionsIndex: map[ScheduledInstructionUuid]*ScheduledInstruction{},
 		instructionsSequence:       []ScheduledInstructionUuid{},
 	}
+}
+
+func (plan *InstructionsPlan) PartialClone(indexOfFirstInstructionToNotClone int) (*InstructionsPlan, error) {
+	newPlan := NewInstructionsPlan()
+	for idx, instructionUuid := range plan.instructionsSequence {
+		if idx >= indexOfFirstInstructionToNotClone {
+			return newPlan, nil
+		}
+		instructionToTransfer, found := plan.scheduledInstructionsIndex[instructionUuid]
+		if !found {
+			return nil, stacktrace.NewError("Instruction with UUID '%s' was part of the instruction sequence but could not be found in the instruction index. This is a Kurtosis internal issue", instructionUuid)
+		}
+		newPlan.AddScheduledInstruction(instructionToTransfer)
+	}
+	return newPlan, nil
+}
+
+func (plan *InstructionsPlan) SetIndexOfFirstInstruction(indexOfFirstInstruction int) {
+	plan.indexOfFirstInstruction = indexOfFirstInstruction
+}
+
+func (plan *InstructionsPlan) GetIndexOfFirstInstruction() int {
+	return plan.indexOfFirstInstruction
 }
 
 func (plan *InstructionsPlan) AddInstruction(instruction kurtosis_instruction.KurtosisInstruction, returnedValue starlark.Value) error {
@@ -45,7 +71,6 @@ func (plan *InstructionsPlan) AddScheduledInstruction(scheduledInstruction *Sche
 	newScheduledInstructionUuid := scheduledInstruction.uuid
 	newScheduledInstruction := NewScheduledInstruction(newScheduledInstructionUuid, scheduledInstruction.kurtosisInstruction, scheduledInstruction.returnedValue)
 	newScheduledInstruction.Executed(scheduledInstruction.IsExecuted())
-	newScheduledInstruction.ImportedFromCurrentEnclavePlan(scheduledInstruction.IsImportedFromCurrentEnclavePlan())
 
 	plan.scheduledInstructionsIndex[newScheduledInstructionUuid] = newScheduledInstruction
 	plan.instructionsSequence = append(plan.instructionsSequence, newScheduledInstructionUuid)

--- a/core/server/api_container/server/startosis_engine/instructions_plan/scheduled_instruction.go
+++ b/core/server/api_container/server/startosis_engine/instructions_plan/scheduled_instruction.go
@@ -20,17 +20,14 @@ type ScheduledInstruction struct {
 	returnedValue starlark.Value
 
 	executed bool
-
-	importedFromCurrentEnclavePlan bool
 }
 
 func NewScheduledInstruction(uuid ScheduledInstructionUuid, kurtosisInstruction kurtosis_instruction.KurtosisInstruction, returnedValue starlark.Value) *ScheduledInstruction {
 	return &ScheduledInstruction{
-		uuid:                           uuid,
-		kurtosisInstruction:            kurtosisInstruction,
-		returnedValue:                  returnedValue,
-		executed:                       false,
-		importedFromCurrentEnclavePlan: false,
+		uuid:                uuid,
+		kurtosisInstruction: kurtosisInstruction,
+		returnedValue:       returnedValue,
+		executed:            false,
 	}
 }
 
@@ -49,13 +46,4 @@ func (instruction *ScheduledInstruction) Executed(isExecuted bool) *ScheduledIns
 
 func (instruction *ScheduledInstruction) IsExecuted() bool {
 	return instruction.executed
-}
-
-func (instruction *ScheduledInstruction) ImportedFromCurrentEnclavePlan(importedFromCurrentEnclavePlan bool) *ScheduledInstruction {
-	instruction.importedFromCurrentEnclavePlan = importedFromCurrentEnclavePlan
-	return instruction
-}
-
-func (instruction *ScheduledInstruction) IsImportedFromCurrentEnclavePlan() bool {
-	return instruction.importedFromCurrentEnclavePlan
 }

--- a/core/server/api_container/server/startosis_engine/kurtosis_starlark_framework/kurtosis_plan_instruction/kurtosis_plan_instruction.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_starlark_framework/kurtosis_plan_instruction/kurtosis_plan_instruction.go
@@ -70,7 +70,7 @@ func (builtin *KurtosisPlanInstructionWrapper) CreateBuiltin() func(thread *star
 		switch instructionResolutionStatus {
 		case enclave_structure.InstructionIsEqual:
 			// add instruction from the mask and mark it as executed but not imported from the current enclave plan
-			builtin.instructionsPlan.AddScheduledInstruction(scheduledInstructionPulledFromMaskMaybe).Executed(true).ImportedFromCurrentEnclavePlan(false)
+			builtin.instructionsPlan.AddScheduledInstruction(scheduledInstructionPulledFromMaskMaybe).Executed(true)
 			return scheduledInstructionPulledFromMaskMaybe.GetReturnedValue(), nil
 		case enclave_structure.InstructionIsUpdate:
 			// otherwise add the instruction as a new one to the plan and return its own returned value

--- a/core/server/api_container/server/startosis_engine/startosis_executor.go
+++ b/core/server/api_container/server/startosis_engine/startosis_executor.go
@@ -51,7 +51,7 @@ func NewStartosisExecutor(runtimeValueStore *runtime_value_store.RuntimeValueSto
 // - A regular KurtosisInstruction that was successfully executed
 // - A KurtosisExecutionError if the execution failed
 // - A ProgressInfo to update the current "state" of the execution
-func (executor *StartosisExecutor) Execute(ctx context.Context, dryRun bool, parallelism int, instructionsSequence []*instructions_plan.ScheduledInstruction, serializedScriptOutput string) <-chan *kurtosis_core_rpc_api_bindings.StarlarkRunResponseLine {
+func (executor *StartosisExecutor) Execute(ctx context.Context, dryRun bool, parallelism int, indexOfFirstInstructionInEnclavePlan int, instructionsSequence []*instructions_plan.ScheduledInstruction, serializedScriptOutput string) <-chan *kurtosis_core_rpc_api_bindings.StarlarkRunResponseLine {
 	executor.mutex.Lock()
 	starlarkRunResponseLineStream := make(chan *kurtosis_core_rpc_api_bindings.StarlarkRunResponseLine)
 	ctxWithParallelism := context.WithValue(ctx, startosis_constants.ParallelismParam, parallelism)
@@ -62,18 +62,20 @@ func (executor *StartosisExecutor) Execute(ctx context.Context, dryRun bool, par
 		}()
 
 		// TODO: for now the plan is append only, as each Starlark run happens on top of whatever exists in the enclave
-		logrus.Debugf("Current enclave plan contains %d instuctions. About to process a new plan with %d instructions (dry-run: %v)",
-			executor.enclavePlan.Size(), len(instructionsSequence), dryRun)
+		logrus.Debugf("Current enclave plan contains %d instuctions. About to process a new plan with %d instructions starting at index %d (dry-run: %v)",
+			executor.enclavePlan.Size(), len(instructionsSequence), indexOfFirstInstructionInEnclavePlan, dryRun)
 
-		executor.enclavePlan = instructions_plan.NewInstructionsPlan()
+		var err error
+		executor.enclavePlan, err = executor.enclavePlan.PartialClone(indexOfFirstInstructionInEnclavePlan)
+		if err != nil {
+			sendErrorAndFail(starlarkRunResponseLineStream, err, "An error occurred keeping the enclave plan up to date with the current enclave state")
+		}
+
+		logrus.Debugf("Transfered %d instructions from previous enclave plan to keep the enclave state consistent", executor.enclavePlan.Size())
+
 		totalNumberOfInstructions := uint32(len(instructionsSequence))
 		for index, scheduledInstruction := range instructionsSequence {
 			instructionNumber := uint32(index + 1)
-
-			if scheduledInstruction.IsImportedFromCurrentEnclavePlan() {
-				executor.enclavePlan.AddScheduledInstruction(scheduledInstruction).Executed(true).ImportedFromCurrentEnclavePlan(true)
-				continue
-			}
 			progress := binding_constructors.NewStarlarkRunResponseLineFromSinglelineProgressInfo(
 				progressMsg, instructionNumber, totalNumberOfInstructions)
 			starlarkRunResponseLineStream <- progress

--- a/core/server/api_container/server/startosis_engine/startosis_executor_test.go
+++ b/core/server/api_container/server/startosis_engine/startosis_executor_test.go
@@ -44,10 +44,6 @@ func TestExecuteKurtosisInstructions_ExecuteForReal_Success(t *testing.T) {
 	executor := NewStartosisExecutor(runtimeValueStore)
 
 	instructionsPlan := instructions_plan.NewInstructionsPlan()
-	instruction0 := createMockInstruction(t, "instruction0", executeSuccessfully)
-	scheduledInstruction0 := instructions_plan.NewScheduledInstruction("instruction0", instruction0, starlark.None).Executed(true).ImportedFromCurrentEnclavePlan(true)
-	instructionsPlan.AddScheduledInstruction(scheduledInstruction0)
-
 	instruction1 := createMockInstruction(t, "instruction1", executeSuccessfully)
 	scheduledInstruction1 := instructions_plan.NewScheduledInstruction("instruction1", instruction1, starlark.None).Executed(true)
 	instructionsPlan.AddScheduledInstruction(scheduledInstruction1)
@@ -60,8 +56,6 @@ func TestExecuteKurtosisInstructions_ExecuteForReal_Success(t *testing.T) {
 	require.Equal(t, executor.enclavePlan.Size(), 0) // check that the enclave plan is empty prior to execution
 
 	_, serializedInstruction, err := executeSynchronously(t, executor, executeForReal, instructionsPlan)
-	instruction0.AssertNumberOfCalls(t, "GetCanonicalInstruction", 0) // skipped directly
-	instruction0.AssertNumberOfCalls(t, "Execute", 0)
 	instruction1.AssertNumberOfCalls(t, "GetCanonicalInstruction", 1)
 	instruction1.AssertNumberOfCalls(t, "Execute", 0) // not executed as it was already executed
 	instruction2.AssertNumberOfCalls(t, "GetCanonicalInstruction", 1)
@@ -80,7 +74,7 @@ func TestExecuteKurtosisInstructions_ExecuteForReal_Success(t *testing.T) {
 			dummyPosition.ToAPIType(), "instruction3", "instruction3()", noInstructionArgsForTesting, isSkipped),
 	}
 	require.Equal(t, expectedSerializedInstructions, serializedInstruction)
-	require.Equal(t, executor.enclavePlan.Size(), 4) // check that the enclave plan now contains the 4 instructions
+	require.Equal(t, executor.enclavePlan.Size(), 3) // check that the enclave plan now contains the 4 instructions
 }
 
 func TestExecuteKurtosisInstructions_ExecuteForReal_FailureHalfWay(t *testing.T) {
@@ -182,7 +176,7 @@ func executeSynchronously(t *testing.T, executor *StartosisExecutor, dryRun bool
 	scheduledInstructions, err := instructionsPlan.GeneratePlan()
 	require.Nil(t, err)
 
-	executionResponseLines := executor.Execute(context.Background(), dryRun, noParallelism, scheduledInstructions, noScriptOutputObject)
+	executionResponseLines := executor.Execute(context.Background(), dryRun, noParallelism, 0, scheduledInstructions, noScriptOutputObject)
 	for executionResponseLine := range executionResponseLines {
 		if executionResponseLine.GetError() != nil {
 			return scriptOutput.String(), serializedInstructions, executionResponseLine.GetError().GetExecutionError()

--- a/core/server/api_container/server/startosis_engine/startosis_interpreter.go
+++ b/core/server/api_container/server/startosis_engine/startosis_interpreter.go
@@ -138,7 +138,7 @@ func (interpreter *StartosisInterpreter) InterpretAndOptimizePlan(
 			// we found a match
 			// -> First recopy store that index into the plan so that all instructions prior to this match will be
 			// kept in the enclave plan
-			logrus.Debugf("Stored index of mathcing instructions: %d into the new plan. The instructions prior to this index in the enclave plan won't be executed but need to be kept in the enclave plan", matchingInstructionIdx)
+			logrus.Debugf("Stored index of matching instructions: %d into the new plan. The instructions prior to this index in the enclave plan won't be executed but need to be kept in the enclave plan", matchingInstructionIdx)
 			optimizedPlan.SetIndexOfFirstInstruction(matchingInstructionIdx)
 			// -> Then recopy all instructions past this match from the enclave state to the mask
 			// Those instructions are the instructions that will mask the instructions for the newly submitted plan

--- a/core/server/api_container/server/startosis_engine/startosis_interpreter.go
+++ b/core/server/api_container/server/startosis_engine/startosis_interpreter.go
@@ -136,12 +136,10 @@ func (interpreter *StartosisInterpreter) InterpretAndOptimizePlan(
 		if matchingInstructionIdx >= 0 {
 			logrus.Debugf("Found an instruction in enclave state at index %d which matches the first instruction of the new instructions plan", matchingInstructionIdx)
 			// we found a match
-			// -> First recopy all enclave state instructions prior to this match to the optimized plan. Those won't
-			// be executed, but they need to be part of the plan to keep the state of the enclave accurate
-			logrus.Debugf("Copying %d instructions from current enclave plan to new plan. Those instructions won't be executed but need to be kept in the enclave plan", matchingInstructionIdx)
-			for i := 0; i < matchingInstructionIdx; i++ {
-				optimizedPlan.AddScheduledInstruction(currentEnclavePlanSequence[i]).ImportedFromCurrentEnclavePlan(true).Executed(true)
-			}
+			// -> First recopy store that index into the plan so that all instructions prior to this match will be
+			// kept in the enclave plan
+			logrus.Debugf("Stored index of mathcing instructions: %d into the new plan. The instructions prior to this index in the enclave plan won't be executed but need to be kept in the enclave plan", matchingInstructionIdx)
+			optimizedPlan.SetIndexOfFirstInstruction(matchingInstructionIdx)
 			// -> Then recopy all instructions past this match from the enclave state to the mask
 			// Those instructions are the instructions that will mask the instructions for the newly submitted plan
 			numberOfInstructionCopiedToMask := 0
@@ -156,9 +154,7 @@ func (interpreter *StartosisInterpreter) InterpretAndOptimizePlan(
 			logrus.Debugf("Writing %d instruction at the beginning of the plan mask, leaving %d empty at the end", numberOfInstructionCopiedToMask, potentialMask.Size()-numberOfInstructionCopiedToMask)
 		} else {
 			// We cannot find any more instructions inside the enclave state matching the first instruction of the plan
-			for _, currentPlanInstruction := range currentEnclavePlanSequence {
-				optimizedPlan.AddScheduledInstruction(currentPlanInstruction).ImportedFromCurrentEnclavePlan(true).Executed(true)
-			}
+			optimizedPlan.SetIndexOfFirstInstruction(currentEnclavePlan.Size())
 			for _, newPlanInstruction := range naiveInstructionsPlanSequence {
 				optimizedPlan.AddScheduledInstruction(newPlanInstruction)
 			}

--- a/core/server/api_container/server/startosis_engine/startosis_interpreter_idempotent_test.go
+++ b/core/server/api_container/server/startosis_engine/startosis_interpreter_idempotent_test.go
@@ -90,17 +90,14 @@ func (suite *StartosisInterpreterIdempotentTestSuite) TestInterpretAndOptimize_I
 
 	scheduledInstruction1 := instructionSequence[0]
 	require.Equal(suite.T(), `print(msg="instruction1")`, scheduledInstruction1.GetInstruction().String())
-	require.False(suite.T(), scheduledInstruction1.IsImportedFromCurrentEnclavePlan())
 	require.True(suite.T(), scheduledInstruction1.IsExecuted())
 
 	scheduledInstruction2 := instructionSequence[1]
 	require.Equal(suite.T(), `print(msg="instruction2")`, scheduledInstruction2.GetInstruction().String())
-	require.False(suite.T(), scheduledInstruction2.IsImportedFromCurrentEnclavePlan())
 	require.True(suite.T(), scheduledInstruction2.IsExecuted())
 
 	scheduledInstruction3 := instructionSequence[2]
 	require.Equal(suite.T(), `print(msg="instruction3")`, scheduledInstruction3.GetInstruction().String())
-	require.False(suite.T(), scheduledInstruction3.IsImportedFromCurrentEnclavePlan())
 	require.True(suite.T(), scheduledInstruction3.IsExecuted())
 }
 
@@ -146,21 +143,19 @@ func (suite *StartosisInterpreterIdempotentTestSuite) TestInterpretAndOptimize_A
 
 	instructionSequence, err := instructionsPlan.GeneratePlan()
 	require.Nil(suite.T(), err)
+	require.Equal(suite.T(), 0, instructionsPlan.GetIndexOfFirstInstruction())
 	require.Equal(suite.T(), 3, len(instructionSequence))
 
 	scheduledInstruction1 := instructionSequence[0]
 	require.Equal(suite.T(), `print(msg="instruction1")`, scheduledInstruction1.GetInstruction().String())
-	require.False(suite.T(), scheduledInstruction1.IsImportedFromCurrentEnclavePlan())
 	require.True(suite.T(), scheduledInstruction1.IsExecuted())
 
 	scheduledInstruction2 := instructionSequence[1]
 	require.Equal(suite.T(), `print(msg="instruction2")`, scheduledInstruction2.GetInstruction().String())
-	require.False(suite.T(), scheduledInstruction2.IsImportedFromCurrentEnclavePlan())
 	require.True(suite.T(), scheduledInstruction2.IsExecuted())
 
 	scheduledInstruction3 := instructionSequence[2]
 	require.Equal(suite.T(), `print(msg="instruction3")`, scheduledInstruction3.GetInstruction().String())
-	require.False(suite.T(), scheduledInstruction3.IsImportedFromCurrentEnclavePlan())
 	require.False(suite.T(), scheduledInstruction3.IsExecuted())
 }
 
@@ -204,25 +199,15 @@ func (suite *StartosisInterpreterIdempotentTestSuite) TestInterpretAndOptimize_D
 
 	instructionSequence, err := instructionsPlan.GeneratePlan()
 	require.Nil(suite.T(), err)
-	require.Equal(suite.T(), 3, len(instructionSequence))
+	require.Equal(suite.T(), 2, instructionsPlan.GetIndexOfFirstInstruction()) // the first 2 instruction are kept
+	require.Equal(suite.T(), 1, len(instructionSequence))                      // the new one is the only one inside the plan
 
-	scheduledInstruction1 := instructionSequence[0]
-	require.Equal(suite.T(), `print(msg="instruction1")`, scheduledInstruction1.GetInstruction().String())
-	require.True(suite.T(), scheduledInstruction1.IsImportedFromCurrentEnclavePlan())
-	require.True(suite.T(), scheduledInstruction1.IsExecuted())
-
-	scheduledInstruction2 := instructionSequence[1]
-	require.Equal(suite.T(), `print(msg="instruction2")`, scheduledInstruction2.GetInstruction().String())
-	require.True(suite.T(), scheduledInstruction2.IsImportedFromCurrentEnclavePlan())
-	require.True(suite.T(), scheduledInstruction2.IsExecuted())
-
-	scheduledInstruction3 := instructionSequence[2]
+	scheduledInstruction3 := instructionSequence[0]
 	require.Equal(suite.T(), `print(msg="instruction3")`, scheduledInstruction3.GetInstruction().String())
-	require.False(suite.T(), scheduledInstruction3.IsImportedFromCurrentEnclavePlan())
 	require.False(suite.T(), scheduledInstruction3.IsExecuted())
 }
 
-// Submit a package with a update on an instruction located "in the middle" of the package
+// Submit a package with an update on an instruction located "in the middle" of the package
 // Current plan ->     [`print("instruction1")`  `print("instruction2")`      `print("instruction3")`]
 // Package to run ->   [`print("instruction1")`  `print("instruction2_NEW")`  `print("instruction3")`]
 // That will result in the concatenation of the two plans because we're not able to properly resolve dependencies yet
@@ -266,36 +251,19 @@ func (suite *StartosisInterpreterIdempotentTestSuite) TestInterpretAndOptimize_I
 
 	instructionSequence, err := instructionsPlan.GeneratePlan()
 	require.Nil(suite.T(), err)
-	require.Equal(suite.T(), 6, len(instructionSequence))
+	require.Equal(suite.T(), 3, instructionsPlan.GetIndexOfFirstInstruction())
+	require.Equal(suite.T(), 3, len(instructionSequence))
 
-	scheduledInstruction1 := instructionSequence[0]
-	require.Equal(suite.T(), `print(msg="instruction1")`, scheduledInstruction1.GetInstruction().String())
-	require.True(suite.T(), scheduledInstruction1.IsImportedFromCurrentEnclavePlan())
-	require.True(suite.T(), scheduledInstruction1.IsExecuted())
-
-	scheduledInstruction2 := instructionSequence[1]
-	require.Equal(suite.T(), `print(msg="instruction2")`, scheduledInstruction2.GetInstruction().String())
-	require.True(suite.T(), scheduledInstruction2.IsImportedFromCurrentEnclavePlan())
-	require.True(suite.T(), scheduledInstruction2.IsExecuted())
-
-	scheduledInstruction3 := instructionSequence[2]
-	require.Equal(suite.T(), `print(msg="instruction3")`, scheduledInstruction3.GetInstruction().String())
-	require.True(suite.T(), scheduledInstruction3.IsImportedFromCurrentEnclavePlan())
-	require.True(suite.T(), scheduledInstruction3.IsExecuted())
-
-	scheduledInstruction4 := instructionSequence[3]
+	scheduledInstruction4 := instructionSequence[0]
 	require.Equal(suite.T(), `print(msg="instruction1")`, scheduledInstruction4.GetInstruction().String())
-	require.False(suite.T(), scheduledInstruction4.IsImportedFromCurrentEnclavePlan())
 	require.False(suite.T(), scheduledInstruction4.IsExecuted())
 
-	scheduledInstruction5 := instructionSequence[4]
+	scheduledInstruction5 := instructionSequence[1]
 	require.Equal(suite.T(), `print(msg="instruction2_NEW")`, scheduledInstruction5.GetInstruction().String())
-	require.False(suite.T(), scheduledInstruction5.IsImportedFromCurrentEnclavePlan())
 	require.False(suite.T(), scheduledInstruction5.IsExecuted())
 
-	scheduledInstruction6 := instructionSequence[5]
+	scheduledInstruction6 := instructionSequence[2]
 	require.Equal(suite.T(), `print(msg="instruction3")`, scheduledInstruction6.GetInstruction().String())
-	require.False(suite.T(), scheduledInstruction6.IsImportedFromCurrentEnclavePlan())
 	require.False(suite.T(), scheduledInstruction6.IsExecuted())
 }
 
@@ -342,26 +310,23 @@ func (suite *StartosisInterpreterIdempotentTestSuite) TestInterpretAndOptimize_A
 
 	instructionSequence, err := instructionsPlan.GeneratePlan()
 	require.Nil(suite.T(), err)
+	require.Equal(suite.T(), 0, instructionsPlan.GetIndexOfFirstInstruction())
 	require.Equal(suite.T(), 4, len(instructionSequence))
 
 	scheduledInstruction1 := instructionSequence[0]
 	require.Equal(suite.T(), `add_service(name="service_1", config=ServiceConfig(image="kurtosistech/image:1.5.0"))`, scheduledInstruction1.GetInstruction().String())
-	require.False(suite.T(), scheduledInstruction1.IsImportedFromCurrentEnclavePlan())
 	require.False(suite.T(), scheduledInstruction1.IsExecuted())
 
 	scheduledInstruction2 := instructionSequence[1]
 	require.Regexp(suite.T(), `print\(msg="Service 1 - IP: {{kurtosis:[a-z0-9]{32}:ip_address\.runtime_value}} - Hostname: {{kurtosis:[a-z0-9]{32}:hostname\.runtime_value}}"\)`, scheduledInstruction2.GetInstruction().String())
-	require.False(suite.T(), scheduledInstruction2.IsImportedFromCurrentEnclavePlan())
 	require.True(suite.T(), scheduledInstruction2.IsExecuted())
 
 	scheduledInstruction3 := instructionSequence[2]
 	require.Equal(suite.T(), `exec(service_name="service_1", recipe=ExecRecipe(command=["echo", "Hello World!"]))`, scheduledInstruction3.GetInstruction().String())
-	require.False(suite.T(), scheduledInstruction3.IsImportedFromCurrentEnclavePlan())
 	require.False(suite.T(), scheduledInstruction3.IsExecuted())
 
 	scheduledInstruction4 := instructionSequence[3]
 	require.Regexp(suite.T(), `assert\(value="{{kurtosis:[a-z0-9]{32}:ip_address\.runtime_value}}", assertion="==", target_value="fake_ip"\)`, scheduledInstruction4.GetInstruction().String())
-	require.False(suite.T(), scheduledInstruction4.IsImportedFromCurrentEnclavePlan())
 	require.True(suite.T(), scheduledInstruction4.IsExecuted())
 }
 
@@ -418,25 +383,22 @@ func (suite *StartosisInterpreterIdempotentTestSuite) TestInterpretAndOptimize_U
 
 	instructionSequence, err := instructionsPlan.GeneratePlan()
 	require.Nil(suite.T(), err)
+	require.Equal(suite.T(), 0, instructionsPlan.GetIndexOfFirstInstruction())
 	require.Equal(suite.T(), 4, len(instructionSequence))
 
 	scheduledInstruction1 := instructionSequence[0]
 	require.Equal(suite.T(), `render_templates(config={"/output.txt": struct(data={"World": "World!"}, template="Bonjour {{.World}}")}, name="files_artifact")`, scheduledInstruction1.GetInstruction().String())
-	require.False(suite.T(), scheduledInstruction1.IsImportedFromCurrentEnclavePlan())
 	require.False(suite.T(), scheduledInstruction1.IsExecuted())
 
 	scheduledInstruction2 := instructionSequence[1]
 	require.Equal(suite.T(), `add_service(name="service_1", config=ServiceConfig(image="kurtosistech/image:1.2.3", files={"/path/": "files_artifact"}))`, scheduledInstruction2.GetInstruction().String())
-	require.False(suite.T(), scheduledInstruction2.IsImportedFromCurrentEnclavePlan())
 	require.False(suite.T(), scheduledInstruction2.IsExecuted()) // since the files artifact has been updated, the service will be updated as well
 
 	scheduledInstruction3 := instructionSequence[2]
 	require.Equal(suite.T(), `exec(service_name="service_1", recipe=ExecRecipe(command=["echo", "Hello World!"]))`, scheduledInstruction3.GetInstruction().String())
-	require.False(suite.T(), scheduledInstruction3.IsImportedFromCurrentEnclavePlan())
 	require.False(suite.T(), scheduledInstruction3.IsExecuted()) // since the service has been updated, the exec will be re-run
 
 	scheduledInstruction4 := instructionSequence[3]
 	require.Regexp(suite.T(), `assert\(value="{{kurtosis:[a-z0-9]{32}:ip_address\.runtime_value}}", assertion="==", target_value="fake_ip"\)`, scheduledInstruction4.GetInstruction().String())
-	require.False(suite.T(), scheduledInstruction4.IsImportedFromCurrentEnclavePlan())
 	require.True(suite.T(), scheduledInstruction4.IsExecuted()) // this instruction is not affected, i.e. it won't be re-run
 }

--- a/core/server/api_container/server/startosis_engine/startosis_runner.go
+++ b/core/server/api_container/server/startosis_engine/startosis_runner.go
@@ -154,7 +154,7 @@ func (runner *StartosisRunner) Run(
 			startingExecutionMsg, defaultCurrentStepNumber, totalNumberOfInstructions)
 		starlarkRunResponseLines <- progressInfo
 
-		executionResponseLinesChan := runner.startosisExecutor.Execute(ctx, dryRun, parallelism, instructionsSequence, serializedScriptOutput)
+		executionResponseLinesChan := runner.startosisExecutor.Execute(ctx, dryRun, parallelism, instructionsPlan.GetIndexOfFirstInstruction(), instructionsSequence, serializedScriptOutput)
 		if isRunFinished, isRunSuccessful := forwardKurtosisResponseLineChannelUntilSourceIsClosed(executionResponseLinesChan, starlarkRunResponseLines); !isRunFinished {
 			logrus.Warnf("Execution finished but no 'RunFinishedEvent' was received through the stream. This is unexpected as every execution should be terminal.")
 		} else if !isRunSuccessful {

--- a/core/server/api_container/server/startosis_engine/startosis_validator.go
+++ b/core/server/api_container/server/startosis_engine/startosis_validator.go
@@ -100,7 +100,7 @@ func (validator *StartosisValidator) Validate(ctx context.Context, instructionsS
 func (validator *StartosisValidator) validateAndUpdateEnvironment(instructionsSequence []*instructions_plan.ScheduledInstruction, environment *startosis_validator.ValidatorEnvironment, starlarkRunResponseLineStream chan *kurtosis_core_rpc_api_bindings.StarlarkRunResponseLine) bool {
 	isValidationFailure := false
 	for _, scheduledInstruction := range instructionsSequence {
-		if scheduledInstruction.IsImportedFromCurrentEnclavePlan() || scheduledInstruction.IsExecuted() {
+		if scheduledInstruction.IsExecuted() {
 			// no need to validate the instruction as it won't be executed in this round
 			continue
 		}


### PR DESCRIPTION
## Description:
Idempotent runs do not copy the instructions that were already executed inside the enclave but not present in the interpreted script anymore.

## Is this change user facing?
NO
<!-- If yes, please add the "user facing" label to the PR -->
<!-- If yes, don't forget to include docs changes where relevant -->

## References (if applicable):
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
