### PR TITLE
fix: kurtosis web cmd work for remote context

### DIFF
--- a/cli/cli/commands/web/web.go
+++ b/cli/cli/commands/web/web.go
@@ -7,6 +7,8 @@ import (
 	"github.com/kurtosis-tech/kurtosis/cli/cli/command_framework/lowlevel/flags"
 	"github.com/kurtosis-tech/kurtosis/cli/cli/command_str_consts"
 	"github.com/kurtosis-tech/kurtosis/cli/cli/helpers/multi_os_command_executor"
+	"github.com/kurtosis-tech/kurtosis/cli/cli/user_support_constants"
+	"github.com/kurtosis-tech/kurtosis/contexts-config-store/store"
 	"github.com/kurtosis-tech/stacktrace"
 )
 
@@ -22,11 +24,23 @@ var WebCmd = &lowlevel.LowlevelKurtosisCommand{
 }
 
 const (
-	webUiLink = "http://localhost:9711/enclaves"
+	webUILink = "http://localhost:9711/enclaves"
 )
 
 func run(_ context.Context, _ *flags.ParsedFlags, _ *args.ParsedArgs) error {
-	if err := multi_os_command_executor.OpenFile(webUiLink); err != nil {
+
+	contextsConfigStore := store.GetContextsConfigStore()
+	currentKurtosisContext, err := contextsConfigStore.GetCurrentContext()
+	if err != nil {
+		return stacktrace.Propagate(err, "tried fetching the current Kurtosis context but failed, we can't switch clusters without this information. This is a bug in Kurtosis")
+	}
+	if store.IsRemote(currentKurtosisContext) {
+		if err := multi_os_command_executor.OpenFile(user_support_constants.KurtosisCloudLink); err != nil {
+			return stacktrace.Propagate(err, "An error occurred while opening the Kurtosis Cloud Web UI")
+		}
+	}
+
+	if err := multi_os_command_executor.OpenFile(webUILink); err != nil {
 		return stacktrace.Propagate(err, "An error occurred while opening the Kurtosis Web UI")
 	}
 	return nil

--- a/cli/cli/user_support_constants/user_support_constants.go
+++ b/cli/cli/user_support_constants/user_support_constants.go
@@ -30,6 +30,7 @@ const (
 	FeedbackEmail                     = "feedback@" + OldDomain
 	FeedbackEmailLink                 = "mailto:" + FeedbackEmail
 	KurtosisTechTwitterProfileLink    = "https://twitter.com/KurtosisTech"
+	KurtosisCloudLink                 = "https://cloud." + Domain
 
 	//    If you add new URLs above, make sure to add them to the urlsToValidateInTest below!!!
 	// WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING
@@ -55,4 +56,5 @@ var urlsToValidateInTest = []string{
 	KurtosisOnBoardCalendlyUrl,
 	HowImportWorksLink,
 	KurtosisTechTwitterProfileLink,
+	KurtosisCloudLink,
 }


### PR DESCRIPTION
## Description:
kurtosis web cmd work for remote context, it will take you to 'cloud.kurtosis.com' 

## Is this change user facing?
YES

## References (if applicable):
fix #1428 
