### PR TITLE
docs: add a note for common docker.sock bug

### DIFF
--- a/docs/docs/guides/installing-the-cli.md
+++ b/docs/docs/guides/installing-the-cli.md
@@ -33,6 +33,10 @@ I. Install & Start Docker
    docker image ls
    ```
 
+:::note
+For some users, Kurtosis fails to run if Docker was not installed in `sudo` mode. We have a workaround detailed in [#1140](https://github.com/kurtosis-tech/kurtosis/issues/1140) while we work on a more graceful solution, outlined in [#1469](https://github.com/kurtosis-tech/kurtosis/issues/1469).
+:::
+
 II. Install the CLI
 -------------------------
 


### PR DESCRIPTION
## Description:
This PR adds a small note in the Kurtosis installation docs about a common bug that we've come across where `unix:///var/run/docker.sock` wasn't found. 

## Is this change user facing?
YES

## References (if applicable):
#1140, #1072, and #1469
