### PR TITLE
docs: add cloud cli commands

### DIFF
--- a/docs/docs/cli-reference/cloud-add.md
+++ b/docs/docs/cli-reference/cloud-add.md
@@ -11,5 +11,5 @@ kurtosis cloud add
 ```
 
 :::note
-Only certain users with elevated permissions are allowed to create more than 1 Kurtosis Cloud instance.
+Currently, Kurtosis limits users to 1 remote instance per valid API key. 
 :::

--- a/docs/docs/cli-reference/cloud-add.md
+++ b/docs/docs/cli-reference/cloud-add.md
@@ -1,0 +1,15 @@
+---
+title: cloud add
+sidebar_label: cloud add
+slug: /cloud-add
+---
+
+This command is used to create a new Kurtosis Cloud instance under your Cloud account. This command requires you to have a a Kurtosis Cloud API key. To sign up for a new Kurtosis Cloud account and to get your Kurotsis Cloud API key, visit [Kurtosis Cloud](https://cloud.kurtosis.com) and head on over to the "Connect" section and follow the instructions. 
+
+```console
+kurtosis cloud add
+```
+
+:::note
+Only certain users with elevated permissions are allowed to create more than 1 Kurtosis Cloud instance.
+:::

--- a/docs/docs/cli-reference/cloud-add.md
+++ b/docs/docs/cli-reference/cloud-add.md
@@ -4,7 +4,7 @@ sidebar_label: cloud add
 slug: /cloud-add
 ---
 
-This command is used to create a new Kurtosis Cloud instance under your Cloud account. This command requires you to have a a Kurtosis Cloud API key. To sign up for a new Kurtosis Cloud account and to get your Kurotsis Cloud API key, visit [Kurtosis Cloud](https://cloud.kurtosis.com) and head on over to the "Connect" section and follow the instructions. 
+This command is used to create a new Kurtosis Cloud instance under your Cloud account. This command requires you to have a Kurtosis Cloud API key. To sign up for a new Kurtosis Cloud account and to get your Kurotsis Cloud API key, visit [Kurtosis Cloud](https://cloud.kurtosis.com) and head on over to the "Connect" section and follow the instructions. 
 
 ```console
 kurtosis cloud add

--- a/docs/docs/cli-reference/cloud-load.md
+++ b/docs/docs/cli-reference/cloud-load.md
@@ -4,7 +4,7 @@ sidebar_label: cloud load
 slug: /cloud-load
 ---
 
-This command will connect your local machine to the given remote Kurtosis Cloud instance. This command requires you to have a a Kurtosis Cloud API key. To sign up for a new Kurtosis Cloud account and to get your Kurotsis Cloud API key, visit [Kurtosis Cloud](https://cloud.kurtosis.com) and head on over to the "Connect" section and follow the instructions. 
+This command will connect your local machine to the given remote Kurtosis Cloud instance. This command requires you to have a Kurtosis Cloud API key. To sign up for a new Kurtosis Cloud account and to get your Kurotsis Cloud API key, visit [Kurtosis Cloud](https://cloud.kurtosis.com) and head on over to the "Connect" section and follow the instructions. 
 
 ```
 kurtosis cloud load $YOUR_CLOUD_INSTANCE_ID

--- a/docs/docs/cli-reference/cloud-load.md
+++ b/docs/docs/cli-reference/cloud-load.md
@@ -1,0 +1,15 @@
+---
+title: cloud load
+sidebar_label: cloud load
+slug: /cloud-load
+---
+
+This command will connect your local machine to the given remote Kurtosis Cloud instance. This command requires you to have a a Kurtosis Cloud API key. To sign up for a new Kurtosis Cloud account and to get your Kurotsis Cloud API key, visit [Kurtosis Cloud](https://cloud.kurtosis.com) and head on over to the "Connect" section and follow the instructions. 
+
+```
+kurtosis cloud load $YOUR_CLOUD_INSTANCE_ID
+```
+
+:::note
+You can find our Cloud Instance ID on the ["Connect" page on Kurtosis Cloud](https://cloud.kurtosis.com/connect).
+:::

--- a/docs/docs/cli-reference/cloud-unload.md
+++ b/docs/docs/cli-reference/cloud-unload.md
@@ -4,7 +4,7 @@ sidebar_label: cloud unload
 slug: /cloud-unload
 ---
 
-This command will disconnect your local machine from the given remote Kurtosis Cloud instance and will switch you back to using your local Kurtosis engine. This command requires you to have a a Kurtosis Cloud API key. To sign up for a new Kurtosis Cloud account and to get your Kurotsis Cloud API key, visit [Kurtosis Cloud](https://cloud.kurtosis.com) and head on over to the "Connect" section and follow the instructions. 
+This command will disconnect your local machine from the given remote Kurtosis Cloud instance and will switch you back to using your local Kurtosis engine. This command requires you to have a Kurtosis Cloud API key. To sign up for a new Kurtosis Cloud account and to get your Kurotsis Cloud API key, visit [Kurtosis Cloud](https://cloud.kurtosis.com) and head on over to the "Connect" section and follow the instructions. 
 
 ```
 kurtosis cloud unload $YOUR_CLOUD_INSTANCE_ID

--- a/docs/docs/cli-reference/cloud-unload.md
+++ b/docs/docs/cli-reference/cloud-unload.md
@@ -1,0 +1,15 @@
+---
+title: cloud unload
+sidebar_label: cloud unload
+slug: /cloud-unload
+---
+
+This command will disconnect your local machine from the given remote Kurtosis Cloud instance and will switch you back to using your local Kurtosis engine. This command requires you to have a a Kurtosis Cloud API key. To sign up for a new Kurtosis Cloud account and to get your Kurotsis Cloud API key, visit [Kurtosis Cloud](https://cloud.kurtosis.com) and head on over to the "Connect" section and follow the instructions. 
+
+```
+kurtosis cloud unload $YOUR_CLOUD_INSTANCE_ID
+```
+
+:::note
+You can find our Cloud Instance ID on the ["Connect" page on Kurtosis Cloud](https://cloud.kurtosis.com/connect).
+:::

--- a/docs/docs/guides/running-in-kurtosis-cloud.md
+++ b/docs/docs/guides/running-in-kurtosis-cloud.md
@@ -5,7 +5,7 @@ slug: /cloud
 sidebar_position: 7
 ---
 
-Kurtosis Cloud is a fully managed cloud offering and accompanying self-service workflows for a stress-free, easy way to deploy test and dev environments, that live as long as you need them to, directly onto remote infrastructure. By logging into our [cloud portal](https://cloud.kurtosis.com), a cloud instance will be provisioned to run your test and dev enclaves.
+Kurtosis Cloud is a fully managed cloud service that provides self-service workflows, allowing for an easy and stress-free deployment of test and dev environments directly onto remote infrastructure. These environments can persist for as long as you require. By logging into our [cloud portal](https://cloud.kurtosis.com), a cloud instance will be provisioned to run your test and dev enclaves.
 
 You can interact with your enclaves using the UI (or the [CLI](./installing-the-cli.md#ii-install-the-cli) for more advanced use cases).
 


### PR DESCRIPTION
## Description:
This pull request adds 3 CLI commands to our docs:
- cloud load
- cloud unload (new, not yet fully functional)
- cloud add 

## Is this change user facing?
YES

## References (if applicable):
#1536 and https://kurtosistech.slack.com/archives/C060Z6HDYR3/p1697211500527029
