### PR TITLE
fix: correct the link to kurtosis upgrade docs

### DIFF
--- a/api/golang/engine/lib/kurtosis_context/kurtosis_context.go
+++ b/api/golang/engine/lib/kurtosis_context/kurtosis_context.go
@@ -485,7 +485,7 @@ func validateEngineApiVersion(ctx context.Context, engineServiceClient kurtosis_
 	if !doApiVersionsMatch {
 		return stacktrace.NewError(
 			"An API version mismatch was detected between the running engine version '%v' and the engine version this Kurtosis SDK library expects, '%v'. You should:\n"+
-				"  1) upgrade your Kurtosis CLI to latest using the instructions at https://docs.kurtosis.com/install#upgrading\n"+
+				"  1) upgrade your Kurtosis CLI to latest using the instructions at https://docs.kurtosis.com/upgrade\n"+
 				"  2) use the Kurtosis CLI to restart your engine via 'kurtosis engine restart'\n"+
 				"  3) upgrade your Kurtosis SDK library using the instructions at https://github.com/kurtosis-tech/kurtosis-engine-api-lib\n",
 			runningEngineSemver.String(),

--- a/api/typescript/src/engine/lib/kurtosis_context/kurtosis_context.ts
+++ b/api/typescript/src/engine/lib/kurtosis_context/kurtosis_context.ts
@@ -342,7 +342,7 @@ export class KurtosisContext {
             if (!doApiVersionsMatch) {
                 return err(new Error(
                     `An API version mismatch was detected between the running engine version '${runningEngineSemver.version}' and the engine version this Kurtosis SDK library expects, '${libraryEngineSemver.version}'. You should:\n` +
-                    `  1) upgrade your Kurtosis CLI to latest using the instructions at https://docs.kurtosis.com/install#upgrading\n` +
+                    `  1) upgrade your Kurtosis CLI to latest using the instructions at https://docs.kurtosis.com/upgrade\n` +
                     `  2) use the Kurtosis CLI to restart your engine via 'kurtosis engine restart'\n`	+
                     `  3) upgrade your Kurtosis SDK library using the instructions at https://github.com/kurtosis-tech/kurtosis-sdk\n`,
                 ));


### PR DESCRIPTION
## Description:
The link to upgrade kurtosis is out of date.  This updates it.

## Is this change user facing?
YES
<!-- If yes, please add the "user facing" label to the PR -->
<!-- If yes, don't forget to include docs changes where relevant -->


