### PR TITLE
fix: check docker engine is up prior to linting and give a useful error when it is not

### DIFF
--- a/cli/cli/commands/lint/lint.go
+++ b/cli/cli/commands/lint/lint.go
@@ -37,6 +37,7 @@ const (
 	allStarlarkFilesMatch   = "\\.star?$"
 	dirVolumeSeparator      = ":"
 	presentWorkingDirectory = "."
+	versionArg              = "version"
 
 	linterFailedAsThingsNeedToBeReformattedExitCode = 1
 	linterFailedWithInternalErrorsExitCode          = 123
@@ -94,6 +95,11 @@ func run(_ context.Context, flags *flags.ParsedFlags, args *args.ParsedArgs) err
 
 	if _, err := exec.LookPath(dockerBinary); err != nil {
 		return stacktrace.Propagate(err, "'%v' uses '%v' underneath in order to use the '%v' image but it couldn't find '%v' in path", command_str_consts.KurtosisLintCmdStr, dockerBinary, pyBlackDockerImage, dockerBinary)
+	}
+
+	versionCommand := exec.Command(dockerBinary, versionArg)
+	if _, err := versionCommand.CombinedOutput(); err != nil {
+		return stacktrace.Propagate(err, "An error occurred checking Docker version. Please ensure Docker engine is running and try again.")
 	}
 
 	for _, fileOrDirToLint := range fileOrDirToLintArg {

--- a/cli/cli/commands/lint/lint.go
+++ b/cli/cli/commands/lint/lint.go
@@ -98,7 +98,7 @@ func run(_ context.Context, flags *flags.ParsedFlags, args *args.ParsedArgs) err
 	}
 
 	versionCommand := exec.Command(dockerBinary, versionArg)
-	if _, err := versionCommand.CombinedOutput(); err != nil {
+	if err := versionCommand.Run(); err != nil {
 		return stacktrace.Propagate(err, "An error occurred checking Docker version. Please ensure Docker engine is running and try again.")
 	}
 


### PR DESCRIPTION
## Description:
Runs `docker version` prior to linting, to verify that docker engine is up.  Throws an exception with a suitable error message if docker is down.  

The error is still a thrown stacktrace but now the message is correct.  Looks like this:

```
?1 kurtosis % ./cli/cli/scripts/launch-cli.sh lint --cli-log-level debug
INFO[2023-10-10T14:05:56+01:00] This depends on 'pyfound/black:23.9.1'; first run may take a while as we might have to download it
Error:  An error occurred running command 'lint'
 --- at ...kurtosis/kurtosis/cli/cli/command_framework/lowlevel/lowlevel_kurtosis_command.go:301 (LowlevelKurtosisCommand.MustGetCobraCommand.func2) ---
Caused by: An error occurred checking Docker version. Please ensure Docker engine is running and try again.
 --- at ...kurtosis/kurtosis/cli/cli/commands/lint/lint.go:102 (run) ---
Caused by: exit status 1
```

## Is this change user facing?
YES
<!-- If yes, please add the "user facing" label to the PR -->
<!-- If yes, don't forget to include docs changes where relevant -->

## References (if applicable):
https://github.com/kurtosis-tech/kurtosis/issues/1375
