### PR TITLE
fix: make vector use ISO week time

### DIFF
--- a/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/logs_aggregator_functions/implementations/vector/consts.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/logs_aggregator_functions/implementations/vector/consts.go
@@ -24,7 +24,7 @@ const (
 	// We instruct vector to store log files per-year, per-week (00-53), per-enclave, per-service
 	// To construct the filepath, we utilize vectors template syntax that allows us to reference fields in log events
 	// https://vector.dev/docs/reference/configuration/template-syntax/
-	baseLogsFilepath = "\"" + logsStorageDirpath + "%%Y/%%U/"
+	baseLogsFilepath = "\"" + logsStorageDirpath + "%%Y/%%V/"
 
 	uuidLogsFilepath = baseLogsFilepath + "{{ enclave_uuid }}/{{ service_uuid }}.json\""
 


### PR DESCRIPTION
## Description:
There was a bug where the `LogsAggregator` was using a different time format for week than the `LogsDatabaseClient`. 

In special cases (like today), the `LogsAggregator` and `LogsDatabaseClient` disagreed about what week it was. The former said it was week 41 and the latter said it was week 40. This disagreement prevented users from being able to pull logs today. 

This change makes them agree from now on by making them use the same week format : )

## Is this change user facing?
YES (no more bug)


