### PR TITLE
feat: make clean -a remove all logs

### DIFF
--- a/engine/server/engine/centralized_logs/client_implementations/persistent_volume/log_file_manager/log_file_manager.go
+++ b/engine/server/engine/centralized_logs/client_implementations/persistent_volume/log_file_manager/log_file_manager.go
@@ -136,7 +136,8 @@ func (manager *LogFileManager) RemoveLogsBeyondRetentionPeriod() {
 }
 
 func (manager *LogFileManager) RemoveAllLogs() error {
-	if err := manager.filesystem.RemoveAll(volume_consts.LogsStorageDirpath); err != nil {
+	year, _ := manager.time.Now().ISOWeek()
+	if err := manager.filesystem.RemoveAll(getLogsDirPathForYear(year)); err != nil {
 		return stacktrace.Propagate(err, "An error occurred attempting to remove all logs.")
 	}
 	return nil
@@ -204,6 +205,7 @@ func (manager *LogFileManager) createSymlinkLogFile(targetLogFilePath, symlinkLo
 	return nil
 }
 
+// TODO: Implement a FilePath Builder to remove exploding constructors
 // creates a filepath of format /<filepath_base>/year/week/<enclave>/serviceIdentifier.<filetype>
 func getFilepathStr(year, week int, enclaveUuid, serviceIdentifier string) string {
 	return fmt.Sprintf(volume_consts.PerWeekFilePathFmtStr, volume_consts.LogsStorageDirpath, strconv.Itoa(year), strconv.Itoa(week), enclaveUuid, serviceIdentifier, volume_consts.Filetype)
@@ -217,5 +219,11 @@ func getEnclaveLogsDirPath(year, week int, enclaveUuid string) string {
 
 // creates a directory path of format /<filepath_base>/year/week/
 func getLogsDirPathForWeek(year, week int) string {
-	return fmt.Sprintf(volume_consts.PerWeekDirPathStr, volume_consts.LogsStorageDirpath, strconv.Itoa(year), strconv.Itoa(week))
+	logsDirPathForYear := getLogsDirPathForYear(year)
+	return fmt.Sprintf("%s/%s/", logsDirPathForYear, strconv.Itoa(week))
+}
+
+// creates a directory path of format /<filepath_base>/year/
+func getLogsDirPathForYear(year int) string {
+	return fmt.Sprintf("%s/%s/", volume_consts.LogsStorageDirpath, strconv.Itoa(year))
 }

--- a/engine/server/engine/centralized_logs/client_implementations/persistent_volume/log_file_manager/log_file_manager.go
+++ b/engine/server/engine/centralized_logs/client_implementations/persistent_volume/log_file_manager/log_file_manager.go
@@ -136,6 +136,7 @@ func (manager *LogFileManager) RemoveLogsBeyondRetentionPeriod() {
 }
 
 func (manager *LogFileManager) RemoveAllLogs() error {
+	// only removes logs for this year because Docker prevents all logs from base logs storage file path
 	year, _ := manager.time.Now().ISOWeek()
 	if err := manager.filesystem.RemoveAll(getLogsDirPathForYear(year)); err != nil {
 		return stacktrace.Propagate(err, "An error occurred attempting to remove all logs.")

--- a/engine/server/engine/main.go
+++ b/engine/server/engine/main.go
@@ -203,7 +203,8 @@ func runMain() error {
 		serverArgs.MetricsUserID,
 		serverArgs.DidUserAcceptSendingMetrics,
 		perWeekLogsDatabaseClient,
-		perFileLogsDatabaseClient)
+		perFileLogsDatabaseClient,
+		logFileManager)
 	apiPath, handler := kurtosis_engine_rpc_api_bindingsconnect.NewEngineServiceHandler(engineConnectServer)
 	defer func() {
 		if err := engineConnectServer.Close(); err != nil {

--- a/engine/server/engine/server/engine_connect_server_service.go
+++ b/engine/server/engine/server/engine_connect_server_service.go
@@ -7,6 +7,7 @@ import (
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/enclave"
 	user_service "github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/service"
 	"github.com/kurtosis-tech/kurtosis/engine/server/engine/centralized_logs"
+	"github.com/kurtosis-tech/kurtosis/engine/server/engine/centralized_logs/client_implementations/persistent_volume/log_file_manager"
 	"github.com/kurtosis-tech/kurtosis/engine/server/engine/centralized_logs/logline"
 	"github.com/kurtosis-tech/kurtosis/engine/server/engine/enclave_manager"
 	"github.com/kurtosis-tech/stacktrace"
@@ -39,6 +40,8 @@ type EngineConnectServerService struct {
 	// per file pulls logs from enclaves created pre log retention feature
 	// TODO: remove once users are fully migrated to log retention/new log schema
 	perFileLogsDatabaseClient centralized_logs.LogsDatabaseClient
+
+	logFileManager *log_file_manager.LogFileManager
 }
 
 func NewEngineConnectServerService(
@@ -48,6 +51,7 @@ func NewEngineConnectServerService(
 	didUserAcceptSendingMetrics bool,
 	perWeekLogsDatabaseClient centralized_logs.LogsDatabaseClient,
 	perFileLogsDatabaseClient centralized_logs.LogsDatabaseClient,
+	logFileManager *log_file_manager.LogFileManager,
 ) *EngineConnectServerService {
 	service := &EngineConnectServerService{
 		imageVersionTag:             imageVersionTag,
@@ -56,6 +60,7 @@ func NewEngineConnectServerService(
 		didUserAcceptSendingMetrics: didUserAcceptSendingMetrics,
 		perWeekLogsDatabaseClient:   perWeekLogsDatabaseClient,
 		perFileLogsDatabaseClient:   perFileLogsDatabaseClient,
+		logFileManager:              logFileManager,
 	}
 	return service
 }
@@ -142,6 +147,11 @@ func (service *EngineConnectServerService) Clean(ctx context.Context, connectArg
 	removedEnclaveUuidsAndNames, err := service.enclaveManager.Clean(ctx, args.ShouldCleanAll)
 	if err != nil {
 		return nil, stacktrace.Propagate(err, "An error occurred while cleaning enclaves")
+	}
+	if args.ShouldCleanAll {
+		if err = service.logFileManager.RemoveAllLogs(); err != nil {
+			return nil, stacktrace.Propagate(err, "An error occurred removing all nodes.")
+		}
 	}
 	response := &kurtosis_engine_rpc_api_bindings.CleanResponse{RemovedEnclaveNameAndUuids: removedEnclaveUuidsAndNames}
 	return connect.NewResponse(response), nil

--- a/engine/server/engine/server/engine_connect_server_service.go
+++ b/engine/server/engine/server/engine_connect_server_service.go
@@ -150,7 +150,7 @@ func (service *EngineConnectServerService) Clean(ctx context.Context, connectArg
 	}
 	if args.ShouldCleanAll {
 		if err = service.logFileManager.RemoveAllLogs(); err != nil {
-			return nil, stacktrace.Propagate(err, "An error occurred removing all nodes.")
+			return nil, stacktrace.Propagate(err, "An error occurred removing all logs.")
 		}
 	}
 	response := &kurtosis_engine_rpc_api_bindings.CleanResponse{RemovedEnclaveNameAndUuids: removedEnclaveUuidsAndNames}


### PR DESCRIPTION
## Description:
Prior to this `kurtosis clean` removed logs for existing running and stopped enclaves. Now, `kurtosis clean -a` will get rid of all logs from this year. 

## Is this change user facing?
YES

## References
https://github.com/kurtosis-tech/kurtosis/issues/1505
