### PR TITLE
docs: add `update` step for apt and yum upgrade commands

### DIFF
--- a/docs/docs/guides/upgrading-the-cli.md
+++ b/docs/docs/guides/upgrading-the-cli.md
@@ -34,14 +34,14 @@ brew update && brew upgrade kurtosis-tech/tap/kurtosis-cli
 <TabItem value="apt" label="apt (Ubuntu)">
 
 ```bash
-apt install --only-upgrade kurtosis-cli
+apt update && apt install --only-upgrade kurtosis-cli
 ```
 
 </TabItem>
 <TabItem value="yum" label="yum (RHEL)">
 
 ```bash
-yum upgrade kurtosis-cli
+yum update && upgrade kurtosis-cli
 ```
 
 </TabItem>


### PR DESCRIPTION
## Description:
This PR adds a crucial `update` command before the `upgrade` command when upgrading Kurtosis using apt or yum
## Is this change user facing?
YES

## References (if applicable):
https://discord.com/channels/783719264308953108/1131048810861314169/1153425647390183486
