### PR TITLE
fix: revert always pull latest img

### DIFF
--- a/container-engine-lib/lib/backend_impls/docker/docker_manager/docker_manager.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_manager/docker_manager.go
@@ -1121,10 +1121,39 @@ func (manager *DockerManager) GetContainersByLabels(ctx context.Context, labels 
 	return result, nil
 }
 
-// [FetchImage] always attempts to retrieve the latest [dockerImage].
+// [FetchImage] uses the local [dockerImage] if it's available.
+// If unavailable, will attempt to fetch the latest image.
+// Returns error if local [dockerImage] is unavailable and pulling image fails.
+func (manager *DockerManager) FetchImage(ctx context.Context, dockerImage string) error {
+	// if the image name doesn't have version information we concatenate `:latest`
+	// this behavior is similar to CreateAndStartContainer above
+	// this allows us to be deterministic in our behaviour
+	if !strings.Contains(dockerImage, dockerTagSeparatorChar) {
+		dockerImage = dockerImage + dockerTagSeparatorChar + dockerDefaultTag
+	}
+	logrus.Tracef("Checking if image '%v' is available locally...", dockerImage)
+	doesImageExistLocally, err := manager.isImageAvailableLocally(ctx, dockerImage)
+	if err != nil {
+		return stacktrace.Propagate(err, "An error occurred checking for local availability of Docker image '%v'", dockerImage)
+	}
+	logrus.Tracef("Is image available locally?: %v", doesImageExistLocally)
+
+	if !doesImageExistLocally {
+		logrus.Tracef("Image doesn't exist locally, so attempting to pull it...")
+		err = manager.pullImage(ctx, dockerImage)
+		if err != nil {
+			return stacktrace.Propagate(err, "Failed to pull Docker image '%v' from remote image repository", dockerImage)
+		}
+		logrus.Tracef("Image successfully pulled from remote to local")
+	}
+
+	return nil
+}
+
+// [FetchLatestImage] always attempts to retrieve the latest [dockerImage].
 // If retrieving the latest [dockerImage] fails, the local image will be used.
 // Returns error, if no local image is available after retrieving latest fails.
-func (manager *DockerManager) FetchImage(ctx context.Context, dockerImage string) error {
+func (manager *DockerManager) FetchLatestImage(ctx context.Context, dockerImage string) error {
 	// if the image name doesn't have version information we concatenate `:latest`
 	// this behavior is similar to CreateAndStartContainer above
 	// this allows us to be deterministic in our behaviour
@@ -1152,35 +1181,6 @@ func (manager *DockerManager) FetchImage(ctx context.Context, dockerImage string
 		if err != nil {
 			return stacktrace.Propagate(err, "Failed to pull Docker image '%v' from remote image repository.", dockerImage)
 		}
-	}
-
-	return nil
-}
-
-// [FetchLocalImage] uses the local [dockerImage] if it's available.
-// If unavailable, will attempt to fetch the latest image.
-// Returns error if local [dockerImage] is unavailable and pulling image fails.
-func (manager *DockerManager) FetchLocalImage(ctx context.Context, dockerImage string) error {
-	// if the image name doesn't have version information we concatenate `:latest`
-	// this behavior is similar to CreateAndStartContainer above
-	// this allows us to be deterministic in our behaviour
-	if !strings.Contains(dockerImage, dockerTagSeparatorChar) {
-		dockerImage = dockerImage + dockerTagSeparatorChar + dockerDefaultTag
-	}
-	logrus.Tracef("Checking if image '%v' is available locally...", dockerImage)
-	doesImageExistLocally, err := manager.isImageAvailableLocally(ctx, dockerImage)
-	if err != nil {
-		return stacktrace.Propagate(err, "An error occurred checking for local availability of Docker image '%v'", dockerImage)
-	}
-	logrus.Tracef("Is image available locally?: %v", doesImageExistLocally)
-
-	if !doesImageExistLocally {
-		logrus.Tracef("Image doesn't exist locally, so attempting to pull it...")
-		err = manager.pullImage(ctx, dockerImage)
-		if err != nil {
-			return stacktrace.Propagate(err, "Failed to pull Docker image '%v' from remote image repository", dockerImage)
-		}
-		logrus.Tracef("Image successfully pulled from remote to local")
 	}
 
 	return nil


### PR DESCRIPTION
## Description:
Will now first check if image is available locally before trying to pull latest - reverting back to original functionality. Reverting because of slowdown experienced by users.

## Is this change user facing?
YES 

## References:
https://github.com/kurtosis-tech/kurtosis/pull/1267
https://github.com/kurtosis-tech/kurtosis/issues/1103
