### PR TITLE
fix: show container status instead of service status in enclave inspect

### DIFF
--- a/cli/cli/commands/enclave/inspect/user_services.go
+++ b/cli/cli/commands/enclave/inspect/user_services.go
@@ -5,6 +5,7 @@ import (
 	"github.com/kurtosis-tech/kurtosis/api/golang/core/kurtosis_core_rpc_api_bindings"
 	"github.com/kurtosis-tech/kurtosis/api/golang/engine/kurtosis_engine_rpc_api_bindings"
 	"github.com/kurtosis-tech/kurtosis/api/golang/engine/lib/kurtosis_context"
+	"github.com/kurtosis-tech/kurtosis/cli/cli/helpers/container_status_stringifier"
 	"github.com/kurtosis-tech/kurtosis/cli/cli/helpers/output_printers"
 	"github.com/kurtosis-tech/kurtosis/cli/cli/helpers/service_status_stringifier"
 	"github.com/kurtosis-tech/kurtosis/cli/cli/helpers/user_services"
@@ -12,15 +13,11 @@ import (
 )
 
 const (
-	userServiceUUIDColHeader      = "UUID"
-	userServiceNameColHeader      = "Name"
-	userServicePortsColHeader     = "Ports"
-	userServiceStatusColHeader    = "Status"
-	defaultEmptyIPAddrForServices = ""
-	emptyApplicationProtocol      = ""
-	missingPortPlaceholder        = "<none>"
-	linkDelimeter                 = "://"
-	defaultEmptyIPAddrForAPIC     = ""
+	userServiceUUIDColHeader            = "UUID"
+	userServiceNameColHeader            = "Name"
+	userServicePortsColHeader           = "Ports"
+	userServiceStatusColHeader          = "Service Status"
+	userServiceContainerStatusColHeader = "Container Status"
 )
 
 func printUserServices(ctx context.Context, _ *kurtosis_context.KurtosisContext, enclaveInfo *kurtosis_engine_rpc_api_bindings.EnclaveInfo, showFullUuids bool, isAPIContainerRunning bool) error {
@@ -39,6 +36,7 @@ func printUserServices(ctx context.Context, _ *kurtosis_context.KurtosisContext,
 		userServiceNameColHeader,
 		userServicePortsColHeader,
 		userServiceStatusColHeader,
+		userServiceContainerStatusColHeader,
 	)
 	sortedUserServices := user_services.GetSortedUserServiceSliceFromUserServiceMap(userServices)
 	for _, userService := range sortedUserServices {
@@ -52,6 +50,9 @@ func printUserServices(ctx context.Context, _ *kurtosis_context.KurtosisContext,
 		serviceStatus := userService.GetServiceStatus()
 		serviceStatusStr := service_status_stringifier.ServiceStatusStringifier(serviceStatus)
 
+		containerStatus := userService.GetContainer().GetStatus()
+		containerStatusStr := container_status_stringifier.ContainerStatusStringifier(containerStatus)
+
 		portBindingLines, err := user_services.GetUserServicePortBindingStrings(userService)
 		if err != nil {
 			return stacktrace.Propagate(err, "An error occurred getting the port binding strings")
@@ -59,7 +60,7 @@ func printUserServices(ctx context.Context, _ *kurtosis_context.KurtosisContext,
 		firstPortBindingLine := portBindingLines[0]
 		additionalPortBindingLines := portBindingLines[1:]
 
-		if err := tablePrinter.AddRow(uuidToPrint, serviceIdStr, firstPortBindingLine, serviceStatusStr); err != nil {
+		if err := tablePrinter.AddRow(uuidToPrint, serviceIdStr, firstPortBindingLine, serviceStatusStr, containerStatusStr); err != nil {
 			return stacktrace.Propagate(
 				err,
 				"An error occurred adding row for user service with UUID '%v' to the table printer",
@@ -68,7 +69,7 @@ func printUserServices(ctx context.Context, _ *kurtosis_context.KurtosisContext,
 		}
 
 		for _, additionalPortBindingLine := range additionalPortBindingLines {
-			if err := tablePrinter.AddRow("", "", additionalPortBindingLine, ""); err != nil {
+			if err := tablePrinter.AddRow("", "", additionalPortBindingLine, "", ""); err != nil {
 				return stacktrace.Propagate(
 					err,
 					"An error occurred adding additional port binding row '%v' for user service with UUID '%v' to the table printer",

--- a/cli/cli/commands/enclave/inspect/user_services.go
+++ b/cli/cli/commands/enclave/inspect/user_services.go
@@ -7,17 +7,15 @@ import (
 	"github.com/kurtosis-tech/kurtosis/api/golang/engine/lib/kurtosis_context"
 	"github.com/kurtosis-tech/kurtosis/cli/cli/helpers/container_status_stringifier"
 	"github.com/kurtosis-tech/kurtosis/cli/cli/helpers/output_printers"
-	"github.com/kurtosis-tech/kurtosis/cli/cli/helpers/service_status_stringifier"
 	"github.com/kurtosis-tech/kurtosis/cli/cli/helpers/user_services"
 	"github.com/kurtosis-tech/stacktrace"
 )
 
 const (
-	userServiceUUIDColHeader            = "UUID"
-	userServiceNameColHeader            = "Name"
-	userServicePortsColHeader           = "Ports"
-	userServiceStatusColHeader          = "Service Status"
-	userServiceContainerStatusColHeader = "Container Status"
+	userServiceUUIDColHeader   = "UUID"
+	userServiceNameColHeader   = "Name"
+	userServicePortsColHeader  = "Ports"
+	userServiceStatusColHeader = "Status"
 )
 
 func printUserServices(ctx context.Context, _ *kurtosis_context.KurtosisContext, enclaveInfo *kurtosis_engine_rpc_api_bindings.EnclaveInfo, showFullUuids bool, isAPIContainerRunning bool) error {
@@ -36,7 +34,6 @@ func printUserServices(ctx context.Context, _ *kurtosis_context.KurtosisContext,
 		userServiceNameColHeader,
 		userServicePortsColHeader,
 		userServiceStatusColHeader,
-		userServiceContainerStatusColHeader,
 	)
 	sortedUserServices := user_services.GetSortedUserServiceSliceFromUserServiceMap(userServices)
 	for _, userService := range sortedUserServices {
@@ -46,9 +43,6 @@ func printUserServices(ctx context.Context, _ *kurtosis_context.KurtosisContext,
 		if showFullUuids {
 			uuidToPrint = uuidStr
 		}
-
-		serviceStatus := userService.GetServiceStatus()
-		serviceStatusStr := service_status_stringifier.ServiceStatusStringifier(serviceStatus)
 
 		containerStatus := userService.GetContainer().GetStatus()
 		containerStatusStr := container_status_stringifier.ContainerStatusStringifier(containerStatus)
@@ -60,7 +54,7 @@ func printUserServices(ctx context.Context, _ *kurtosis_context.KurtosisContext,
 		firstPortBindingLine := portBindingLines[0]
 		additionalPortBindingLines := portBindingLines[1:]
 
-		if err := tablePrinter.AddRow(uuidToPrint, serviceIdStr, firstPortBindingLine, serviceStatusStr, containerStatusStr); err != nil {
+		if err := tablePrinter.AddRow(uuidToPrint, serviceIdStr, firstPortBindingLine, containerStatusStr); err != nil {
 			return stacktrace.Propagate(
 				err,
 				"An error occurred adding row for user service with UUID '%v' to the table printer",
@@ -69,7 +63,7 @@ func printUserServices(ctx context.Context, _ *kurtosis_context.KurtosisContext,
 		}
 
 		for _, additionalPortBindingLine := range additionalPortBindingLines {
-			if err := tablePrinter.AddRow("", "", additionalPortBindingLine, "", ""); err != nil {
+			if err := tablePrinter.AddRow("", "", additionalPortBindingLine, ""); err != nil {
 				return stacktrace.Propagate(
 					err,
 					"An error occurred adding additional port binding row '%v' for user service with UUID '%v' to the table printer",

--- a/cli/cli/helpers/container_status_stringifier/container_status_stringifier.go
+++ b/cli/cli/helpers/container_status_stringifier/container_status_stringifier.go
@@ -1,0 +1,23 @@
+package container_status_stringifier
+
+import (
+	"github.com/fatih/color"
+	"github.com/kurtosis-tech/kurtosis/api/golang/core/kurtosis_core_rpc_api_bindings"
+)
+
+var (
+	colorizeRunning = color.New(color.FgGreen).SprintFunc()
+	colorizeStopped = color.New(color.FgYellow).SprintFunc()
+)
+
+func ContainerStatusStringifier(containerStatus kurtosis_core_rpc_api_bindings.Container_Status) string {
+	containerStatusStr := kurtosis_core_rpc_api_bindings.Container_Status_name[int32(containerStatus)]
+	switch containerStatus {
+	case kurtosis_core_rpc_api_bindings.Container_RUNNING:
+		return colorizeStopped(containerStatusStr)
+	case kurtosis_core_rpc_api_bindings.Container_STOPPED:
+		return colorizeRunning(containerStatusStr)
+	default:
+		return containerStatusStr
+	}
+}

--- a/cli/cli/helpers/container_status_stringifier/container_status_stringifier.go
+++ b/cli/cli/helpers/container_status_stringifier/container_status_stringifier.go
@@ -13,9 +13,9 @@ var (
 func ContainerStatusStringifier(containerStatus kurtosis_core_rpc_api_bindings.Container_Status) string {
 	containerStatusStr := kurtosis_core_rpc_api_bindings.Container_Status_name[int32(containerStatus)]
 	switch containerStatus {
-	case kurtosis_core_rpc_api_bindings.Container_RUNNING:
-		return colorizeStopped(containerStatusStr)
 	case kurtosis_core_rpc_api_bindings.Container_STOPPED:
+		return colorizeStopped(containerStatusStr)
+	case kurtosis_core_rpc_api_bindings.Container_RUNNING:
 		return colorizeRunning(containerStatusStr)
 	default:
 		return containerStatusStr


### PR DESCRIPTION
## Description:
If a service eventually dies we would still show `RUNNING` while in reality it would be stopped

1. Create an enclave
2. Stop a service
3. Use inspect -> this prints service status Running (Kurtosis was told to keep it running)

Post this PR

3. This would print container status -> Stopped - actually reflecting reality


## Is this change user facing?
YES

## References (if applicable):
Closes #1351 
