### PR TITLE
docs: add docs about kurtosis gateway

### DIFF
--- a/docs/docs/cli-reference/gateway.md
+++ b/docs/docs/cli-reference/gateway.md
@@ -1,0 +1,11 @@
+---
+title: gateway
+sidebar_label: gateway
+slug: /gateway
+---
+
+The Kurtosis gateway command is exclusively for use with Kubernetes backends and is intended to be a command you invoke before interacting with a remote Kurtosis engine deployed on a Kubernetes clsuter. Assuming you have configured your `kurtosis-config.yml` file to work with your Kubernetes cluster [guide here](../guides/running-in-k8s.md), then this command will start a local "gateway" to connect your local machine to your remote Kubernetes cluster, enabling you to interact with the remote Kurtosis engine that lives on that cluster. 
+
+```console
+kurtosis gateway
+```

--- a/docs/docs/guides/running-in-k8s.md
+++ b/docs/docs/guides/running-in-k8s.md
@@ -65,8 +65,8 @@ kurtosis-clusters:
 IV. Configure Kurtosis
 --------------------------------
 
-1. Run `kurtosis cluster set cloud`.  This will start the engine remotely. 
-1. *In another terminal*, run `kurtosis gateway`. This will act as a middle man between your computer's ports and your services deployed on Kubernetes ports and has to stay running as a separate proccess.
+1. Run `kurtosis cluster set cloud`.  This will start the engine remotely. See the CLI reference for more information about `kurtosis cluster` commands [here](../cli-reference/cluster-set.md).
+1. *In another terminal*, run [`kurtosis gateway`](../cli-reference/gateway.md). This will act as a middle man between your computer's ports and your services deployed on Kubernetes ports and has to stay running as a separate proccess.
 
 Done! Now you can run any Kurtosis command or package just like if you were doing it locally.
 


### PR DESCRIPTION
## Description:
This pull request adds docs for the `kurtosis gateway` command - a previously undocumented command necessary for interaction with kurtosis-on-k8s set ups.

## Is this change user facing?
YES

## References (if applicable):

