### PR TITLE
feat: allow kurtosis cli to be used behind proxy

### DIFF
--- a/cli/cli/helpers/engine_manager/engine_existence_guarantor.go
+++ b/cli/cli/helpers/engine_manager/engine_existence_guarantor.go
@@ -84,6 +84,8 @@ type engineExistenceGuarantor struct {
 
 	// To restart the current API containers after the engine has been restarted
 	restartAPIContainers bool
+
+	gitProxy string
 }
 
 func newEngineExistenceGuarantorWithDefaultVersion(
@@ -102,6 +104,7 @@ func newEngineExistenceGuarantorWithDefaultVersion(
 	shouldRunInDebugMode bool,
 	githubAuthTokenOverride string,
 	restartAPIContainers bool,
+	gitProxy string,
 ) *engineExistenceGuarantor {
 	return newEngineExistenceGuarantorWithCustomVersion(
 		ctx,
@@ -120,6 +123,7 @@ func newEngineExistenceGuarantorWithDefaultVersion(
 		shouldRunInDebugMode,
 		githubAuthTokenOverride,
 		restartAPIContainers,
+		gitProxy,
 	)
 }
 
@@ -140,6 +144,7 @@ func newEngineExistenceGuarantorWithCustomVersion(
 	shouldRunInDebugMode bool,
 	githubAuthTokenOverride string,
 	restartAPIContainers bool,
+	gitProxy string,
 ) *engineExistenceGuarantor {
 	return &engineExistenceGuarantor{
 		ctx:                                  ctx,
@@ -160,6 +165,7 @@ func newEngineExistenceGuarantorWithCustomVersion(
 		shouldRunInDebugMode:                      shouldRunInDebugMode,
 		githubAuthTokenOverride:                   githubAuthTokenOverride,
 		restartAPIContainers:                      restartAPIContainers,
+		gitProxy:                                  gitProxy,
 	}
 }
 
@@ -219,7 +225,7 @@ func (guarantor *engineExistenceGuarantor) VisitStopped() error {
 			guarantor.shouldRunInDebugMode,
 			githubAuthToken,
 			guarantor.restartAPIContainers,
-		)
+			guarantor.gitProxy)
 	} else {
 		_, _, engineLaunchErr = guarantor.engineServerLauncher.LaunchWithCustomVersion(
 			guarantor.ctx,
@@ -239,7 +245,7 @@ func (guarantor *engineExistenceGuarantor) VisitStopped() error {
 			guarantor.shouldRunInDebugMode,
 			githubAuthToken,
 			guarantor.restartAPIContainers,
-		)
+			guarantor.gitProxy)
 	}
 	if engineLaunchErr != nil {
 		return stacktrace.Propagate(engineLaunchErr, "An error occurred launching the engine server container")

--- a/cli/cli/helpers/engine_manager/engine_manager.go
+++ b/cli/cli/helpers/engine_manager/engine_manager.go
@@ -37,6 +37,7 @@ const (
 	doNotStartTheEngineInDebugModeForDefaultVersion = false
 )
 
+// what's happening here in this file
 type EngineManager struct {
 	kurtosisBackend                           backend_interface.KurtosisBackend
 	shouldSendMetrics                         bool
@@ -188,7 +189,11 @@ func (manager *EngineManager) StartEngineIdempotentlyWithDefaultVersion(
 		return nil, nil, stacktrace.Propagate(err, "An error occurred retrieving the Kurtosis engine status, which is necessary for creating a connection to the engine")
 	}
 	logrus.Debugf("Engine status: '%v'", status)
+
+	// Given that the gitproxy parameter will live directly on kurtosis_cluster_config.go I would say I'd first pull
+	//this property off like clusterType is pulled off the clusterConfig here
 	clusterType := manager.clusterConfig.GetClusterType()
+	gitProxy := manager.clusterConfig.GetGitProxy()
 	engineGuarantor := newEngineExistenceGuarantorWithDefaultVersion(
 		ctx,
 		maybeHostMachinePortBinding,
@@ -205,6 +210,7 @@ func (manager *EngineManager) StartEngineIdempotentlyWithDefaultVersion(
 		doNotStartTheEngineInDebugModeForDefaultVersion,
 		githubAuthTokenOverride,
 		restartAPIContainers,
+		gitProxy,
 	)
 	// TODO Need to handle the Kubernetes case, where a gateway needs to be started after the engine is started but
 	//  before we can return an EngineClient
@@ -231,6 +237,7 @@ func (manager *EngineManager) StartEngineIdempotentlyWithCustomVersion(
 	}
 
 	clusterType := manager.clusterConfig.GetClusterType()
+	gitProxy := manager.clusterConfig.GetGitProxy()
 	engineGuarantor := newEngineExistenceGuarantorWithCustomVersion(
 		ctx,
 		maybeHostMachinePortBinding,
@@ -248,6 +255,7 @@ func (manager *EngineManager) StartEngineIdempotentlyWithCustomVersion(
 		shouldStartInDebugMode,
 		githubAuthTokenOverride,
 		restartAPIContainers,
+		gitProxy,
 	)
 	engineClient, engineClientCloseFunc, err := manager.startEngineWithGuarantor(ctx, status, engineGuarantor)
 	if err != nil {

--- a/cli/cli/kurtosis_config/config_version/config_version.go
+++ b/cli/cli/kurtosis_config/config_version/config_version.go
@@ -8,4 +8,5 @@ const (
 	ConfigVersion_v0 ConfigVersion = iota
 	ConfigVersion_v1
 	ConfigVersion_v2 // Fixed a typo in Kubernetes config, `enclave-size-in-Megabytes` -> `enclave-size-in-megabytes`
+	ConfigVersion_v3
 )

--- a/cli/cli/kurtosis_config/config_version/configversion_enumer.go
+++ b/cli/cli/kurtosis_config/config_version/configversion_enumer.go
@@ -7,11 +7,11 @@ import (
 	"strings"
 )
 
-const _ConfigVersionName = "ConfigVersion_v0ConfigVersion_v1ConfigVersion_v2"
+const _ConfigVersionName = "ConfigVersion_v0ConfigVersion_v1ConfigVersion_v2ConfigVersion_v3"
 
-var _ConfigVersionIndex = [...]uint8{0, 16, 32, 48}
+var _ConfigVersionIndex = [...]uint8{0, 16, 32, 48, 64}
 
-const _ConfigVersionLowerName = "configversion_v0configversion_v1configversion_v2"
+const _ConfigVersionLowerName = "configversion_v0configversion_v1configversion_v2configversion_v3"
 
 func (i ConfigVersion) String() string {
 	if i >= ConfigVersion(len(_ConfigVersionIndex)-1) {
@@ -27,9 +27,10 @@ func _ConfigVersionNoOp() {
 	_ = x[ConfigVersion_v0-(0)]
 	_ = x[ConfigVersion_v1-(1)]
 	_ = x[ConfigVersion_v2-(2)]
+	_ = x[ConfigVersion_v3-(3)]
 }
 
-var _ConfigVersionValues = []ConfigVersion{ConfigVersion_v0, ConfigVersion_v1, ConfigVersion_v2}
+var _ConfigVersionValues = []ConfigVersion{ConfigVersion_v0, ConfigVersion_v1, ConfigVersion_v2, ConfigVersion_v3}
 
 var _ConfigVersionNameToValueMap = map[string]ConfigVersion{
 	_ConfigVersionName[0:16]:       ConfigVersion_v0,
@@ -38,12 +39,15 @@ var _ConfigVersionNameToValueMap = map[string]ConfigVersion{
 	_ConfigVersionLowerName[16:32]: ConfigVersion_v1,
 	_ConfigVersionName[32:48]:      ConfigVersion_v2,
 	_ConfigVersionLowerName[32:48]: ConfigVersion_v2,
+	_ConfigVersionName[48:64]:      ConfigVersion_v3,
+	_ConfigVersionLowerName[48:64]: ConfigVersion_v3,
 }
 
 var _ConfigVersionNames = []string{
 	_ConfigVersionName[0:16],
 	_ConfigVersionName[16:32],
 	_ConfigVersionName[32:48],
+	_ConfigVersionName[48:64],
 }
 
 // ConfigVersionString retrieves an enum value from the enum constants string name.

--- a/cli/cli/kurtosis_config/overrides_deserializers/config_overrides_deserializers.go
+++ b/cli/cli/kurtosis_config/overrides_deserializers/config_overrides_deserializers.go
@@ -6,6 +6,7 @@ import (
 	"github.com/kurtosis-tech/kurtosis/cli/cli/kurtosis_config/overrides_objects/v0"
 	"github.com/kurtosis-tech/kurtosis/cli/cli/kurtosis_config/overrides_objects/v1"
 	"github.com/kurtosis-tech/kurtosis/cli/cli/kurtosis_config/overrides_objects/v2"
+	v3 "github.com/kurtosis-tech/kurtosis/cli/cli/kurtosis_config/overrides_objects/v3"
 	"github.com/kurtosis-tech/stacktrace"
 )
 
@@ -20,6 +21,19 @@ type configOverridesDeserializer func(configFileBytes []byte) (interface{}, erro
 // We keep these sorted in REVERSE chronological order so you don't need to scroll to the bottom each time
 // >>>>>>>>>>>>>>>>>>>>>>>>>>>>> INSTRUCTIONS <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 var AllConfigOverridesDeserializers = map[config_version.ConfigVersion]configOverridesDeserializer{
+	config_version.ConfigVersion_v3: func(configFileBytes []byte) (interface{}, error) {
+		overrides := &v3.KurtosisConfigV3{
+			ConfigVersion:     0,
+			ShouldSendMetrics: nil,
+			GitProxy:          nil,
+			KurtosisClusters:  nil,
+			CloudConfig:       nil,
+		}
+		if err := yaml.Unmarshal(configFileBytes, overrides); err != nil {
+			return nil, stacktrace.Propagate(err, "An error occurred unmarshalling Kurtosis config YAML file content '%v'", string(configFileBytes))
+		}
+		return overrides, nil
+	},
 	config_version.ConfigVersion_v2: func(configFileBytes []byte) (interface{}, error) {
 		overrides := &v2.KurtosisConfigV2{
 			ConfigVersion:     0,

--- a/cli/cli/kurtosis_config/overrides_deserializers/config_overrides_deserializers.go
+++ b/cli/cli/kurtosis_config/overrides_deserializers/config_overrides_deserializers.go
@@ -25,7 +25,6 @@ var AllConfigOverridesDeserializers = map[config_version.ConfigVersion]configOve
 		overrides := &v3.KurtosisConfigV3{
 			ConfigVersion:     0,
 			ShouldSendMetrics: nil,
-			GitProxy:          nil,
 			KurtosisClusters:  nil,
 			CloudConfig:       nil,
 		}

--- a/cli/cli/kurtosis_config/overrides_migrators/config_overrides_migrators.go
+++ b/cli/cli/kurtosis_config/overrides_migrators/config_overrides_migrators.go
@@ -5,6 +5,7 @@ import (
 	"github.com/kurtosis-tech/kurtosis/cli/cli/kurtosis_config/overrides_objects/v0"
 	"github.com/kurtosis-tech/kurtosis/cli/cli/kurtosis_config/overrides_objects/v1"
 	"github.com/kurtosis-tech/kurtosis/cli/cli/kurtosis_config/overrides_objects/v2"
+	v3 "github.com/kurtosis-tech/kurtosis/cli/cli/kurtosis_config/overrides_objects/v3"
 	"github.com/kurtosis-tech/stacktrace"
 )
 
@@ -24,11 +25,56 @@ type configOverridesMigrator = func(uncastedOldConfig interface{}) (interface{},
 // to the bottom each time
 // >>>>>>>>>>>>>>>>>>>>>>>>>>>>> INSTRUCTIONS <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 var AllConfigOverridesMigrators = map[config_version.ConfigVersion]configOverridesMigrator{
+	config_version.ConfigVersion_v2: migrateFromV2,
 	config_version.ConfigVersion_v1: migrateFromV1,
 	config_version.ConfigVersion_v0: migrateFromV0,
 }
 
 // vvvvvvvvvvvvvvvvvvvvvvv REVERSE chronological order so you don't have to scroll forever vvvvvvvvvvvvvvvvvvvv
+func migrateFromV2(uncastedConfig interface{}) (interface{}, error) {
+	// cast "uncastedConfig" to current version we're upgrading from
+	castedOldConfig, ok := uncastedConfig.(*v2.KurtosisConfigV2)
+	if !ok {
+		return nil, stacktrace.NewError(
+			"Failed to cast old configuration '%+v' to expected configuration struct",
+			uncastedConfig,
+		)
+	}
+
+	// Migrate cluster configs across
+	var newClusters map[string]*v3.KurtosisClusterConfigV3
+	if castedOldConfig.KurtosisClusters != nil {
+		newClusters = map[string]*v3.KurtosisClusterConfigV3{}
+		for oldClusterName, oldClusterConfig := range castedOldConfig.KurtosisClusters {
+			oldKubernetesConfig := oldClusterConfig.Config
+
+			var newKubernetesConfig *v3.KubernetesClusterConfigV3
+			if oldKubernetesConfig != nil {
+				newKubernetesConfig = &v3.KubernetesClusterConfigV3{
+					KubernetesClusterName:  oldKubernetesConfig.KubernetesClusterName,
+					StorageClass:           oldKubernetesConfig.StorageClass,
+					EnclaveSizeInMegabytes: oldKubernetesConfig.EnclaveSizeInMegabytes,
+				}
+			}
+
+			newClusterConfig := &v3.KurtosisClusterConfigV3{
+				Type:   oldClusterConfig.Type,
+				Config: newKubernetesConfig,
+			}
+			newClusters[oldClusterName] = newClusterConfig
+		}
+	}
+
+	// create a new configuration object to represent the migrated work
+	newConfig := &v3.KurtosisConfigV3{
+		ConfigVersion:     config_version.ConfigVersion_v3,
+		ShouldSendMetrics: castedOldConfig.ShouldSendMetrics,
+		KurtosisClusters:  newClusters,
+		GitProxy:          nil,
+	}
+	return newConfig, nil
+}
+
 func migrateFromV1(uncastedConfig interface{}) (interface{}, error) {
 	// cast "uncastedConfig" to current version we're upgrading from
 	castedOldConfig, ok := uncastedConfig.(*v1.KurtosisConfigV1)

--- a/cli/cli/kurtosis_config/overrides_migrators/config_overrides_migrators.go
+++ b/cli/cli/kurtosis_config/overrides_migrators/config_overrides_migrators.go
@@ -58,8 +58,9 @@ func migrateFromV2(uncastedConfig interface{}) (interface{}, error) {
 			}
 
 			newClusterConfig := &v3.KurtosisClusterConfigV3{
-				Type:   oldClusterConfig.Type,
-				Config: newKubernetesConfig,
+				Type:     oldClusterConfig.Type,
+				Config:   newKubernetesConfig,
+				GitProxy: nil,
 			}
 			newClusters[oldClusterName] = newClusterConfig
 		}
@@ -70,7 +71,6 @@ func migrateFromV2(uncastedConfig interface{}) (interface{}, error) {
 		ConfigVersion:     config_version.ConfigVersion_v3,
 		ShouldSendMetrics: castedOldConfig.ShouldSendMetrics,
 		KurtosisClusters:  newClusters,
-		GitProxy:          nil,
 	}
 	return newConfig, nil
 }

--- a/cli/cli/kurtosis_config/overrides_objects/config_version_emptystructs.go
+++ b/cli/cli/kurtosis_config/overrides_objects/config_version_emptystructs.go
@@ -5,6 +5,7 @@ import (
 	v0 "github.com/kurtosis-tech/kurtosis/cli/cli/kurtosis_config/overrides_objects/v0"
 	v1 "github.com/kurtosis-tech/kurtosis/cli/cli/kurtosis_config/overrides_objects/v1"
 	v2 "github.com/kurtosis-tech/kurtosis/cli/cli/kurtosis_config/overrides_objects/v2"
+	v3 "github.com/kurtosis-tech/kurtosis/cli/cli/kurtosis_config/overrides_objects/v3"
 )
 
 /*
@@ -17,6 +18,13 @@ For an explanation, see the docs on TestKurtosisConfigIsUsingLatestConfigStruct.
 */
 
 var AllConfigVersionEmptyStructs = map[config_version.ConfigVersion]interface{}{
+	config_version.ConfigVersion_v3: &v3.KurtosisConfigV3{
+		ConfigVersion:     0,
+		ShouldSendMetrics: nil,
+		GitProxy:          nil,
+		KurtosisClusters:  nil,
+		CloudConfig:       nil,
+	},
 	config_version.ConfigVersion_v2: &v2.KurtosisConfigV2{
 		ConfigVersion:     0,
 		ShouldSendMetrics: nil,

--- a/cli/cli/kurtosis_config/overrides_objects/config_version_emptystructs.go
+++ b/cli/cli/kurtosis_config/overrides_objects/config_version_emptystructs.go
@@ -21,7 +21,6 @@ var AllConfigVersionEmptyStructs = map[config_version.ConfigVersion]interface{}{
 	config_version.ConfigVersion_v3: &v3.KurtosisConfigV3{
 		ConfigVersion:     0,
 		ShouldSendMetrics: nil,
-		GitProxy:          nil,
 		KurtosisClusters:  nil,
 		CloudConfig:       nil,
 	},

--- a/cli/cli/kurtosis_config/overrides_objects/v3/kubernetes_cluster_config_v3.go
+++ b/cli/cli/kurtosis_config/overrides_objects/v3/kubernetes_cluster_config_v3.go
@@ -11,6 +11,6 @@ package v3
 
 type KubernetesClusterConfigV3 struct {
 	KubernetesClusterName  *string `yaml:"kubernetes-cluster-name,omitempty"`
-	StorageClass           *string `yaml:"storage-class,omitempty"`
+	StorageClass           *string `yaml:"storage-class,omitemprty"`
 	EnclaveSizeInMegabytes *uint   `yaml:"enclave-size-in-megabytes,omitempty"`
 }

--- a/cli/cli/kurtosis_config/overrides_objects/v3/kubernetes_cluster_config_v3.go
+++ b/cli/cli/kurtosis_config/overrides_objects/v3/kubernetes_cluster_config_v3.go
@@ -1,0 +1,16 @@
+package v3
+
+/*
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! WARNING !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+                           DO NOT CHANGE THIS FILE!
+  If you change this file, it will break config for users who have instantiated an
+           overrides file with this version of config overrides!
+    Instead, to make changes, you will need to add a new version of the config
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! WARNING !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+*/
+
+type KubernetesClusterConfigV3 struct {
+	KubernetesClusterName  *string `yaml:"kubernetes-cluster-name,omitempty"`
+	StorageClass           *string `yaml:"storage-class,omitempty"`
+	EnclaveSizeInMegabytes *uint   `yaml:"enclave-size-in-megabytes,omitempty"`
+}

--- a/cli/cli/kurtosis_config/overrides_objects/v3/kurtosis_cloud_config_v3.go
+++ b/cli/cli/kurtosis_config/overrides_objects/v3/kurtosis_cloud_config_v3.go
@@ -1,0 +1,16 @@
+package v3
+
+/*
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! WARNING !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+                           DO NOT CHANGE THIS FILE!
+  If you change this file, it will break config for users who have instantiated an
+           overrides file with this version of config overrides!
+    Instead, to make changes, you will need to add a new version of the config
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! WARNING !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+*/
+
+type KurtosisCloudConfigV3 struct {
+	ApiUrl           *string `yaml:"api-url,omitempty"`
+	Port             *uint   `yaml:"port,omitempty"`
+	CertificateChain *string `yaml:"certificate-chain,omitempty"`
+}

--- a/cli/cli/kurtosis_config/overrides_objects/v3/kurtosis_cluster_config_v3.go
+++ b/cli/cli/kurtosis_config/overrides_objects/v3/kurtosis_cluster_config_v3.go
@@ -12,5 +12,6 @@ package v3
 type KurtosisClusterConfigV3 struct {
 	Type *string `yaml:"type,omitempty"`
 	// If we ever get another type of cluster that has configuration, this will need to be polymorphically deserialized
-	Config *KubernetesClusterConfigV3 `yaml:"config,omitempty"`
+	Config   *KubernetesClusterConfigV3 `yaml:"config,omitempty"`
+	GitProxy *string                    `yaml:"git-proxy,omitempty"`
 }

--- a/cli/cli/kurtosis_config/overrides_objects/v3/kurtosis_cluster_config_v3.go
+++ b/cli/cli/kurtosis_config/overrides_objects/v3/kurtosis_cluster_config_v3.go
@@ -1,0 +1,16 @@
+package v3
+
+/*
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! WARNING !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+                           DO NOT CHANGE THIS FILE!
+  If you change this file, it will break config for users who have instantiated an
+           overrides file with this version of config overrides!
+    Instead, to make changes, you will need to add a new version of the config
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! WARNING !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+*/
+
+type KurtosisClusterConfigV3 struct {
+	Type *string `yaml:"type,omitempty"`
+	// If we ever get another type of cluster that has configuration, this will need to be polymorphically deserialized
+	Config *KubernetesClusterConfigV3 `yaml:"config,omitempty"`
+}

--- a/cli/cli/kurtosis_config/overrides_objects/v3/kurtosis_config_v3.go
+++ b/cli/cli/kurtosis_config/overrides_objects/v3/kurtosis_config_v3.go
@@ -1,0 +1,27 @@
+package v3
+
+import "github.com/kurtosis-tech/kurtosis/cli/cli/kurtosis_config/config_version"
+
+/*
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! WARNING !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+                           DO NOT CHANGE THIS FILE!
+  If you change this file, it will break config for users who have instantiated an
+           overrides file with this version of config overrides!
+    Instead, to make changes, you will need to add a new version of the config
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! WARNING !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+*/
+
+// NOTE: All new YAML property names here should be kebab-case because
+//  1. it's easier to read
+//  2. it's easier to write
+//  3. it's consistent with previous properties and changing the format of an already-written config file is very difficult
+type KurtosisConfigV3 struct {
+	// vvvvvvvvv Every new Kurtosis config version must have this key vvvvvvvv
+	ConfigVersion config_version.ConfigVersion `yaml:"config-version"`
+	// ^^^^^^^^^ Every new Kurtosis config version must have this key ^^^^^^^^
+
+	ShouldSendMetrics *bool                               `yaml:"should-send-metrics,omitempty"`
+	GitProxy          *string                             `yaml:"git-proxy,omitempty"`
+	KurtosisClusters  map[string]*KurtosisClusterConfigV3 `yaml:"kurtosis-clusters,omitempty"`
+	CloudConfig       *KurtosisCloudConfigV3              `yaml:"cloud-config,omitempty"`
+}

--- a/cli/cli/kurtosis_config/overrides_objects/v3/kurtosis_config_v3.go
+++ b/cli/cli/kurtosis_config/overrides_objects/v3/kurtosis_config_v3.go
@@ -19,9 +19,7 @@ type KurtosisConfigV3 struct {
 	// vvvvvvvvv Every new Kurtosis config version must have this key vvvvvvvv
 	ConfigVersion config_version.ConfigVersion `yaml:"config-version"`
 	// ^^^^^^^^^ Every new Kurtosis config version must have this key ^^^^^^^^
-
 	ShouldSendMetrics *bool                               `yaml:"should-send-metrics,omitempty"`
-	GitProxy          *string                             `yaml:"git-proxy,omitempty"`
 	KurtosisClusters  map[string]*KurtosisClusterConfigV3 `yaml:"kurtosis-clusters,omitempty"`
 	CloudConfig       *KurtosisCloudConfigV3              `yaml:"cloud-config,omitempty"`
 }

--- a/cli/cli/kurtosis_config/resolved_config/kurtosis_cluster_config.go
+++ b/cli/cli/kurtosis_config/resolved_config/kurtosis_cluster_config.go
@@ -24,6 +24,7 @@ type KurtosisClusterConfig struct {
 	kurtosisBackendSupplier     kurtosisBackendSupplier
 	engineBackendConfigSupplier engine_server_launcher.KurtosisBackendConfigSupplier
 	clusterType                 KurtosisClusterType
+	gitProxy                    string
 }
 
 func NewKurtosisClusterConfigFromOverrides(clusterId string, overrides *v3.KurtosisClusterConfigV3) (*KurtosisClusterConfig, error) {
@@ -51,6 +52,7 @@ func NewKurtosisClusterConfigFromOverrides(clusterId string, overrides *v3.Kurto
 		kurtosisBackendSupplier:     backendSupplier,
 		engineBackendConfigSupplier: engineBackendConfigSupplier,
 		clusterType:                 clusterType,
+		gitProxy:                    *overrides.GitProxy,
 	}, nil
 }
 
@@ -68,6 +70,10 @@ func (clusterConfig *KurtosisClusterConfig) GetEngineBackendConfigSupplier() eng
 
 func (clusterConfig *KurtosisClusterConfig) GetClusterType() KurtosisClusterType {
 	return clusterConfig.clusterType
+}
+
+func (clusterConfig *KurtosisClusterConfig) GetGitProxy() string {
+	return clusterConfig.gitProxy
 }
 
 // ====================================================================================================

--- a/cli/cli/kurtosis_config/resolved_config/kurtosis_cluster_config.go
+++ b/cli/cli/kurtosis_config/resolved_config/kurtosis_cluster_config.go
@@ -2,7 +2,7 @@ package resolved_config
 
 import (
 	"context"
-	v2 "github.com/kurtosis-tech/kurtosis/cli/cli/kurtosis_config/overrides_objects/v2"
+	v3 "github.com/kurtosis-tech/kurtosis/cli/cli/kurtosis_config/overrides_objects/v3"
 	"strings"
 
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/backend_creator"
@@ -26,7 +26,7 @@ type KurtosisClusterConfig struct {
 	clusterType                 KurtosisClusterType
 }
 
-func NewKurtosisClusterConfigFromOverrides(clusterId string, overrides *v2.KurtosisClusterConfigV2) (*KurtosisClusterConfig, error) {
+func NewKurtosisClusterConfigFromOverrides(clusterId string, overrides *v3.KurtosisClusterConfigV3) (*KurtosisClusterConfig, error) {
 	if overrides.Type == nil {
 		return nil, stacktrace.NewError("Kurtosis cluster must have a defined type")
 	}
@@ -75,7 +75,7 @@ func (clusterConfig *KurtosisClusterConfig) GetClusterType() KurtosisClusterType
 //	Private Helpers
 //
 // ====================================================================================================
-func getSuppliers(clusterId string, clusterType KurtosisClusterType, kubernetesConfig *v2.KubernetesClusterConfigV2) (
+func getSuppliers(clusterId string, clusterType KurtosisClusterType, kubernetesConfig *v3.KubernetesClusterConfigV3) (
 	kurtosisBackendSupplier,
 	engine_server_launcher.KurtosisBackendConfigSupplier,
 	error,

--- a/cli/cli/kurtosis_config/resolved_config/kurtosis_cluster_config_test.go
+++ b/cli/cli/kurtosis_config/resolved_config/kurtosis_cluster_config_test.go
@@ -1,13 +1,13 @@
 package resolved_config
 
 import (
-	v2 "github.com/kurtosis-tech/kurtosis/cli/cli/kurtosis_config/overrides_objects/v2"
+	v3 "github.com/kurtosis-tech/kurtosis/cli/cli/kurtosis_config/overrides_objects/v3"
 	"github.com/stretchr/testify/require"
 	"testing"
 )
 
 func TestNewKurtosisClusterConfigEmptyOverrides(t *testing.T) {
-	kurtosisClusterConfigOverrides := v2.KurtosisClusterConfigV2{
+	kurtosisClusterConfigOverrides := v3.KurtosisClusterConfigV3{
 		Type:   nil,
 		Config: nil,
 	}
@@ -17,7 +17,7 @@ func TestNewKurtosisClusterConfigEmptyOverrides(t *testing.T) {
 
 func TestNewKurtosisClusterConfigDockerType(t *testing.T) {
 	dockerType := KurtosisClusterType_Docker.String()
-	kurtosisClusterConfigOverrides := v2.KurtosisClusterConfigV2{
+	kurtosisClusterConfigOverrides := v3.KurtosisClusterConfigV3{
 		Type:   &dockerType,
 		Config: nil,
 	}
@@ -27,7 +27,7 @@ func TestNewKurtosisClusterConfigDockerType(t *testing.T) {
 
 func TestNewKurtosisClusterConfigKubernetesNoConfig(t *testing.T) {
 	kubernetesType := KurtosisClusterType_Kubernetes.String()
-	kurtosisClusterConfigOverrides := v2.KurtosisClusterConfigV2{
+	kurtosisClusterConfigOverrides := v3.KurtosisClusterConfigV3{
 		Type:   &kubernetesType,
 		Config: nil,
 	}
@@ -37,7 +37,7 @@ func TestNewKurtosisClusterConfigKubernetesNoConfig(t *testing.T) {
 
 func TestNewKurtosisClusterConfigNonsenseType(t *testing.T) {
 	clusterType := "gdsfgsdfvsf"
-	kurtosisClusterConfigOverrides := v2.KurtosisClusterConfigV2{
+	kurtosisClusterConfigOverrides := v3.KurtosisClusterConfigV3{
 		Type:   &clusterType,
 		Config: nil,
 	}
@@ -48,12 +48,12 @@ func TestNewKurtosisClusterConfigNonsenseType(t *testing.T) {
 func TestNewKurtosisClusterConfigKubernetesPartialConfig(t *testing.T) {
 	kubernetesType := KurtosisClusterType_Kubernetes.String()
 	kubernetesClusterName := "some-name"
-	kubernetesPartialConfig := v2.KubernetesClusterConfigV2{
+	kubernetesPartialConfig := v3.KubernetesClusterConfigV3{
 		KubernetesClusterName:  &kubernetesClusterName,
 		StorageClass:           nil,
 		EnclaveSizeInMegabytes: nil,
 	}
-	kurtosisClusterConfigOverrides := v2.KurtosisClusterConfigV2{
+	kurtosisClusterConfigOverrides := v3.KurtosisClusterConfigV3{
 		Type:   &kubernetesType,
 		Config: &kubernetesPartialConfig,
 	}
@@ -66,12 +66,12 @@ func TestNewKurtosisClusterConfigKubernetesFullConfig(t *testing.T) {
 	kubernetesClusterName := "some-name"
 	kubernetesStorageClass := "some-storage-class"
 	kubernetesEnclaveSizeInMB := uint(5)
-	kubernetesFullConfig := v2.KubernetesClusterConfigV2{
+	kubernetesFullConfig := v3.KubernetesClusterConfigV3{
 		KubernetesClusterName:  &kubernetesClusterName,
 		StorageClass:           &kubernetesStorageClass,
 		EnclaveSizeInMegabytes: &kubernetesEnclaveSizeInMB,
 	}
-	kurtosisClusterConfigOverrides := v2.KurtosisClusterConfigV2{
+	kurtosisClusterConfigOverrides := v3.KurtosisClusterConfigV3{
 		Type:   &kubernetesType,
 		Config: &kubernetesFullConfig,
 	}

--- a/cli/cli/kurtosis_config/resolved_config/kurtosis_cluster_config_test.go
+++ b/cli/cli/kurtosis_config/resolved_config/kurtosis_cluster_config_test.go
@@ -53,9 +53,11 @@ func TestNewKurtosisClusterConfigKubernetesPartialConfig(t *testing.T) {
 		StorageClass:           nil,
 		EnclaveSizeInMegabytes: nil,
 	}
+	gitProxy := "some-git-proxy"
 	kurtosisClusterConfigOverrides := v3.KurtosisClusterConfigV3{
-		Type:   &kubernetesType,
-		Config: &kubernetesPartialConfig,
+		Type:     &kubernetesType,
+		Config:   &kubernetesPartialConfig,
+		GitProxy: &gitProxy,
 	}
 	_, err := NewKurtosisClusterConfigFromOverrides("test", &kurtosisClusterConfigOverrides)
 	require.Error(t, err)
@@ -71,9 +73,11 @@ func TestNewKurtosisClusterConfigKubernetesFullConfig(t *testing.T) {
 		StorageClass:           &kubernetesStorageClass,
 		EnclaveSizeInMegabytes: &kubernetesEnclaveSizeInMB,
 	}
+	gitProxy := "some-git-proxy"
 	kurtosisClusterConfigOverrides := v3.KurtosisClusterConfigV3{
-		Type:   &kubernetesType,
-		Config: &kubernetesFullConfig,
+		Type:     &kubernetesType,
+		Config:   &kubernetesFullConfig,
+		GitProxy: &gitProxy,
 	}
 	_, err := NewKurtosisClusterConfigFromOverrides("test", &kurtosisClusterConfigOverrides)
 	require.NoError(t, err)

--- a/cli/cli/kurtosis_config/resolved_config/kurtosis_config.go
+++ b/cli/cli/kurtosis_config/resolved_config/kurtosis_config.go
@@ -2,7 +2,7 @@ package resolved_config
 
 import (
 	"github.com/kurtosis-tech/kurtosis/cli/cli/kurtosis_config/config_version"
-	v2 "github.com/kurtosis-tech/kurtosis/cli/cli/kurtosis_config/overrides_objects/v2"
+	v3 "github.com/kurtosis-tech/kurtosis/cli/cli/kurtosis_config/overrides_objects/v3"
 	"github.com/kurtosis-tech/stacktrace"
 )
 
@@ -37,9 +37,10 @@ the overrides on top of the default config.
 */
 type KurtosisConfig struct {
 	// Only necessary to store for when we serialize overrides
-	overrides *v2.KurtosisConfigV2
+	overrides *v3.KurtosisConfigV3
 
 	shouldSendMetrics bool
+	gitProxy          string
 	clusters          map[string]*KurtosisClusterConfig
 	cloudConfig       *KurtosisCloudConfig
 }
@@ -135,9 +136,10 @@ func NewKurtosisConfigFromOverrides(uncastedOverrides interface{}) (*KurtosisCon
 
 // NOTE: We probably want to remove this function entirely
 func NewKurtosisConfigFromRequiredFields(shouldSendMetrics bool) (*KurtosisConfig, error) {
-	overrides := &v2.KurtosisConfigV2{
+	overrides := &v3.KurtosisConfigV3{
 		ConfigVersion:     0,
 		ShouldSendMetrics: &shouldSendMetrics,
+		GitProxy:          nil,
 		KurtosisClusters:  nil,
 		CloudConfig:       nil,
 	}
@@ -163,11 +165,15 @@ func (kurtosisConfig *KurtosisConfig) GetShouldSendMetrics() bool {
 	return kurtosisConfig.shouldSendMetrics
 }
 
+func (kurtosisConfig *KurtosisConfig) GetGitProxy() string {
+	return kurtosisConfig.gitProxy
+}
+
 func (kurtosisConfig *KurtosisConfig) GetKurtosisClusters() map[string]*KurtosisClusterConfig {
 	return kurtosisConfig.clusters
 }
 
-func (kurtosisConfig *KurtosisConfig) GetOverrides() *v2.KurtosisConfigV2 {
+func (kurtosisConfig *KurtosisConfig) GetOverrides() *v3.KurtosisConfigV3 {
 	return kurtosisConfig.overrides
 }
 
@@ -181,29 +187,29 @@ func (kurtosisConfig *KurtosisConfig) GetCloudConfig() *KurtosisCloudConfig {
 //
 // ====================================================================================================
 // This is a separate helper function so that we can use it to ensure that the
-func castUncastedOverrides(uncastedOverrides interface{}) (*v2.KurtosisConfigV2, error) {
-	castedOverrides, ok := uncastedOverrides.(*v2.KurtosisConfigV2)
+func castUncastedOverrides(uncastedOverrides interface{}) (*v3.KurtosisConfigV3, error) {
+	castedOverrides, ok := uncastedOverrides.(*v3.KurtosisConfigV3)
 	if !ok {
 		return nil, stacktrace.NewError("An error occurred casting the uncasted config overrides to the right version")
 	}
 	return castedOverrides, nil
 }
 
-func getDefaultKurtosisClusterConfigOverrides() map[string]*v2.KurtosisClusterConfigV2 {
+func getDefaultKurtosisClusterConfigOverrides() map[string]*v3.KurtosisClusterConfigV3 {
 	dockerClusterType := KurtosisClusterType_Docker.String()
 	minikubeClusterType := KurtosisClusterType_Kubernetes.String()
 	minikubeKubernetesClusterName := defaultMinikubeClusterKubernetesClusterNameStr
 	minikubeStorageClass := defaultMinikubeStorageClass
 	minikubeEnclaveDataVolSizeMB := defaultMinikubeEnclaveDataVolumeMB
 
-	result := map[string]*v2.KurtosisClusterConfigV2{
+	result := map[string]*v3.KurtosisClusterConfigV3{
 		DefaultDockerClusterName: {
 			Type:   &dockerClusterType,
 			Config: nil, // Must be nil for Docker
 		},
 		defaultMinikubeClusterName: {
 			Type: &minikubeClusterType,
-			Config: &v2.KubernetesClusterConfigV2{
+			Config: &v3.KubernetesClusterConfigV3{
 				KubernetesClusterName:  &minikubeKubernetesClusterName,
 				StorageClass:           &minikubeStorageClass,
 				EnclaveSizeInMegabytes: &minikubeEnclaveDataVolSizeMB,

--- a/cli/cli/kurtosis_config/resolved_config/kurtosis_config.go
+++ b/cli/cli/kurtosis_config/resolved_config/kurtosis_config.go
@@ -139,7 +139,6 @@ func NewKurtosisConfigFromRequiredFields(shouldSendMetrics bool) (*KurtosisConfi
 	overrides := &v3.KurtosisConfigV3{
 		ConfigVersion:     0,
 		ShouldSendMetrics: &shouldSendMetrics,
-		GitProxy:          nil,
 		KurtosisClusters:  nil,
 		CloudConfig:       nil,
 	}

--- a/cli/cli/kurtosis_config/resolved_config/kurtosis_config_test.go
+++ b/cli/cli/kurtosis_config/resolved_config/kurtosis_config_test.go
@@ -4,6 +4,7 @@ import (
 	"github.com/kurtosis-tech/kurtosis/cli/cli/kurtosis_config/config_version"
 	"github.com/kurtosis-tech/kurtosis/cli/cli/kurtosis_config/overrides_objects"
 	v2 "github.com/kurtosis-tech/kurtosis/cli/cli/kurtosis_config/overrides_objects/v2"
+	v3 "github.com/kurtosis-tech/kurtosis/cli/cli/kurtosis_config/overrides_objects/v3"
 	"github.com/stretchr/testify/require"
 	"sort"
 	"testing"
@@ -63,9 +64,10 @@ func TestNewKurtosisConfigEmptyOverrides(t *testing.T) {
 func TestNewKurtosisConfigJustMetrics(t *testing.T) {
 	version := config_version.ConfigVersion_v0
 	shouldSendMetrics := true
-	originalOverrides := v2.KurtosisConfigV2{
+	originalOverrides := v3.KurtosisConfigV3{
 		ConfigVersion:     version,
 		ShouldSendMetrics: &shouldSendMetrics,
+		GitProxy:          nil,
 		KurtosisClusters:  nil,
 		CloudConfig:       nil,
 	}
@@ -94,11 +96,12 @@ func TestCloudConfigOverridesApiUrl(t *testing.T) {
 	version := config_version.ConfigVersion_v0
 	shouldSendMetrics := true
 	apiUrl := "test.com"
-	originalOverrides := v2.KurtosisConfigV2{
+	originalOverrides := v3.KurtosisConfigV3{
 		ConfigVersion:     version,
 		ShouldSendMetrics: &shouldSendMetrics,
+		GitProxy:          nil,
 		KurtosisClusters:  nil,
-		CloudConfig: &v2.KurtosisCloudConfigV2{
+		CloudConfig: &v3.KurtosisCloudConfigV3{
 			ApiUrl:           &apiUrl,
 			Port:             nil,
 			CertificateChain: nil,

--- a/cli/cli/kurtosis_config/resolved_config/kurtosis_config_test.go
+++ b/cli/cli/kurtosis_config/resolved_config/kurtosis_config_test.go
@@ -67,7 +67,6 @@ func TestNewKurtosisConfigJustMetrics(t *testing.T) {
 	originalOverrides := v3.KurtosisConfigV3{
 		ConfigVersion:     version,
 		ShouldSendMetrics: &shouldSendMetrics,
-		GitProxy:          nil,
 		KurtosisClusters:  nil,
 		CloudConfig:       nil,
 	}
@@ -99,7 +98,6 @@ func TestCloudConfigOverridesApiUrl(t *testing.T) {
 	originalOverrides := v3.KurtosisConfigV3{
 		ConfigVersion:     version,
 		ShouldSendMetrics: &shouldSendMetrics,
-		GitProxy:          nil,
 		KurtosisClusters:  nil,
 		CloudConfig: &v3.KurtosisCloudConfigV3{
 			ApiUrl:           &apiUrl,

--- a/engine/launcher/args/args.go
+++ b/engine/launcher/args/args.go
@@ -64,6 +64,8 @@ type EngineServerArgs struct {
 
 	// To restart the current API containers after the engine has been restarted
 	RestartAPIContainers bool `json:"restart_api_containers"`
+
+	GitProxy string `json:"git_proxy"`
 }
 
 var skipValidation = map[string]bool{
@@ -120,6 +122,7 @@ func NewEngineServerArgs(
 	cloudInstanceID metrics_client.CloudInstanceID,
 	allowedCORSOrigins *[]string,
 	restartAPIContainers bool,
+	gitProxy string,
 ) (*EngineServerArgs, error) {
 	if enclaveEnvVars == "" {
 		enclaveEnvVars = emptyJsonField
@@ -140,6 +143,7 @@ func NewEngineServerArgs(
 		CloudInstanceID:             cloudInstanceID,
 		AllowedCORSOrigins:          allowedCORSOrigins,
 		RestartAPIContainers:        restartAPIContainers,
+		GitProxy:                    gitProxy,
 	}
 	if err := result.validate(); err != nil {
 		return nil, stacktrace.Propagate(err, "An error occurred validating engine server args")

--- a/engine/launcher/engine_server_launcher/engine_server_launcher.go
+++ b/engine/launcher/engine_server_launcher/engine_server_launcher.go
@@ -47,6 +47,7 @@ func (launcher *EngineServerLauncher) LaunchWithDefaultVersion(
 	shouldStartInDebugMode bool,
 	githubAuthToken string,
 	restartAPIContainers bool,
+	gitProxy string,
 ) (
 	resultPublicIpAddr net.IP,
 	resultPublicGrpcPortSpec *port_spec.PortSpec,
@@ -69,7 +70,8 @@ func (launcher *EngineServerLauncher) LaunchWithDefaultVersion(
 		allowedCORSOrigins,
 		shouldStartInDebugMode,
 		githubAuthToken,
-		restartAPIContainers)
+		restartAPIContainers,
+		gitProxy)
 	if err != nil {
 		return nil, nil, stacktrace.Propagate(err, "An error occurred launching the engine server container with default version tag '%v'", kurtosis_version.KurtosisVersion)
 	}
@@ -94,6 +96,7 @@ func (launcher *EngineServerLauncher) LaunchWithCustomVersion(
 	shouldStartInDebugMode bool,
 	githubAuthToken string,
 	restartAPIContainers bool,
+	gitProxy string,
 ) (
 	resultPublicIpAddr net.IP,
 	resultPublicGrpcPortSpec *port_spec.PortSpec,
@@ -101,6 +104,7 @@ func (launcher *EngineServerLauncher) LaunchWithCustomVersion(
 ) {
 	kurtosisBackendType, kurtosisBackendConfig := backendConfigSupplier.getKurtosisBackendConfig()
 
+	// Here the args object is made
 	argsObj, err := args.NewEngineServerArgs(
 		grpcListenPortNum,
 		logLevel.String(),
@@ -117,6 +121,7 @@ func (launcher *EngineServerLauncher) LaunchWithCustomVersion(
 		cloudInstanceID,
 		allowedCORSOrigins,
 		restartAPIContainers,
+		gitProxy,
 	)
 	if err != nil {
 		return nil, nil, stacktrace.Propagate(err, "An error occurred creating the engine server args")

--- a/engine/server/engine/enclave_manager/enclave_creator.go
+++ b/engine/server/engine/enclave_manager/enclave_creator.go
@@ -100,6 +100,7 @@ func (creator *EnclaveCreator) CreateEnclave(
 		}()
 	}
 
+	// and then pass in the proxy setting from the config to each enclave (just like metricsUserId here:
 	apiContainer, err := creator.LaunchApiContainer(setupCtx,
 		apiContainerImageVersionTag,
 		apiContainerLogLevel,

--- a/engine/server/engine/main.go
+++ b/engine/server/engine/main.go
@@ -146,6 +146,7 @@ func runMain() error {
 	}
 	logrus.SetLevel(logLevel)
 
+	// so you can access it on the other side when the engine starts here
 	backendConfig := serverArgs.KurtosisLocalBackendConfig
 	if backendConfig == nil {
 		return stacktrace.NewError("Backend configuration parameters are null - there must be backend configuration parameters.")
@@ -186,6 +187,7 @@ func runMain() error {
 		serverArgs.EnclaveEnvVars,
 		logFileManager,
 		serverArgs.MetricsUserID,
+		// provide gitproxy here
 		serverArgs.DidUserAcceptSendingMetrics,
 		serverArgs.IsCI,
 		serverArgs.CloudUserID,


### PR DESCRIPTION
## Description:
This update introduces the ability to specify a proxy URL for git operations, facilitating the cloning of repositories when behind a (corporate) proxy. Initially, this draft PR allows setting just the proxy URL, but the plan is to expand this by including a full proxy options struct that go-git utilizes, encompassing not just the URL but also the username and password for proxy authentication. The struct is outlined as follows:

```go
type ProxyOptions struct {
	URL      string
	Username string
	Password string
}
```

- [ ] Add proper test for loading of proxy config into `git_package_content_provider.go`
- [ ] Provide entire ProxyOptions struct as configurable parameter instead of just URL
- [ ] Add test to verify that ProxyOptions is picked when cloning a repo
- [ ] Fix linting issues

## Is this change user facing?
YES

## References (if applicable):
https://github.com/kurtosis-tech/kurtosis/issues/1434
