### PR TITLE
docs: add docs for pinning package versions with import_module()

### DIFF
--- a/docs/docs/faq.md
+++ b/docs/docs/faq.md
@@ -62,7 +62,7 @@ Does Kurtosis expose ports to the public internet?
 --------------------------------------------------
 Kurtosis does not allow you to expose any ports in your enclave to the internet. Service ports in enclaves are automatically mapped to ports on your local machine.
 
-How do I pin a specific version of an upstream/dependent package that I want to import into my own package?
+How do I pin a specific version of package that my package depends on?
 -----------------------------------------------------------------------------------------------------------
 To pin the specific version of a dependent package, simply do:
 ```py

--- a/docs/docs/faq.md
+++ b/docs/docs/faq.md
@@ -64,7 +64,7 @@ Kurtosis does not allow you to expose any ports in your enclave to the internet.
 
 How do I pin a specific version of package that my package depends on?
 -----------------------------------------------------------------------------------------------------------
-To pin the specific version of a dependent package, simply do:
+To pin the specific version of a package dependency (i.e. a package that your package depends on), simply do:
 ```python
 # Import remote code from another package using an absolute import for a specific version of 1.0
 database = import_module("github.com/foo/bar/src/postgres.star@1.0")

--- a/docs/docs/faq.md
+++ b/docs/docs/faq.md
@@ -61,3 +61,16 @@ def run():
 Does Kurtosis expose ports to the public internet?
 --------------------------------------------------
 Kurtosis does not allow you to expose any ports in your enclave to the internet. Service ports in enclaves are automatically mapped to ports on your local machine.
+
+How do I pin a specific version of an upstream/dependent package that I want to import into my own package?
+-----------------------------------------------------------------------------------------------------------
+To pin the specific version of a dependent package, simply do:
+```py
+# Import remote code from another package using an absolute import for a specific version of 1.0
+database = import_module("github.com/foo/bar/src/postgres.star@1.0")
+
+# Import local code from the same package using a relative import for a specific package version of 2.0
+nginx = import_module("/nginx.star@2.0")
+```
+
+More details can be found in the [`import_module()` Starlark reference](./starlark-reference/import-module.md)

--- a/docs/docs/faq.md
+++ b/docs/docs/faq.md
@@ -65,7 +65,7 @@ Kurtosis does not allow you to expose any ports in your enclave to the internet.
 How do I pin a specific version of package that my package depends on?
 -----------------------------------------------------------------------------------------------------------
 To pin the specific version of a dependent package, simply do:
-```py
+```python
 # Import remote code from another package using an absolute import for a specific version of 1.0
 database = import_module("github.com/foo/bar/src/postgres.star@1.0")
 ```

--- a/docs/docs/faq.md
+++ b/docs/docs/faq.md
@@ -49,7 +49,7 @@ def run()...
 def getConfig()...
 ```
 
-Then you can technically add services from `service.star` in parallel into your package with:
+Then you can technically add services from `serviceA.star` in parallel into your package with:
 ```
 a = import_module("/serviceA.star")
 

--- a/docs/docs/faq.md
+++ b/docs/docs/faq.md
@@ -63,7 +63,7 @@ Does Kurtosis expose ports to the public internet?
 Kurtosis does not allow you to expose any ports in your enclave to the internet. Service ports in enclaves are automatically mapped to ports on your local machine.
 
 How do I pin a specific version of package that my package depends on?
------------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------
 To pin the specific version of a package dependency (i.e. a package that your package depends on), simply do:
 ```python
 # Import remote code from another package using an absolute import for a specific version of 1.0

--- a/docs/docs/faq.md
+++ b/docs/docs/faq.md
@@ -51,7 +51,7 @@ def getConfig()...
 
 Then you can technically add services from `serviceA.star` in parallel into your package with:
 ```
-a = import_module("/serviceA.star")
+a = import_module("./serviceA.star")
 
 def run():
    a_config = a.getConfig()
@@ -68,9 +68,6 @@ To pin the specific version of a dependent package, simply do:
 ```py
 # Import remote code from another package using an absolute import for a specific version of 1.0
 database = import_module("github.com/foo/bar/src/postgres.star@1.0")
-
-# Import local code from the same package using a relative import for a specific package version of 2.0
-nginx = import_module("/nginx.star@2.0")
 ```
 
 More details can be found in the [`import_module()` Starlark reference](./starlark-reference/import-module.md)

--- a/docs/docs/faq.md
+++ b/docs/docs/faq.md
@@ -42,19 +42,19 @@ Adding services in parallel is a great way to speed up how quickly your distribu
 
 However, when it comes to adding multiple services from different packages, you must do so within the `plan.add_services` instruction with the configuration for each service in a dictionary. You cannot currently import multiple packages (using locators) and run them in parallel without using the `plan.add_services` instruction because the call to `run` each of those imported packages starts the service itself.
 
-As an example, if you have a `service_a.star` file that looks like this:
-```py
+As an example, if you have a `serviceA.star` file that looks like this:
+```
 def run()...
 
-def get_config()...
+def getConfig()...
 ```
 
-Then you can technically add services from `service_a.star` in parallel into your package with:
-```py
-a = import_module("./service_a.star")
+Then you can technically add services from `service.star` in parallel into your package with:
+```
+a = import_module("/serviceA.star")
 
 def run():
-   a_config = a.get_gonfig()
+   a_config = a.getConfig()
    plan.add_services({"a": a_config})
 ``` 
 

--- a/docs/docs/faq.md
+++ b/docs/docs/faq.md
@@ -42,19 +42,19 @@ Adding services in parallel is a great way to speed up how quickly your distribu
 
 However, when it comes to adding multiple services from different packages, you must do so within the `plan.add_services` instruction with the configuration for each service in a dictionary. You cannot currently import multiple packages (using locators) and run them in parallel without using the `plan.add_services` instruction because the call to `run` each of those imported packages starts the service itself.
 
-As an example, if you have a `serviceA.star` file that looks like this:
-```
+As an example, if you have a `service_a.star` file that looks like this:
+```py
 def run()...
 
-def getConfig()...
+def get_config()...
 ```
 
-Then you can technically add services from `serviceA.star` in parallel into your package with:
-```
-a = import_module("./serviceA.star")
+Then you can technically add services from `service_a.star` in parallel into your package with:
+```py
+a = import_module("./service_a.star")
 
 def run():
-   a_config = a.getConfig()
+   a_config = a.get_gonfig()
    plan.add_services({"a": a_config})
 ``` 
 

--- a/docs/docs/starlark-reference/import-module.md
+++ b/docs/docs/starlark-reference/import-module.md
@@ -9,6 +9,9 @@ The `import_module` function imports the symbols from a Starlark script specifie
 # Import remote code from another package using an absolute import
 remote = import_module("github.com/foo/bar/src/lib.star")
 
+# Simiarily, you can also import a specific version (e.g. 2.0) of an upstream package using an absolute import
+remote_2 = import_module("github.com/foo/bar/src/lib.star@2.0")
+
 # Import local code from the same package using a relative import
 local = import_module("./local.star")
 


### PR DESCRIPTION
## Description:
This PR adds a code example and a short blurb in our FAQ on how to pin specific versions of packages when using the `import_module()` function in starlark.

## Is this change user facing?
YES

## References (if applicable):
Fixes #1255 
