### PR TITLE
fix: set parallelism to 4 when its passed as 0

### DIFF
--- a/core/server/api_container/server/api_container_service.go
+++ b/core/server/api_container/server/api_container_service.go
@@ -69,6 +69,7 @@ const (
 	isScript               = true
 	isNotScript            = false
 	isNotRemote            = false
+	defaultParallelism     = 4
 )
 
 // Guaranteed (by a unit test) to be a 1:1 mapping between API port protos and port spec protos
@@ -112,7 +113,7 @@ func NewApiContainerService(
 			PackageId:              startosis_constants.PackageIdPlaceholderForStandaloneScript,
 			SerializedScript:       "",
 			SerializedParams:       "",
-			Parallelism:            0,
+			Parallelism:            defaultParallelism,
 			RelativePathToMainFile: startosis_constants.PlaceHolderMainFileForPlaceStandAloneScript,
 			MainFunctionName:       "",
 			ExperimentalFeatures:   []kurtosis_core_rpc_api_bindings.KurtosisFeatureFlag{},
@@ -128,6 +129,9 @@ func (apicService *ApiContainerService) RunStarlarkScript(args *kurtosis_core_rp
 	serializedStarlarkScript := args.GetSerializedScript()
 	serializedParams := args.GetSerializedParams()
 	parallelism := int(args.GetParallelism())
+	if parallelism == 0 {
+		parallelism = defaultParallelism
+	}
 	dryRun := shared_utils.GetOrDefaultBool(args.DryRun, defaultStartosisDryRun)
 	mainFuncName := args.GetMainFunctionName()
 	experimentalFeatures := args.GetExperimentalFeatures()
@@ -223,6 +227,9 @@ func (apicService *ApiContainerService) InspectFilesArtifactContents(_ context.C
 func (apicService *ApiContainerService) RunStarlarkPackage(args *kurtosis_core_rpc_api_bindings.RunStarlarkPackageArgs, stream kurtosis_core_rpc_api_bindings.ApiContainerService_RunStarlarkPackageServer) error {
 	packageId := args.GetPackageId()
 	parallelism := int(args.GetParallelism())
+	if parallelism == 0 {
+		parallelism = defaultParallelism
+	}
 	dryRun := shared_utils.GetOrDefaultBool(args.DryRun, defaultStartosisDryRun)
 	serializedParams := args.GetSerializedParams()
 	relativePathToMainFile := args.GetRelativePathToMainFile()


### PR DESCRIPTION
## Description:
The frontend is passing 0 as parallelism instead of 4 as the default; setting it to 4 in the backend for now. Someone better than me at frontend can fix the frontend bug; I spent some time looking into connect/enclave-manager/frontend inside engine and gave up

## Is this change user facing?
YES - fixes cloud runs of things that use `add_services`

