### PR TITLE
fix: run_sh doesn't remove new lines from input

### DIFF
--- a/core/server/api_container/server/startosis_engine/kurtosis_instruction/tasks/run_sh.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_instruction/tasks/run_sh.go
@@ -21,7 +21,6 @@ import (
 	"github.com/kurtosis-tech/stacktrace"
 	"github.com/xtgo/uuid"
 	"go.starlark.net/starlark"
-	"strings"
 )
 
 const (
@@ -253,7 +252,6 @@ func getCommandToRun(builtin *RunShCapabilities) (string, error) {
 	if err != nil {
 		return "", stacktrace.Propagate(err, "An error occurred while replacing runtime values in run_sh")
 	}
-	commandWithNoNewLines := strings.ReplaceAll(maybeSubCommandWithRuntimeValues, newlineChar, " ")
 
-	return commandWithNoNewLines, nil
+	return maybeSubCommandWithRuntimeValues, nil
 }

--- a/internal_testsuites/golang/testsuite/startosis_run_sh_task_test/run_task_sh_task_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_run_sh_task_test/run_task_sh_task_test.go
@@ -11,7 +11,7 @@ const (
 	runshTest           = "run-sh-test"
 	runshStarlarkSimple = `
 def run(plan):
-  result1 = plan.run_sh(run="echo kurtosis")
+  result1 = plan.run_sh(run="echo kurtosis | tr -d '\n'")
   result2 = plan.run_sh(run="mkdir -p /src/{0} && cd /src/{0} && echo $(pwd)".format(result1.output))
   plan.verify(result2.output, "==", "/src/kurtosis\n")
 `
@@ -59,8 +59,9 @@ def run(plan):
 
 func TestStarlark_RunshTaskSimple(t *testing.T) {
 	ctx := context.Background()
-	runResult, _ := test_helpers.SetupSimpleEnclaveAndRunScript(t, ctx, runshTest, runshStarlarkSimple)
-	expectedOutput := "Command returned with exit code '0' and the following output:\n--------------------\nkurtosis\n\n--------------------\nCommand returned with exit code '0' and the following output:\n--------------------\n/src/kurtosis\n\n--------------------\nVerification succeeded. Value is '\"/src/kurtosis\\n\"'.\n"
+	runResult, err := test_helpers.SetupSimpleEnclaveAndRunScript(t, ctx, runshTest, runshStarlarkSimple)
+	require.Nil(t, err)
+	expectedOutput := "Command returned with exit code '0' and the following output: kurtosis\nCommand returned with exit code '0' and the following output:\n--------------------\n/src/kurtosis\n\n--------------------\nVerification succeeded. Value is '\"/src/kurtosis\\n\"'.\n"
 	require.Equal(t, expectedOutput, string(runResult.RunOutput))
 }
 

--- a/internal_testsuites/golang/testsuite/startosis_run_sh_task_test/run_task_sh_task_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_run_sh_task_test/run_task_sh_task_test.go
@@ -46,6 +46,15 @@ def run(plan):
   result2 = plan.run_sh(files={"/temp": files_artifacts[0]}, run="cat /temp/data/kurtosis.txt")
   plan.verify(result2.output, "==", "kurtosis\n")
 `
+	runShWithNewLineRemoval = `
+def run(plan):
+  result = plan.run_sh(run="mkdir -p /src && echo kurtosis > /src/tech.txt", store=["/src/tech.txt"])
+  file_artifacts = result.files_artifacts
+  result2 = plan.run_sh(run="cat /temp/tech.txt", files={"/temp": file_artifacts[0]})
+  plan.verify(result2.output, "==", "kurtosis\n")
+  result2 = plan.run_sh(run="cat /temp/tech.txt | tr -d '\n'", files={"/temp": file_artifacts[0]})
+  plan.verify(result2.output, "==", "kurtosis")
+`
 )
 
 func TestStarlark_RunshTaskSimple(t *testing.T) {
@@ -84,4 +93,10 @@ func TestStarlark_RunshFileArtifactWithoutParentDir(t *testing.T) {
 	runResult, _ := test_helpers.SetupSimpleEnclaveAndRunScript(t, ctx, runshTest, runshStarlarkIgnoreParentDir)
 	expectedOutput := "Command returned with exit code '0' with no output\nCommand returned with exit code '0' and the following output:\n--------------------\nkurtosis\n\n--------------------\nVerification succeeded. Value is '\"kurtosis\\n\"'.\n"
 	require.Equal(t, expectedOutput, string(runResult.RunOutput))
+}
+
+func TestStarlark_RunShWithNewLineRemovalPipe(t *testing.T) {
+	ctx := context.Background()
+	_, err := test_helpers.SetupSimpleEnclaveAndRunScript(t, ctx, runshTest, runShWithNewLineRemoval)
+	require.Nil(t, err)
 }

--- a/run.star
+++ b/run.star
@@ -1,7 +1,0 @@
-def run(plan):
-  result = plan.run_sh(run="mkdir -p /src && echo kurtosis > /src/tech.txt", store=["/src/tech.txt"])
-  file_artifacts = result.files_artifacts
-  result2 = plan.run_sh(run="cat /temp/tech.txt", files={"/temp": file_artifacts[0]})
-  plan.verify(result2.output, "==", "kurtosis\n")
-  result2 = plan.run_sh(run="cat /temp/tech.txt | tr -d '\n'", files={"/temp": file_artifacts[0]})
-  plan.verify(result2.output, "==", "kurtosis") # this should pass but fails

--- a/run.star
+++ b/run.star
@@ -1,0 +1,7 @@
+def run(plan):
+  result = plan.run_sh(run="mkdir -p /src && echo kurtosis > /src/tech.txt", store=["/src/tech.txt"])
+  file_artifacts = result.files_artifacts
+  result2 = plan.run_sh(run="cat /temp/tech.txt", files={"/temp": file_artifacts[0]})
+  plan.verify(result2.output, "==", "kurtosis\n")
+  result2 = plan.run_sh(run="cat /temp/tech.txt | tr -d '\n'", files={"/temp": file_artifacts[0]})
+  plan.verify(result2.output, "==", "kurtosis") # this should pass but fails


### PR DESCRIPTION
## Description:
Earlier `cat foo.txt | tr -d '\n'` wouldn't work as it would run as `cat foo.txt | tr -d ' '`
