### PR TITLE
fix: propagate unexpected test errors via the test framework

### DIFF
--- a/internal_testsuites/golang/testsuite/startosis_package_test/startosis_no_main_file_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_package_test/startosis_no_main_file_test.go
@@ -11,9 +11,12 @@ const (
 
 func (suite *StartosisPackageTestSuite) TestStartosisPackage_NoMainFile() {
 	ctx := context.Background()
-	runResult, _ := suite.RunPackage(ctx, packageWithNoMainStarRelPath)
+	runResult, err := suite.RunPackage(ctx, packageWithNoMainStarRelPath)
 
 	t := suite.T()
+
+	require.NoError(t, err)
+
 	expectedErrorContents := `An error occurred while verifying that 'main.star' exists in the package 'github.com/kurtosis-tech/kurtosis/internal_testsuites/starlark/no-main-star' at '/kurtosis-data/startosis-packages/kurtosis-tech/kurtosis/internal_testsuites/starlark/no-main-star/main.star'
 	Caused by: stat /kurtosis-data/startosis-packages/kurtosis-tech/kurtosis/internal_testsuites/starlark/no-main-star/main.star: no such file or directory`
 	require.NotNil(t, runResult.InterpretationError)

--- a/internal_testsuites/golang/testsuite/startosis_package_test/startosis_no_main_file_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_package_test/startosis_no_main_file_test.go
@@ -15,7 +15,8 @@ func (suite *StartosisPackageTestSuite) TestStartosisPackage_NoMainFile() {
 
 	t := suite.T()
 
-	require.NoError(t, err)
+	require.Error(t, err)
+	require.NotNil(t, runResult)
 
 	expectedErrorContents := `An error occurred while verifying that 'main.star' exists in the package 'github.com/kurtosis-tech/kurtosis/internal_testsuites/starlark/no-main-star' at '/kurtosis-data/startosis-packages/kurtosis-tech/kurtosis/internal_testsuites/starlark/no-main-star/main.star'
 	Caused by: stat /kurtosis-data/startosis-packages/kurtosis-tech/kurtosis/internal_testsuites/starlark/no-main-star/main.star: no such file or directory`

--- a/internal_testsuites/golang/testsuite/startosis_package_test/startosis_no_run_in_main_star_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_package_test/startosis_no_run_in_main_star_test.go
@@ -15,7 +15,8 @@ func (suite *StartosisPackageTestSuite) TestStartosisPackage_NoMainInMainStar() 
 
 	t := suite.T()
 
-	require.NoError(t, err)
+	require.Error(t, err)
+	require.NotNil(t, runResult)
 
 	expectedInterpretationErr := "No 'run' function found in the main file of package 'github.com/kurtosis-tech/kurtosis/internal_testsuites/starlark/no-run-in-main-star'; a 'run' entrypoint function with the signature `run(plan, args)` or `run()` is required in the main file of the Kurtosis package"
 	require.NotNil(t, runResult.InterpretationError)

--- a/internal_testsuites/golang/testsuite/startosis_package_test/startosis_no_run_in_main_star_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_package_test/startosis_no_run_in_main_star_test.go
@@ -11,9 +11,12 @@ const (
 
 func (suite *StartosisPackageTestSuite) TestStartosisPackage_NoMainInMainStar() {
 	ctx := context.Background()
-	runResult, _ := suite.RunPackage(ctx, packageWithNoMainInMainStarRelPath)
+	runResult, err := suite.RunPackage(ctx, packageWithNoMainInMainStarRelPath)
 
 	t := suite.T()
+
+	require.NoError(t, err)
+
 	expectedInterpretationErr := "No 'run' function found in the main file of package 'github.com/kurtosis-tech/kurtosis/internal_testsuites/starlark/no-run-in-main-star'; a 'run' entrypoint function with the signature `run(plan, args)` or `run()` is required in the main file of the Kurtosis package"
 	require.NotNil(t, runResult.InterpretationError)
 	require.Contains(t, runResult.InterpretationError.GetErrorMessage(), expectedInterpretationErr)

--- a/internal_testsuites/golang/testsuite/startosis_package_test/startosis_package_relative_import_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_package_test/startosis_package_relative_import_test.go
@@ -11,9 +11,10 @@ const (
 
 func (suite *StartosisPackageTestSuite) TestStartosisPackage_RelativeImports() {
 	ctx := context.Background()
-	runResult, _ := suite.RunPackage(ctx, packageWithRelativeImport)
+	runResult, err := suite.RunPackage(ctx, packageWithRelativeImport)
 
 	t := suite.T()
+	require.NoError(t, err)
 	require.Nil(t, runResult.InterpretationError)
 	require.Empty(t, runResult.ValidationErrors)
 	require.Nil(t, runResult.ExecutionError)

--- a/internal_testsuites/golang/testsuite/startosis_package_test/startosis_package_relative_import_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_package_test/startosis_package_relative_import_test.go
@@ -15,6 +15,8 @@ func (suite *StartosisPackageTestSuite) TestStartosisPackage_RelativeImports() {
 
 	t := suite.T()
 	require.NoError(t, err)
+	require.NotNil(t, runResult)
+
 	require.Nil(t, runResult.InterpretationError)
 	require.Empty(t, runResult.ValidationErrors)
 	require.Nil(t, runResult.ExecutionError)

--- a/internal_testsuites/golang/testsuite/startosis_package_test/startosis_valid_package_no_input_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_package_test/startosis_valid_package_no_input_test.go
@@ -16,6 +16,7 @@ func (suite *StartosisPackageTestSuite) TestStartosisPackage_ValidPackageNoInput
 	t := suite.T()
 	require.Nil(t, err, "Unexpected error executing Starlark package")
 
+	require.NotNil(t, runResult)
 	require.Nil(t, runResult.InterpretationError)
 	require.Empty(t, runResult.ValidationErrors)
 	require.Nil(t, runResult.ExecutionError)

--- a/internal_testsuites/golang/testsuite/startosis_package_test/startosis_valid_package_with_input_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_package_test/startosis_valid_package_with_input_test.go
@@ -59,9 +59,10 @@ Hello World!
 func (suite *StartosisPackageTestSuite) TestStartosisPackage_ValidPackageWithInput_MissingKeyInParams() {
 	ctx := context.Background()
 	params := `{"hello": "world"}` // expecting key 'greetings' here
-	runResult, _ := suite.RunPackageWithParams(ctx, validPackageWithInputRelPath, params)
+	runResult, err := suite.RunPackageWithParams(ctx, validPackageWithInputRelPath, params)
 
 	t := suite.T()
+	require.NoError(t, err)
 	require.NotNil(t, runResult.InterpretationError, "Unexpected interpretation error")
 	require.Contains(t, runResult.InterpretationError.GetErrorMessage(), "Evaluation error: key \"greetings\" not in dict")
 	require.Empty(t, runResult.ValidationErrors, "Unexpected validation error")

--- a/internal_testsuites/golang/testsuite/startosis_package_test/startosis_valid_package_with_input_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_package_test/startosis_valid_package_with_input_test.go
@@ -62,7 +62,10 @@ func (suite *StartosisPackageTestSuite) TestStartosisPackage_ValidPackageWithInp
 	runResult, err := suite.RunPackageWithParams(ctx, validPackageWithInputRelPath, params)
 
 	t := suite.T()
-	require.NoError(t, err)
+
+	require.Error(t, err)
+	require.NotNil(t, runResult)
+
 	require.NotNil(t, runResult.InterpretationError, "Unexpected interpretation error")
 	require.Contains(t, runResult.InterpretationError.GetErrorMessage(), "Evaluation error: key \"greetings\" not in dict")
 	require.Empty(t, runResult.ValidationErrors, "Unexpected validation error")

--- a/internal_testsuites/golang/testsuite/startosis_replace_test/startosis_no_main_branch_replace_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_replace_test/startosis_no_main_branch_replace_test.go
@@ -12,9 +12,10 @@ const (
 
 func (suite *StartosisReplaceTestSuite) TestStartosisNoMainBranchReplace() {
 	ctx := context.Background()
-	runResult, _ := suite.RunPackageWithParams(ctx, packageWithNoMainBranchReplaceRelPath, packageWithNoMainBranchReplaceParams)
+	runResult, err := suite.RunPackageWithParams(ctx, packageWithNoMainBranchReplaceRelPath, packageWithNoMainBranchReplaceParams)
 
 	t := suite.T()
+	require.NoError(t, err)
 	require.Nil(t, runResult.InterpretationError)
 	require.Empty(t, runResult.ValidationErrors)
 	require.Nil(t, runResult.ExecutionError)

--- a/internal_testsuites/golang/testsuite/startosis_replace_test/startosis_no_main_branch_replace_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_replace_test/startosis_no_main_branch_replace_test.go
@@ -16,6 +16,8 @@ func (suite *StartosisReplaceTestSuite) TestStartosisNoMainBranchReplace() {
 
 	t := suite.T()
 	require.NoError(t, err)
+	require.NotNil(t, runResult)
+
 	require.Nil(t, runResult.InterpretationError)
 	require.Empty(t, runResult.ValidationErrors)
 	require.Nil(t, runResult.ExecutionError)

--- a/internal_testsuites/golang/testsuite/startosis_replace_test/startosis_regular_replace_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_replace_test/startosis_regular_replace_test.go
@@ -16,6 +16,8 @@ func (suite *StartosisReplaceTestSuite) TestStartosisRegularReplace() {
 
 	t := suite.T()
 	require.NoError(t, err)
+	require.NotNil(t, runResult)
+
 	require.Nil(t, runResult.InterpretationError)
 	require.Empty(t, runResult.ValidationErrors)
 	require.Nil(t, runResult.ExecutionError)

--- a/internal_testsuites/golang/testsuite/startosis_replace_test/startosis_regular_replace_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_replace_test/startosis_regular_replace_test.go
@@ -12,9 +12,10 @@ const (
 
 func (suite *StartosisReplaceTestSuite) TestStartosisRegularReplace() {
 	ctx := context.Background()
-	runResult, _ := suite.RunPackageWithParams(ctx, packageWithRegularReplaceRelPath, packageWithRegularReplaceParams)
+	runResult, err := suite.RunPackageWithParams(ctx, packageWithRegularReplaceRelPath, packageWithRegularReplaceParams)
 
 	t := suite.T()
+	require.NoError(t, err)
 	require.Nil(t, runResult.InterpretationError)
 	require.Empty(t, runResult.ValidationErrors)
 	require.Nil(t, runResult.ExecutionError)

--- a/internal_testsuites/golang/testsuite/startosis_replace_test/startosis_replace_package_with_module_in_directory_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_replace_test/startosis_replace_package_with_module_in_directory_test.go
@@ -12,13 +12,14 @@ const (
 
 func (suite *StartosisReplaceTestSuite) TestStartosisReplaceWithModuleInDirectory() {
 	ctx := context.Background()
-	runResult, _ := suite.RunPackageWithParams(ctx, packageWithReplaceModuleInDirectoryRelPath, packageWithReplaceModuleInDirectoryParams)
+	runResult, err := suite.RunPackageWithParams(ctx, packageWithReplaceModuleInDirectoryRelPath, packageWithReplaceModuleInDirectoryParams)
 
 	t := suite.T()
+
+	require.NoError(t, err)
 	require.Nil(t, runResult.InterpretationError)
 	require.Empty(t, runResult.ValidationErrors)
 	require.Nil(t, runResult.ExecutionError)
 	expectedResult := "Replace with module in directory sample package loaded.\nVerification succeeded. Value is '\"another-dependency-loaded-from-internal-module-in-main-branch\"'.\n"
 	require.Regexp(t, expectedResult, string(runResult.RunOutput))
-
 }

--- a/internal_testsuites/golang/testsuite/startosis_replace_test/startosis_replace_package_with_module_in_directory_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_replace_test/startosis_replace_package_with_module_in_directory_test.go
@@ -15,8 +15,9 @@ func (suite *StartosisReplaceTestSuite) TestStartosisReplaceWithModuleInDirector
 	runResult, err := suite.RunPackageWithParams(ctx, packageWithReplaceModuleInDirectoryRelPath, packageWithReplaceModuleInDirectoryParams)
 
 	t := suite.T()
-
 	require.NoError(t, err)
+	require.NotNil(t, runResult)
+
 	require.Nil(t, runResult.InterpretationError)
 	require.Empty(t, runResult.ValidationErrors)
 	require.Nil(t, runResult.ExecutionError)

--- a/internal_testsuites/golang/testsuite/startosis_replace_test/startosis_replace_with_local_and_then_with_remote_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_replace_test/startosis_replace_with_local_and_then_with_remote_test.go
@@ -12,17 +12,18 @@ const (
 
 func (suite *StartosisReplaceTestSuite) TestStartosisReplaceWithLocalAndThenWithRemote() {
 	ctx := context.Background()
-	runResult, _ := suite.RunPackageWithParams(ctx, packageWithLocalReplaceRelPath, packageWithLocalReplaceParams)
+	runResult, err := suite.RunPackageWithParams(ctx, packageWithLocalReplaceRelPath, packageWithLocalReplaceParams)
 
 	t := suite.T()
+	require.NoError(t, err)
 	require.Nil(t, runResult.InterpretationError)
 	require.Empty(t, runResult.ValidationErrors)
 	require.Nil(t, runResult.ExecutionError)
 	expectedResult := "Replace with local package loaded.\nVerification succeeded. Value is '\"msg-loaded-from-local-dependency\"'.\n"
 	require.Equal(t, expectedResult, string(runResult.RunOutput))
 
-	runResult2, _ := suite.RunPackageWithParams(ctx, packageWithoutReplaceRelPath, packageWithoutReplaceParams)
-
+	runResult2, err := suite.RunPackageWithParams(ctx, packageWithoutReplaceRelPath, packageWithoutReplaceParams)
+	require.NoError(t, err)
 	require.Nil(t, runResult.InterpretationError)
 	require.Empty(t, runResult.ValidationErrors)
 	require.Nil(t, runResult.ExecutionError)

--- a/internal_testsuites/golang/testsuite/startosis_replace_test/startosis_replace_with_local_and_then_with_remote_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_replace_test/startosis_replace_with_local_and_then_with_remote_test.go
@@ -16,17 +16,21 @@ func (suite *StartosisReplaceTestSuite) TestStartosisReplaceWithLocalAndThenWith
 
 	t := suite.T()
 	require.NoError(t, err)
+	require.NotNil(t, runResult)
+
 	require.Nil(t, runResult.InterpretationError)
 	require.Empty(t, runResult.ValidationErrors)
 	require.Nil(t, runResult.ExecutionError)
 	expectedResult := "Replace with local package loaded.\nVerification succeeded. Value is '\"msg-loaded-from-local-dependency\"'.\n"
 	require.Equal(t, expectedResult, string(runResult.RunOutput))
 
-	runResult2, err := suite.RunPackageWithParams(ctx, packageWithoutReplaceRelPath, packageWithoutReplaceParams)
-	require.NoError(t, err)
-	require.Nil(t, runResult.InterpretationError)
-	require.Empty(t, runResult.ValidationErrors)
-	require.Nil(t, runResult.ExecutionError)
+	runResult2, err2 := suite.RunPackageWithParams(ctx, packageWithoutReplaceRelPath, packageWithoutReplaceParams)
+	require.NoError(t, err2)
+	require.NotNil(t, runResult2)
+
+	require.Nil(t, runResult2.InterpretationError)
+	require.Empty(t, runResult2.ValidationErrors)
+	require.Nil(t, runResult2.ExecutionError)
 	expectedResult2 := "Without replace package loaded.\nVerification succeeded. Value is '\"dependency-loaded-from-main\"'.\n"
 	require.Equal(t, expectedResult2, string(runResult2.RunOutput))
 }

--- a/internal_testsuites/golang/testsuite/startosis_replace_test/startosis_replace_with_local_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_replace_test/startosis_replace_with_local_test.go
@@ -12,9 +12,10 @@ const (
 
 func (suite *StartosisReplaceTestSuite) TestStartosisReplaceWithLocal() {
 	ctx := context.Background()
-	runResult, _ := suite.RunPackageWithParams(ctx, packageWithLocalReplaceRelPath, packageWithLocalReplaceParams)
+	runResult, err := suite.RunPackageWithParams(ctx, packageWithLocalReplaceRelPath, packageWithLocalReplaceParams)
 
 	t := suite.T()
+	require.NoError(t, err)
 	require.Nil(t, runResult.InterpretationError)
 	require.Empty(t, runResult.ValidationErrors)
 	require.Nil(t, runResult.ExecutionError)

--- a/internal_testsuites/golang/testsuite/startosis_replace_test/startosis_replace_with_local_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_replace_test/startosis_replace_with_local_test.go
@@ -16,6 +16,8 @@ func (suite *StartosisReplaceTestSuite) TestStartosisReplaceWithLocal() {
 
 	t := suite.T()
 	require.NoError(t, err)
+	require.NotNil(t, runResult)
+
 	require.Nil(t, runResult.InterpretationError)
 	require.Empty(t, runResult.ValidationErrors)
 	require.Nil(t, runResult.ExecutionError)

--- a/internal_testsuites/golang/testsuite/startosis_subpackage_test/startosis_remote_subpackage_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_subpackage_test/startosis_remote_subpackage_test.go
@@ -36,9 +36,10 @@ func (suite *StartosisSubpackageTestSuite) TestStarlarkRemotePackage() {
 func (suite *StartosisSubpackageTestSuite) TestStartosisSiblingRemotePackages_RelativeImports() {
 	ctx := context.Background()
 	isRemotePackage := true
-	runResult, _ := suite.RunPackage(ctx, packageWithSiblingImport, isRemotePackage)
+	runResult, err := suite.RunPackage(ctx, packageWithSiblingImport, isRemotePackage)
 
 	t := suite.T()
+	require.NoError(t, err)
 	require.Nil(t, runResult.InterpretationError)
 	require.Empty(t, runResult.ValidationErrors)
 	require.Nil(t, runResult.ExecutionError)


### PR DESCRIPTION
## Description:
When an unexpected error happens in `enclave_context.RunStarlarkPackageBlocking`, it will return `(nil, error)`.  Some tests don't account for this, so they don't detect or report said error, then panic when trying to reference the `nil` result. 

This adds `require.NoError(t, err)` to all the tests I could find that hit this codepath. 

## Is this change user facing?
NO

## References (if applicable):
https://github.com/kurtosis-tech/kurtosis/issues/1538
