### PR TITLE
feat: support deletion in the new enclave manager ui

### DIFF
--- a/enclave-manager/web/package.json
+++ b/enclave-manager/web/package.json
@@ -15,7 +15,9 @@
     "luxon": "^3.4.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-hook-form": "^7.47.0",
     "react-icons": "^4.11.0",
+    "react-markdown": "^9.0.0",
     "react-router-dom": "^6.17.0",
     "react-scripts": "5.0.1",
     "true-myth": "^7.1.0"

--- a/enclave-manager/web/src/client/enclaveManager/KurtosisClient.ts
+++ b/enclave-manager/web/src/client/enclaveManager/KurtosisClient.ts
@@ -1,10 +1,17 @@
 import { PromiseClient } from "@connectrpc/connect";
-import { DestroyEnclaveArgs, EnclaveInfo } from "enclave-manager-sdk/build/engine_service_pb";
+import { RunStarlarkPackageArgs } from "enclave-manager-sdk/build/api_container_service_pb";
+import {
+  CreateEnclaveArgs,
+  DestroyEnclaveArgs,
+  EnclaveInfo,
+  EnclaveMode,
+} from "enclave-manager-sdk/build/engine_service_pb";
 import { KurtosisEnclaveManagerServer } from "enclave-manager-sdk/build/kurtosis_enclave_manager_api_connect";
 import {
   GetListFilesArtifactNamesAndUuidsRequest,
   GetServicesRequest,
   GetStarlarkRunRequest,
+  RunStarlarkPackageRequest,
 } from "enclave-manager-sdk/build/kurtosis_enclave_manager_api_pb";
 import { assertDefined, asyncResult } from "../../utils";
 import { RemoveFunctions } from "../../utils/types";
@@ -73,5 +80,41 @@ export abstract class KurtosisClient {
       });
       return this.client.listFilesArtifactNamesAndUuids(request, this.getHeaderOptions());
     }, "KurtosisClient could not listFilesArtifactNamesAndUuids");
+  }
+
+  async createEnclave(
+    enclaveName: string,
+    apiContainerLogLevel: string,
+    productionMode?: boolean,
+    apiContainerVersionTag?: string,
+  ) {
+    return asyncResult(() => {
+      const request = new CreateEnclaveArgs({
+        enclaveName,
+        apiContainerLogLevel,
+        mode: productionMode ? EnclaveMode.PRODUCTION : EnclaveMode.TEST,
+        apiContainerVersionTag: apiContainerVersionTag || "",
+      });
+      return this.client.createEnclave(request, this.getHeaderOptions());
+    });
+  }
+
+  async runStarlarkPackage(enclave: RemoveFunctions<EnclaveInfo>, packageId: string, args: Record<string, any>) {
+    // Not currently using asyncResult as the return type here is an asyncIterable
+    const apicInfo = enclave.apiContainerInfo;
+    assertDefined(
+      apicInfo,
+      `Cannot listFilesArtifactNamesAndUuids because the passed enclave '${enclave.name}' does not have apicInfo`,
+    );
+    const request = new RunStarlarkPackageRequest({
+      apicIpAddress: apicInfo.bridgeIpAddress,
+      apicPort: apicInfo.grpcPortInsideEnclave,
+      RunStarlarkPackageArgs: new RunStarlarkPackageArgs({
+        dryRun: false,
+        packageId: packageId,
+        serializedParams: JSON.stringify(args),
+      }),
+    });
+    return this.client.runStarlarkPackage(request, this.getHeaderOptions());
   }
 }

--- a/enclave-manager/web/src/client/enclaveManager/KurtosisClient.ts
+++ b/enclave-manager/web/src/client/enclaveManager/KurtosisClient.ts
@@ -1,5 +1,5 @@
 import { PromiseClient } from "@connectrpc/connect";
-import { EnclaveInfo } from "enclave-manager-sdk/build/engine_service_pb";
+import { DestroyEnclaveArgs, EnclaveInfo } from "enclave-manager-sdk/build/engine_service_pb";
 import { KurtosisEnclaveManagerServer } from "enclave-manager-sdk/build/kurtosis_enclave_manager_api_connect";
 import {
   GetListFilesArtifactNamesAndUuidsRequest,
@@ -7,6 +7,7 @@ import {
   GetStarlarkRunRequest,
 } from "enclave-manager-sdk/build/kurtosis_enclave_manager_api_pb";
 import { assertDefined, asyncResult } from "../../utils";
+import { RemoveFunctions } from "../../utils/types";
 
 export abstract class KurtosisClient {
   protected client: PromiseClient<typeof KurtosisEnclaveManagerServer>;
@@ -25,7 +26,14 @@ export abstract class KurtosisClient {
     return asyncResult(this.client.getEnclaves({}, this.getHeaderOptions()), "KurtosisClient could not getEnclaves");
   }
 
-  async getServices(enclave: EnclaveInfo) {
+  async destroy(enclaveUUID: string) {
+    return asyncResult(
+      this.client.destroyEnclave(new DestroyEnclaveArgs({ enclaveIdentifier: enclaveUUID }), this.getHeaderOptions()),
+      `KurtosisClient could not destroy enclave ${enclaveUUID}`,
+    );
+  }
+
+  async getServices(enclave: RemoveFunctions<EnclaveInfo>) {
     return await asyncResult(() => {
       const apicInfo = enclave.apiContainerInfo;
       assertDefined(apicInfo, `Cannot getServices because the passed enclave '${enclave.name}' does not have apicInfo`);
@@ -37,7 +45,7 @@ export abstract class KurtosisClient {
     }, "KurtosisClient could not getServices");
   }
 
-  async getStarlarkRun(enclave: EnclaveInfo) {
+  async getStarlarkRun(enclave: RemoveFunctions<EnclaveInfo>) {
     return await asyncResult(() => {
       const apicInfo = enclave.apiContainerInfo;
       assertDefined(
@@ -52,7 +60,7 @@ export abstract class KurtosisClient {
     }, "KurtosisClient could not getStarlarkRun");
   }
 
-  async listFilesArtifactNamesAndUuids(enclave: EnclaveInfo) {
+  async listFilesArtifactNamesAndUuids(enclave: RemoveFunctions<EnclaveInfo>) {
     return await asyncResult(() => {
       const apicInfo = enclave.apiContainerInfo;
       assertDefined(

--- a/enclave-manager/web/src/components/CopyButton.tsx
+++ b/enclave-manager/web/src/components/CopyButton.tsx
@@ -1,0 +1,31 @@
+import { Button, ButtonProps, useToast } from "@chakra-ui/react";
+import { FiCopy } from "react-icons/fi";
+import { isDefined } from "../utils";
+
+type CopyButtonProps = ButtonProps & {
+  valueToCopy?: string | null;
+};
+
+export const CopyButton = ({ valueToCopy, ...buttonProps }: CopyButtonProps) => {
+  const toast = useToast();
+
+  const handleCopyClick = () => {
+    if (isDefined(valueToCopy)) {
+      navigator.clipboard.writeText(valueToCopy);
+      toast({
+        title: `Copied '${valueToCopy}' to the clipboard`,
+        status: `success`,
+      });
+    }
+  };
+
+  if (!isDefined(valueToCopy)) {
+    return null;
+  }
+
+  return (
+    <Button leftIcon={<FiCopy />} size={"xs"} colorScheme={"darkBlue"} onClick={handleCopyClick} {...buttonProps}>
+      Copy
+    </Button>
+  );
+};

--- a/enclave-manager/web/src/components/KurtosisAlertModal.tsx
+++ b/enclave-manager/web/src/components/KurtosisAlertModal.tsx
@@ -1,0 +1,58 @@
+import {
+  Button,
+  ButtonProps,
+  Flex,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Text,
+} from "@chakra-ui/react";
+
+type KurtosisAlertModalProps = {
+  title: string;
+  content: string;
+  isOpen: boolean;
+  isLoading: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  confirmText: string;
+  confirmButtonProps?: ButtonProps;
+};
+
+export const KurtosisAlertModal = ({
+  title,
+  content,
+  isOpen,
+  isLoading,
+  onClose,
+  onConfirm,
+  confirmText,
+  confirmButtonProps,
+}: KurtosisAlertModalProps) => {
+  return (
+    <Modal isOpen={isOpen} onClose={() => !isLoading && onClose()} isCentered>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>{title}</ModalHeader>
+        <ModalCloseButton />
+        <ModalBody>
+          <Text>{content}</Text>
+        </ModalBody>
+        <ModalFooter>
+          <Flex justifyContent={"flex-end"} gap={"12px"}>
+            <Button color={"gray.100"} onClick={onClose} disabled={isLoading}>
+              Cancel
+            </Button>
+            <Button onClick={onConfirm} {...confirmButtonProps} isLoading={isLoading}>
+              {confirmText}
+            </Button>
+          </Flex>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+};

--- a/enclave-manager/web/src/components/KurtosisBreadcrumbs.tsx
+++ b/enclave-manager/web/src/components/KurtosisBreadcrumbs.tsx
@@ -18,12 +18,10 @@ export const KurtosisBreadcrumbs = () => {
     .map((match) => (isDefined(match.handle?.crumb) ? match.handle.crumb(match.data, match.params) : null))
     .filter(isDefined);
 
-  const crumbs: KurtosisBreadcrumb[] = [...(matchCrumbs.length > 1 ? matchCrumbs : [])];
-
   return (
     <Flex h="40px" p={"4px 0"} alignItems={"center"}>
       <Breadcrumb variant={"topNavigation"} separator={<ChevronRightIcon h={"20px"} w={"24px"} />}>
-        {crumbs.map(({ name, destination }, i, arr) => (
+        {matchCrumbs.map(({ name, destination }, i, arr) => (
           <BreadcrumbItem key={i} isCurrentPage={i === arr.length - 1}>
             <BreadcrumbLink as={i === arr.length - 1 ? undefined : Link} to={destination}>
               {name}

--- a/enclave-manager/web/src/components/KurtosisBreadcrumbs.tsx
+++ b/enclave-manager/web/src/components/KurtosisBreadcrumbs.tsx
@@ -1,5 +1,6 @@
 import { ChevronRightIcon } from "@chakra-ui/icons";
 import { Breadcrumb, BreadcrumbItem, BreadcrumbLink, Flex } from "@chakra-ui/react";
+import { useEffect, useState } from "react";
 import { Link, Params, UIMatch, useMatches } from "react-router-dom";
 import { isDefined } from "../utils";
 
@@ -11,12 +12,24 @@ export type KurtosisBreadcrumb = {
 export const KurtosisBreadcrumbs = () => {
   const matches = useMatches() as UIMatch<
     object,
-    { crumb?: (data: object, params: Params<string>) => KurtosisBreadcrumb }
+    { crumb?: (data: object, params: Params<string>) => KurtosisBreadcrumb | Promise<KurtosisBreadcrumb> }
   >[];
 
-  const matchCrumbs = matches
-    .map((match) => (isDefined(match.handle?.crumb) ? match.handle.crumb(match.data, match.params) : null))
-    .filter(isDefined);
+  const [matchCrumbs, setMatchCrumbs] = useState<KurtosisBreadcrumb[]>([]);
+
+  useEffect(() => {
+    (async () => {
+      setMatchCrumbs(
+        await Promise.all(
+          matches
+            .map((match) =>
+              isDefined(match.handle?.crumb) ? Promise.resolve(match.handle.crumb(match.data, match.params)) : null,
+            )
+            .filter(isDefined),
+        ),
+      );
+    })();
+  }, [matches]);
 
   return (
     <Flex h="40px" p={"4px 0"} alignItems={"center"}>

--- a/enclave-manager/web/src/components/KurtosisThemeProvider.tsx
+++ b/enclave-manager/web/src/components/KurtosisThemeProvider.tsx
@@ -3,6 +3,7 @@ import type { ChakraProviderProps } from "@chakra-ui/react/dist/chakra-provider"
 import { mode } from "@chakra-ui/theme-tools";
 import { PropsWithChildren } from "react";
 import Fonts from "./theme/Fonts";
+import { formsTheme } from "./theme/formsTheme";
 import { tabsTheme } from "./theme/tabsTheme";
 import { tagTheme } from "./theme/tagsTheme";
 
@@ -78,6 +79,12 @@ const theme = extendTheme({
     }),
   },
   components: {
+    Badge: {
+      baseStyle: {
+        textTransform: "none",
+        color: "gray.100",
+      },
+    },
     Button: {
       defaultProps: {
         variant: "outline",
@@ -179,6 +186,14 @@ const theme = extendTheme({
         },
       })),
     },
+    Form: formsTheme,
+    Menu: {
+      baseStyle: {
+        list: {
+          minW: "unset",
+        },
+      },
+    },
     Popover: {
       baseStyle: {
         content: {
@@ -187,6 +202,16 @@ const theme = extendTheme({
         },
       },
     },
+    Switch: {
+      baseStyle: defineStyle((props) => ({
+        track: {
+          _checked: {
+            bg: `${props.colorScheme}.500`,
+          },
+        },
+      })),
+    },
+
     Table: {
       variants: {
         simple: {

--- a/enclave-manager/web/src/components/ValueCard.tsx
+++ b/enclave-manager/web/src/components/ValueCard.tsx
@@ -1,7 +1,7 @@
-import { Button, Card, Flex, Text, useToast } from "@chakra-ui/react";
+import { Card, Flex, Text, useToast } from "@chakra-ui/react";
 import { ReactElement } from "react";
-import { FiCopy } from "react-icons/fi";
-import { assertDefined, isDefined } from "../utils";
+import { isDefined } from "../utils";
+import { CopyButton } from "./CopyButton";
 
 type ValueCardProps = {
   title: string;
@@ -13,16 +13,6 @@ type ValueCardProps = {
 export const ValueCard = ({ title, value, copyEnabled, copyValue }: ValueCardProps) => {
   const toast = useToast();
 
-  const handleCopyClick = () => {
-    const valueToUse = isDefined(copyValue) ? copyValue : typeof value === "string" ? value : null;
-    assertDefined(valueToUse, `Cannot work out which value to copy in ${title} value card`);
-    navigator.clipboard.writeText(valueToUse);
-    toast({
-      title: `Copied '${valueToUse}' to the clipboard`,
-      status: `success`,
-    });
-  };
-
   return (
     <Card height={"100%"} display={"flex"} flexDirection={"column"} justifyContent={"space-between"} gap={"16px"}>
       <Flex flexDirection={"row"} justifyContent={"space-between"} alignItems={"center"} width={"100%"}>
@@ -30,9 +20,7 @@ export const ValueCard = ({ title, value, copyEnabled, copyValue }: ValueCardPro
           {title}
         </Text>
         {copyEnabled && (
-          <Button leftIcon={<FiCopy />} size={"xs"} colorScheme={"darkBlue"} onClick={handleCopyClick}>
-            Copy
-          </Button>
+          <CopyButton valueToCopy={isDefined(copyValue) ? copyValue : typeof value === "string" ? value : null} />
         )}
       </Flex>
       <Text fontSize={"xl"}>{value}</Text>

--- a/enclave-manager/web/src/components/enclaves/CreateEnclaveButton.tsx
+++ b/enclave-manager/web/src/components/enclaves/CreateEnclaveButton.tsx
@@ -1,0 +1,56 @@
+import { Button, Menu, MenuButton, MenuItem, MenuList } from "@chakra-ui/react";
+import { useState } from "react";
+import { FiPackage, FiPlus, FiSettings } from "react-icons/fi";
+import { useNavigate } from "react-router-dom";
+import { KurtosisPackage } from "../../client/packageIndexer/api/kurtosis_package_indexer_pb";
+import { isDefined } from "../../utils";
+import { ConfigureEnclaveModal } from "./modals/ConfigureEnclaveModal";
+import { ManualCreateEnclaveModal } from "./modals/ManualCreateEnclaveModal";
+
+export const CreateEnclaveButton = () => {
+  const navigate = useNavigate();
+  const [manualCreateEnclaveOpen, setManualCreateEnclaveOpen] = useState(false);
+  const [configureEnclaveOpen, setConfigureEnclaveOpen] = useState(false);
+  const [kurtosisPackage, setKurtosisPackage] = useState<KurtosisPackage>();
+
+  const handleManualCreateEnclaveClick = () => {
+    setKurtosisPackage(undefined);
+    setManualCreateEnclaveOpen(true);
+  };
+
+  const handleManualCreateEnclaveConfirmed = (kurtosisPackage: KurtosisPackage) => {
+    setKurtosisPackage(kurtosisPackage);
+    setManualCreateEnclaveOpen(false);
+    setConfigureEnclaveOpen(true);
+  };
+
+  return (
+    <>
+      <Menu matchWidth>
+        <MenuButton as={Button} colorScheme={"kurtosisGreen"} leftIcon={<FiPlus />} size={"md"}>
+          Create Enclave
+        </MenuButton>
+        <MenuList>
+          <MenuItem onClick={handleManualCreateEnclaveClick} icon={<FiSettings />}>
+            Manual
+          </MenuItem>
+          <MenuItem onClick={() => navigate("/catalog")} icon={<FiPackage />}>
+            Catalog
+          </MenuItem>
+        </MenuList>
+      </Menu>
+      <ManualCreateEnclaveModal
+        isOpen={manualCreateEnclaveOpen}
+        onClose={() => setManualCreateEnclaveOpen(false)}
+        onConfirm={handleManualCreateEnclaveConfirmed}
+      />
+      {isDefined(kurtosisPackage) && (
+        <ConfigureEnclaveModal
+          isOpen={configureEnclaveOpen}
+          onClose={() => setConfigureEnclaveOpen(false)}
+          kurtosisPackage={kurtosisPackage}
+        />
+      )}
+    </>
+  );
+};

--- a/enclave-manager/web/src/components/enclaves/configuration/EnclaveConfigurationForm.tsx
+++ b/enclave-manager/web/src/components/enclaves/configuration/EnclaveConfigurationForm.tsx
@@ -1,0 +1,93 @@
+import { PropsWithChildren } from "react";
+import { FormProvider, SubmitHandler, useForm, useFormContext } from "react-hook-form";
+import {
+  ArgumentValueType,
+  KurtosisPackage,
+  PackageArg,
+} from "../../../client/packageIndexer/api/kurtosis_package_indexer_pb";
+import { isDefined, isStringTrue } from "../../../utils";
+import { ConfigureEnclaveForm } from "./types";
+
+type PackageConfigurationFormProps = PropsWithChildren<{
+  onSubmit: SubmitHandler<ConfigureEnclaveForm>;
+  kurtosisPackage: KurtosisPackage;
+}>;
+
+export const EnclaveConfigurationForm = ({ children, kurtosisPackage, onSubmit }: PackageConfigurationFormProps) => {
+  const methods = useForm<ConfigureEnclaveForm>();
+
+  const handleSubmit: SubmitHandler<ConfigureEnclaveForm> = (data) => {
+    const transformValue = (
+      valueType: ArgumentValueType | undefined,
+      value: any,
+      innerValuetype?: ArgumentValueType,
+    ) => {
+      // The DICT type is stored as an array of {key, value} objects, before passing it up we should correct
+      // any instances of it to be Record<string, any> objects
+      const transformRecordsToObject = (records: { key: string; value: any }[], valueType?: ArgumentValueType) =>
+        records.reduce(
+          (acc, { key, value }) => ({
+            ...acc,
+            [key]: valueType === ArgumentValueType.BOOL ? isStringTrue(value) : value,
+          }),
+          {},
+        );
+
+      switch (valueType) {
+        case ArgumentValueType.DICT:
+          return transformRecordsToObject(value, innerValuetype);
+        case ArgumentValueType.LIST:
+          return value.map((v: any) => transformValue(innerValuetype, v));
+        case ArgumentValueType.BOOL:
+          return isStringTrue(value);
+        case ArgumentValueType.INTEGER:
+          return isNaN(value) || isNaN(parseFloat(value)) ? null : parseFloat(value);
+        case ArgumentValueType.STRING:
+          return value;
+        case ArgumentValueType.JSON:
+          return JSON.parse(value);
+        default:
+          return value;
+      }
+    };
+
+    const newArgs: Record<string, any> = kurtosisPackage.args
+      .map((arg): [PackageArg, any] => [
+        arg,
+        transformValue(
+          arg.typeV2?.topLevelType,
+          data.args[arg.name],
+          arg.typeV2?.topLevelType === ArgumentValueType.LIST ? arg.typeV2?.innerType1 : arg.typeV2?.innerType2,
+        ),
+      ])
+      .filter(([arg, value]) => {
+        switch (arg.typeV2?.topLevelType) {
+          case ArgumentValueType.DICT:
+            return Object.keys(value).length > 0;
+          case ArgumentValueType.LIST:
+            return value.length > 0;
+          case ArgumentValueType.STRING:
+            return isDefined(value) && value.length > 0;
+          default:
+            return isDefined(value);
+        }
+      })
+      .reduce(
+        (acc, [arg, value]) => ({
+          ...acc,
+          [arg.name]: value,
+        }),
+        {},
+      );
+
+    onSubmit({ ...data, args: newArgs });
+  };
+
+  return (
+    <FormProvider {...methods}>
+      <form onSubmit={methods.handleSubmit(handleSubmit)}>{children}</form>
+    </FormProvider>
+  );
+};
+
+export const useEnclaveConfigurationFormContext = () => useFormContext<ConfigureEnclaveForm>();

--- a/enclave-manager/web/src/components/enclaves/configuration/KurtosisArgumentFormControl.tsx
+++ b/enclave-manager/web/src/components/enclaves/configuration/KurtosisArgumentFormControl.tsx
@@ -1,0 +1,47 @@
+import { Badge, Flex, FormControl, FormErrorMessage, FormHelperText, FormLabel } from "@chakra-ui/react";
+import { PropsWithChildren } from "react";
+import { FieldError, FieldPath } from "react-hook-form";
+import Markdown from "react-markdown";
+import { isDefined } from "../../../utils";
+import { useEnclaveConfigurationFormContext } from "./EnclaveConfigurationForm";
+import { ConfigureEnclaveForm } from "./types";
+
+type KurtosisArguementFormControlProps = PropsWithChildren<{
+  name: FieldPath<ConfigureEnclaveForm>;
+  label: string;
+  type: string;
+  helperText?: string;
+  disabled?: boolean;
+  isRequired?: boolean;
+}>;
+export const KurtosisArgumentFormControl = ({
+  name,
+  label,
+  type,
+  helperText,
+  disabled,
+  isRequired,
+  children,
+}: KurtosisArguementFormControlProps) => {
+  const {
+    formState: { errors },
+  } = useEnclaveConfigurationFormContext();
+  // This looks a little strange because `FieldErrors` has the same structure as `ConfigureEnclaveForm`
+  const error = name
+    .split(".")
+    .reduce((e, part) => (isDefined(e) ? e[part] : undefined), errors as Record<string, any>) as FieldError | undefined;
+
+  return (
+    <FormControl isInvalid={isDefined(error)} isDisabled={disabled} isRequired={isRequired}>
+      <Flex alignItems={"center"}>
+        <FormLabel>{label}</FormLabel>
+        <Badge mb={2}>{type}</Badge>
+      </Flex>
+      {children}
+      <FormHelperText>
+        <Markdown>{helperText}</Markdown>
+      </FormHelperText>
+      <FormErrorMessage>{error?.message}</FormErrorMessage>
+    </FormControl>
+  );
+};

--- a/enclave-manager/web/src/components/enclaves/configuration/KurtosisPackageArgumentInput.tsx
+++ b/enclave-manager/web/src/components/enclaves/configuration/KurtosisPackageArgumentInput.tsx
@@ -1,0 +1,37 @@
+import { ArgumentValueType, PackageArg } from "../../../client/packageIndexer/api/kurtosis_package_indexer_pb";
+import { KurtosisArgumentTypeInput } from "./inputs/KurtosisArgumentTypeInput";
+import { KurtosisArgumentFormControl } from "./KurtosisArgumentFormControl";
+import { argToTypeString } from "./utils";
+
+type KurtosisPackageArgumentInputProps = {
+  argument: PackageArg;
+  disabled?: boolean;
+};
+
+export const KurtosisPackageArgumentInput = ({ argument, disabled }: KurtosisPackageArgumentInputProps) => {
+  if (argument.name === "plan") {
+    // The 'plan' argument is internal and is not used.
+    return null;
+  }
+
+  const fieldName: `args.${string}` = `args.${argument.name}`;
+
+  return (
+    <KurtosisArgumentFormControl
+      name={fieldName}
+      label={argument.name}
+      type={argToTypeString(argument)}
+      disabled={disabled}
+      isRequired={argument.isRequired}
+      helperText={argument.description}
+    >
+      <KurtosisArgumentTypeInput
+        type={argument.typeV2?.topLevelType || ArgumentValueType.JSON}
+        subType1={argument.typeV2?.innerType1}
+        subType2={argument.typeV2?.innerType2}
+        name={fieldName}
+        isRequired={argument.isRequired}
+      />
+    </KurtosisArgumentFormControl>
+  );
+};

--- a/enclave-manager/web/src/components/enclaves/configuration/inputs/BooleanArgumentInput.tsx
+++ b/enclave-manager/web/src/components/enclaves/configuration/inputs/BooleanArgumentInput.tsx
@@ -1,0 +1,49 @@
+import { Radio, RadioGroup, Stack, Switch } from "@chakra-ui/react";
+import { useEnclaveConfigurationFormContext } from "../EnclaveConfigurationForm";
+import { KurtosisArgumentTypeInputProps } from "./KurtosisArgumentTypeInput";
+
+type BooleanArgumentInputProps = Omit<KurtosisArgumentTypeInputProps, "type"> & {
+  inputType?: "radio" | "switch";
+};
+
+export const BooleanArgumentInput = ({ inputType, ...props }: BooleanArgumentInputProps) => {
+  const { register } = useEnclaveConfigurationFormContext();
+
+  if (inputType === "switch") {
+    return (
+      <Switch
+        colorScheme={"green"}
+        {...register(props.name, {
+          disabled: props.disabled,
+          required: props.isRequired,
+          value: true,
+        })}
+      />
+    );
+  } else {
+    return (
+      <RadioGroup>
+        <Stack direction={"row"}>
+          <Radio
+            {...register(props.name, {
+              disabled: props.disabled,
+              required: props.isRequired,
+            })}
+            value={"true"}
+          >
+            True
+          </Radio>
+          <Radio
+            {...register(props.name, {
+              disabled: props.disabled,
+              required: props.isRequired,
+            })}
+            value={"false"}
+          >
+            False
+          </Radio>
+        </Stack>
+      </RadioGroup>
+    );
+  }
+};

--- a/enclave-manager/web/src/components/enclaves/configuration/inputs/DictArgumentInput.tsx
+++ b/enclave-manager/web/src/components/enclaves/configuration/inputs/DictArgumentInput.tsx
@@ -1,0 +1,42 @@
+import { Button, Flex } from "@chakra-ui/react";
+import { ArgumentValueType } from "../../../../client/packageIndexer/api/kurtosis_package_indexer_pb";
+
+import { useFieldArray } from "react-hook-form";
+import { FiDelete, FiPlus } from "react-icons/fi";
+import { KurtosisArgumentTypeInput, KurtosisArgumentTypeInputProps } from "./KurtosisArgumentTypeInput";
+
+type DictArgumentInputProps = Omit<KurtosisArgumentTypeInputProps, "type"> & {
+  keyType: ArgumentValueType;
+  valueType: ArgumentValueType;
+};
+
+export const DictArgumentInput = ({ keyType, valueType, ...otherProps }: DictArgumentInputProps) => {
+  const { fields, append, remove } = useFieldArray({ name: otherProps.name });
+
+  return (
+    <Flex flexDirection={"column"} gap={"10px"}>
+      {fields.map((field, i) => (
+        <Flex key={i} gap={"10px"}>
+          <KurtosisArgumentTypeInput
+            type={keyType}
+            name={`${otherProps.name as `args.${string}.${number}.value`}.${i}.key`}
+            isRequired
+          />
+          <KurtosisArgumentTypeInput
+            type={valueType}
+            name={`${otherProps.name as `args.${string}.${number}.value`}.${i}.value`}
+            isRequired
+          />
+          <Button onClick={() => remove(i)} leftIcon={<FiDelete />} minW={"90px"}>
+            Delete
+          </Button>
+        </Flex>
+      ))}
+      <Flex>
+        <Button onClick={() => append({})} leftIcon={<FiPlus />} minW={"90px"}>
+          Add
+        </Button>
+      </Flex>
+    </Flex>
+  );
+};

--- a/enclave-manager/web/src/components/enclaves/configuration/inputs/IntegerArgumentInput.tsx
+++ b/enclave-manager/web/src/components/enclaves/configuration/inputs/IntegerArgumentInput.tsx
@@ -1,0 +1,21 @@
+import { Input } from "@chakra-ui/react";
+import { useEnclaveConfigurationFormContext } from "../EnclaveConfigurationForm";
+import { KurtosisArgumentTypeInputProps } from "./KurtosisArgumentTypeInput";
+
+export const IntegerArgumentInput = (props: Omit<KurtosisArgumentTypeInputProps, "type">) => {
+  const { register } = useEnclaveConfigurationFormContext();
+
+  return (
+    <Input
+      {...register(props.name, {
+        disabled: props.disabled,
+        required: props.isRequired,
+        validate: (value: number) => {
+          if (isNaN(value)) {
+            return "This value should be an integer";
+          }
+        },
+      })}
+    />
+  );
+};

--- a/enclave-manager/web/src/components/enclaves/configuration/inputs/JSONArgumentInput.tsx
+++ b/enclave-manager/web/src/components/enclaves/configuration/inputs/JSONArgumentInput.tsx
@@ -1,0 +1,25 @@
+import { Textarea } from "@chakra-ui/react";
+import { stringifyError } from "../../../../utils";
+import { useEnclaveConfigurationFormContext } from "../EnclaveConfigurationForm";
+import { KurtosisArgumentTypeInputProps } from "./KurtosisArgumentTypeInput";
+
+export const JSONArgumentInput = (props: Omit<KurtosisArgumentTypeInputProps, "type">) => {
+  const { register } = useEnclaveConfigurationFormContext();
+
+  return (
+    <Textarea
+      {...register(props.name, {
+        disabled: props.disabled,
+        required: props.isRequired,
+        value: "{}",
+        validate: (value: string) => {
+          try {
+            JSON.parse(value);
+          } catch (err: any) {
+            return `This is not valid JSON. ${stringifyError(err)}`;
+          }
+        },
+      })}
+    />
+  );
+};

--- a/enclave-manager/web/src/components/enclaves/configuration/inputs/KurtosisArgumentTypeInput.tsx
+++ b/enclave-manager/web/src/components/enclaves/configuration/inputs/KurtosisArgumentTypeInput.tsx
@@ -1,0 +1,55 @@
+import { FieldPath } from "react-hook-form";
+import { ArgumentValueType } from "../../../../client/packageIndexer/api/kurtosis_package_indexer_pb";
+import { assertDefined } from "../../../../utils";
+import { ConfigureEnclaveForm } from "../types";
+import { BooleanArgumentInput } from "./BooleanArgumentInput";
+import { DictArgumentInput } from "./DictArgumentInput";
+import { IntegerArgumentInput } from "./IntegerArgumentInput";
+import { JSONArgumentInput } from "./JSONArgumentInput";
+import { ListArgumentInput } from "./ListArgumentInput";
+import { StringArgumentInput } from "./StringArgumentInput";
+
+export type KurtosisArgumentTypeInputProps = {
+  type: ArgumentValueType;
+  subType1?: ArgumentValueType;
+  subType2?: ArgumentValueType;
+  name: FieldPath<ConfigureEnclaveForm>;
+  isRequired?: boolean;
+  disabled?: boolean;
+};
+
+export const KurtosisArgumentTypeInput = ({
+  type,
+  subType1,
+  subType2,
+  name,
+  isRequired,
+  disabled,
+}: KurtosisArgumentTypeInputProps) => {
+  switch (type) {
+    case ArgumentValueType.INTEGER:
+      return <IntegerArgumentInput name={name} isRequired={isRequired} disabled={disabled} />;
+    case ArgumentValueType.DICT:
+      assertDefined(subType1, `innerType1 was not defined on DICT argument ${name}`);
+      assertDefined(subType2, `innerType2 was not defined on DICT argument ${name}`);
+      return (
+        <DictArgumentInput
+          name={name}
+          isRequired={isRequired}
+          keyType={subType1}
+          valueType={subType2}
+          disabled={disabled}
+        />
+      );
+    case ArgumentValueType.LIST:
+      assertDefined(subType1, `innerType1 was not defined on DICT argument ${name}`);
+      return <ListArgumentInput name={name} isRequired={isRequired} valueType={subType1} disabled={disabled} />;
+    case ArgumentValueType.BOOL:
+      return <BooleanArgumentInput name={name} isRequired={isRequired} />;
+    case ArgumentValueType.STRING:
+      return <StringArgumentInput name={name} isRequired={isRequired} disabled={disabled} />;
+    case ArgumentValueType.JSON:
+    default:
+      return <JSONArgumentInput name={name} isRequired={isRequired} disabled={disabled} />;
+  }
+};

--- a/enclave-manager/web/src/components/enclaves/configuration/inputs/ListArgumentInput.tsx
+++ b/enclave-manager/web/src/components/enclaves/configuration/inputs/ListArgumentInput.tsx
@@ -1,0 +1,36 @@
+import { Button, Flex } from "@chakra-ui/react";
+import { ArgumentValueType } from "../../../../client/packageIndexer/api/kurtosis_package_indexer_pb";
+
+import { useFieldArray } from "react-hook-form";
+import { FiDelete, FiPlus } from "react-icons/fi";
+import { KurtosisArgumentTypeInput, KurtosisArgumentTypeInputProps } from "./KurtosisArgumentTypeInput";
+
+type ListArgumentInputProps = Omit<KurtosisArgumentTypeInputProps, "type"> & {
+  valueType: ArgumentValueType;
+};
+
+export const ListArgumentInput = ({ valueType, ...otherProps }: ListArgumentInputProps) => {
+  const { fields, append, remove } = useFieldArray({ name: otherProps.name });
+
+  return (
+    <Flex flexDirection={"column"} gap={"10px"}>
+      {fields.map((field, i) => (
+        <Flex key={i} gap={"10px"}>
+          <KurtosisArgumentTypeInput
+            type={valueType}
+            name={`${otherProps.name as `args.${string}.${number}`}.${i}.value`}
+            isRequired
+          />
+          <Button onClick={() => remove(i)} leftIcon={<FiDelete />} minW={"90px"}>
+            Delete
+          </Button>
+        </Flex>
+      ))}
+      <Flex>
+        <Button onClick={() => append({})} leftIcon={<FiPlus />} minW={"90px"}>
+          Add
+        </Button>
+      </Flex>
+    </Flex>
+  );
+};

--- a/enclave-manager/web/src/components/enclaves/configuration/inputs/StringArgumentInput.tsx
+++ b/enclave-manager/web/src/components/enclaves/configuration/inputs/StringArgumentInput.tsx
@@ -1,0 +1,9 @@
+import { Input } from "@chakra-ui/react";
+import { useEnclaveConfigurationFormContext } from "../EnclaveConfigurationForm";
+import { KurtosisArgumentTypeInputProps } from "./KurtosisArgumentTypeInput";
+
+export const StringArgumentInput = (props: Omit<KurtosisArgumentTypeInputProps, "type">) => {
+  const { register } = useEnclaveConfigurationFormContext();
+
+  return <Input {...register(props.name, { disabled: props.disabled, required: props.isRequired })} />;
+};

--- a/enclave-manager/web/src/components/enclaves/configuration/types.ts
+++ b/enclave-manager/web/src/components/enclaves/configuration/types.ts
@@ -1,0 +1,5 @@
+export type ConfigureEnclaveForm = {
+  enclaveName: string;
+  restartServices: boolean;
+  args: Record<string, any>;
+};

--- a/enclave-manager/web/src/components/enclaves/configuration/utils.ts
+++ b/enclave-manager/web/src/components/enclaves/configuration/utils.ts
@@ -1,0 +1,36 @@
+import { ArgumentValueType, PackageArg } from "../../../client/packageIndexer/api/kurtosis_package_indexer_pb";
+
+export function argTypeToString(argType?: ArgumentValueType) {
+  switch (argType) {
+    case ArgumentValueType.BOOL:
+      return "boolean";
+    case ArgumentValueType.DICT:
+      return "dictionary";
+    case ArgumentValueType.INTEGER:
+      return "integer";
+    case ArgumentValueType.JSON:
+      return "json";
+    case ArgumentValueType.LIST:
+      return "list";
+    case ArgumentValueType.STRING:
+      return "string";
+    default:
+      return "unknown";
+  }
+}
+
+export function argToTypeString(arg: PackageArg) {
+  switch (arg.typeV2?.topLevelType) {
+    case ArgumentValueType.BOOL:
+    case ArgumentValueType.STRING:
+    case ArgumentValueType.INTEGER:
+    case ArgumentValueType.JSON:
+      return argTypeToString(arg.typeV2.topLevelType);
+    case ArgumentValueType.DICT:
+      return `${argTypeToString(arg.typeV2.innerType1)} -> ${argTypeToString(arg.typeV2.innerType2)}`;
+    case ArgumentValueType.LIST:
+      return `${argTypeToString(arg.typeV2.innerType1)}[]`;
+    default:
+      return "unknown";
+  }
+}

--- a/enclave-manager/web/src/components/enclaves/modals/ConfigureEnclaveModal.tsx
+++ b/enclave-manager/web/src/components/enclaves/modals/ConfigureEnclaveModal.tsx
@@ -1,0 +1,120 @@
+import {
+  Button,
+  Flex,
+  FormControl,
+  Input,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Text,
+} from "@chakra-ui/react";
+import { useState } from "react";
+import { SubmitHandler } from "react-hook-form";
+import { useSubmit } from "react-router-dom";
+import { useKurtosisClient } from "../../../client/enclaveManager/KurtosisClientContext";
+import { KurtosisPackage } from "../../../client/packageIndexer/api/kurtosis_package_indexer_pb";
+import { isDefined } from "../../../utils";
+import { CopyButton } from "../../CopyButton";
+import { KurtosisAlert } from "../../KurtosisAlert";
+import { EnclaveConfigurationForm } from "../configuration/EnclaveConfigurationForm";
+import { BooleanArgumentInput } from "../configuration/inputs/BooleanArgumentInput";
+import { StringArgumentInput } from "../configuration/inputs/StringArgumentInput";
+import { KurtosisArgumentFormControl } from "../configuration/KurtosisArgumentFormControl";
+import { KurtosisPackageArgumentInput } from "../configuration/KurtosisPackageArgumentInput";
+import { ConfigureEnclaveForm } from "../configuration/types";
+import { EnclaveSourceButton } from "../widgets/EnclaveSourceButton";
+
+type ConfigureEnclaveModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  kurtosisPackage: KurtosisPackage;
+};
+
+export const ConfigureEnclaveModal = ({ isOpen, onClose, kurtosisPackage }: ConfigureEnclaveModalProps) => {
+  const kurtosisClient = useKurtosisClient();
+  const submit = useSubmit();
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string>();
+
+  const handleClose = () => {
+    onClose();
+  };
+
+  const handleLoadSubmit: SubmitHandler<ConfigureEnclaveForm> = async (formData) => {
+    setIsLoading(true);
+    setError(undefined);
+    const newEnclave = await kurtosisClient.createEnclave(formData.enclaveName, "info", formData.restartServices);
+    setIsLoading(false);
+
+    if (newEnclave.isErr) {
+      setError(`Could not create enclave, got: ${newEnclave.error.message}`);
+      return;
+    }
+    if (!isDefined(newEnclave.value.enclaveInfo)) {
+      setError(`Did not receive enclave info when running createEnclave`);
+      return;
+    }
+    console.log(formData);
+    submit(
+      { config: formData, packageId: kurtosisPackage.name, enclave: newEnclave.value.enclaveInfo.toJson() },
+      {
+        method: "post",
+        action: `/enclave/${newEnclave.value.enclaveInfo.shortenedUuid}`,
+        encType: "application/json",
+      },
+    );
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={handleClose} isCentered size={"5xl"}>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader textAlign={"center"}>Enclave Configuration</ModalHeader>
+        <ModalCloseButton />
+        <EnclaveConfigurationForm onSubmit={handleLoadSubmit} kurtosisPackage={kurtosisPackage}>
+          <ModalBody p={"0px"}>
+            <Flex fontSize={"sm"} justifyContent={"center"} alignItems={"center"} gap={"12px"} pb={"12px"}>
+              <Text>Deploying</Text>
+              <EnclaveSourceButton source={kurtosisPackage.name} size={"sm"} variant={"outline"} color={"gray.100"} />
+              <Text>to</Text>
+              <Input size={"sm"} placeholder={"an unamed environment"} width={"auto"} />
+              {isDefined(error) && <KurtosisAlert message={error} />}
+            </Flex>
+            <Flex flexDirection={"column"} gap={"24px"} p={"12px 24px"} bg={"gray.900"}>
+              <Flex justifyContent={"space-between"} alignItems={"center"}>
+                <FormControl display={"flex"} alignItems={"center"} gap={"16px"}>
+                  <BooleanArgumentInput inputType={"switch"} name={"restartServices"} />
+                  <Text fontSize={"xs"}>
+                    Restart services (When enabled, Kurtosis will automatically restart any services that crash inside
+                    the enclave)
+                  </Text>
+                </FormControl>
+                <CopyButton valueToCopy={"some value"} />
+              </Flex>
+              <KurtosisArgumentFormControl name={"enclaveName"} label={"Enclave name"} type={"string"}>
+                <StringArgumentInput name={"enclaveName"} />
+              </KurtosisArgumentFormControl>
+              {kurtosisPackage.args.map((arg, i) => (
+                <KurtosisPackageArgumentInput key={i} argument={arg} />
+              ))}
+            </Flex>
+          </ModalBody>
+          <ModalFooter>
+            <Flex justifyContent={"flex-end"} gap={"12px"}>
+              <Button color={"gray.100"} onClick={handleClose} disabled={isLoading}>
+                Cancel
+              </Button>
+              <Button type={"submit"} isLoading={isLoading} colorScheme={"kurtosisGreen"}>
+                Run
+              </Button>
+            </Flex>
+          </ModalFooter>
+        </EnclaveConfigurationForm>
+      </ModalContent>
+    </Modal>
+  );
+};

--- a/enclave-manager/web/src/components/enclaves/modals/ManualCreateEnclaveModal.tsx
+++ b/enclave-manager/web/src/components/enclaves/modals/ManualCreateEnclaveModal.tsx
@@ -1,0 +1,106 @@
+import {
+  Button,
+  Flex,
+  FormControl,
+  FormErrorMessage,
+  FormLabel,
+  Input,
+  InputGroup,
+  InputLeftElement,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+} from "@chakra-ui/react";
+import { useState } from "react";
+import { SubmitHandler, useForm } from "react-hook-form";
+import { IoLogoGithub } from "react-icons/io";
+import { KurtosisPackage } from "../../../client/packageIndexer/api/kurtosis_package_indexer_pb";
+import { useKurtosisPackageIndexerClient } from "../../../client/packageIndexer/KurtosisPackageIndexerClientContext";
+import { isDefined } from "../../../utils";
+
+type ManualCreateEnclaveForm = {
+  url: string;
+};
+
+type ManualCreateEnclaveModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: (kurtosisPackage: KurtosisPackage) => void;
+};
+
+export const ManualCreateEnclaveModal = ({ isOpen, onClose, onConfirm }: ManualCreateEnclaveModalProps) => {
+  const kurtosisIndexerClient = useKurtosisPackageIndexerClient();
+  const {
+    register,
+    handleSubmit,
+    setError,
+    formState: { errors },
+    reset,
+  } = useForm<ManualCreateEnclaveForm>();
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleClose = () => {
+    reset();
+    onClose();
+  };
+
+  const handleLoadSubmit: SubmitHandler<ManualCreateEnclaveForm> = async (form) => {
+    setIsLoading(true);
+    const packageResponse = await kurtosisIndexerClient.readPackage(form.url);
+    setIsLoading(false);
+    if (packageResponse.isErr) {
+      setError("url", { message: `Could not load '${form.url}', got error ${packageResponse.error.message}` });
+      return;
+    }
+    if (!isDefined(packageResponse.value.package)) {
+      setError("url", { message: `No package found at this url` });
+      return;
+    }
+    onConfirm(packageResponse.value.package);
+    reset();
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={handleClose} isCentered>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>Create an Enclave</ModalHeader>
+        <ModalCloseButton />
+        <form onSubmit={handleSubmit(handleLoadSubmit)}>
+          <ModalBody>
+            <FormControl isInvalid={isDefined(errors.url)} isRequired>
+              <FormLabel>Enter Github URL to package</FormLabel>
+              <InputGroup>
+                <InputLeftElement pointerEvents={"none"} color={"gray.400"}>
+                  <IoLogoGithub />
+                </InputLeftElement>
+                <Input
+                  {...register("url", {
+                    disabled: isLoading,
+                    required: true,
+                    value: "github.com/kurtosis-tech/etcd-package",
+                  })}
+                />
+              </InputGroup>
+              <FormErrorMessage>{errors.url?.message}</FormErrorMessage>
+            </FormControl>
+          </ModalBody>
+          <ModalFooter>
+            <Flex justifyContent={"flex-end"} gap={"12px"}>
+              <Button color={"gray.100"} onClick={handleClose} disabled={isLoading}>
+                Cancel
+              </Button>
+              <Button type={"submit"} isLoading={isLoading} colorScheme={"kurtosisGreen"}>
+                Load
+              </Button>
+            </Flex>
+          </ModalFooter>
+        </form>
+      </ModalContent>
+    </Modal>
+  );
+};

--- a/enclave-manager/web/src/components/enclaves/widgets/DeleteEnclavesButton.tsx
+++ b/enclave-manager/web/src/components/enclaves/widgets/DeleteEnclavesButton.tsx
@@ -1,0 +1,48 @@
+import { Button } from "@chakra-ui/react";
+import { useEffect, useState } from "react";
+import { FiTrash2 } from "react-icons/fi";
+import { useFetcher } from "react-router-dom";
+import { EnclaveFullInfo } from "../../../emui/enclaves/types";
+import { KurtosisAlertModal } from "../../KurtosisAlertModal";
+
+type DeleteEnclavesButtonProps = {
+  enclaves: EnclaveFullInfo[];
+};
+
+export const DeleteEnclavesButton = ({ enclaves }: DeleteEnclavesButtonProps) => {
+  const fetcher = useFetcher();
+
+  const [showModal, setShowModal] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    setIsLoading(false);
+    setShowModal(false);
+  }, [enclaves]);
+
+  const handleDelete = async () => {
+    setIsLoading(true);
+    fetcher.submit(
+      { intent: "delete", enclaveUUIDs: enclaves.map(({ enclaveUuid }) => enclaveUuid) },
+      { method: "post", action: "/enclaves", encType: "application/json" },
+    );
+  };
+
+  return (
+    <>
+      <Button colorScheme={"red"} leftIcon={<FiTrash2 />} onClick={() => setShowModal(true)}>
+        Delete
+      </Button>
+      <KurtosisAlertModal
+        isOpen={showModal}
+        isLoading={isLoading}
+        title={"Delete Enclaves"}
+        content={"Are you sure? You cannot undo this action afterwards."}
+        confirmText={"Delete"}
+        confirmButtonProps={{ leftIcon: <FiTrash2 />, colorScheme: "red" }}
+        onClose={() => setShowModal(false)}
+        onConfirm={handleDelete}
+      />
+    </>
+  );
+};

--- a/enclave-manager/web/src/components/enclaves/widgets/DeleteEnclavesButton.tsx
+++ b/enclave-manager/web/src/components/enclaves/widgets/DeleteEnclavesButton.tsx
@@ -15,10 +15,14 @@ export const DeleteEnclavesButton = ({ enclaves }: DeleteEnclavesButtonProps) =>
   const [showModal, setShowModal] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
 
-  useEffect(() => {
-    setIsLoading(false);
-    setShowModal(false);
-  }, [enclaves]);
+  useEffect(
+    () => {
+      setIsLoading(false);
+      setShowModal(false);
+    },
+    // These deps are defined this way to detect whether or not the enclaves in props are actually different
+    [enclaves.map(({ enclaveUuid }) => enclaveUuid).join(",")],
+  );
 
   const handleDelete = async () => {
     setIsLoading(true);

--- a/enclave-manager/web/src/components/enclaves/widgets/EnclaveSourceButton.tsx
+++ b/enclave-manager/web/src/components/enclaves/widgets/EnclaveSourceButton.tsx
@@ -1,21 +1,21 @@
-import { Button, Icon } from "@chakra-ui/react";
+import { Button, ButtonProps, Icon } from "@chakra-ui/react";
 import { IoLogoGithub } from "react-icons/io";
 
-type EnclaveSourceProps = {
+type EnclaveSourceProps = ButtonProps & {
   source: string;
 };
 
-export const EnclaveSourceButton = ({ source }: EnclaveSourceProps) => {
+export const EnclaveSourceButton = ({ source, ...buttonProps }: EnclaveSourceProps) => {
   if (source.startsWith("github.com/")) {
     return (
-      <Button leftIcon={<Icon as={IoLogoGithub} color={"gray.400"} />} variant={"ghost"} size={"xs"}>
+      <Button leftIcon={<Icon as={IoLogoGithub} color={"gray.400"} />} variant={"ghost"} size={"xs"} {...buttonProps}>
         {source.replace("github.com/", "")}
       </Button>
     );
   }
 
   return (
-    <Button variant={"ghost"} size={"xs"}>
+    <Button variant={"ghost"} size={"xs"} {...buttonProps}>
       {source}
     </Button>
   );

--- a/enclave-manager/web/src/components/theme/formsTheme.tsx
+++ b/enclave-manager/web/src/components/theme/formsTheme.tsx
@@ -1,0 +1,39 @@
+import { formAnatomy as parts } from "@chakra-ui/anatomy";
+import { createMultiStyleConfigHelpers, cssVar, defineStyle } from "@chakra-ui/styled-system";
+
+const { definePartsStyle, defineMultiStyleConfig } = createMultiStyleConfigHelpers(parts.keys);
+
+const $fg = cssVar("form-control-color");
+
+const baseStyleRequiredIndicator = defineStyle({
+  marginStart: "1",
+  [$fg.variable]: "colors.red.400",
+  _dark: {
+    [$fg.variable]: "colors.red.300",
+  },
+  color: $fg.reference,
+});
+
+const baseStyleHelperText = defineStyle({
+  mt: "2",
+  [$fg.variable]: "colors.gray.600",
+  _dark: {
+    [$fg.variable]: "colors.whiteAlpha.600",
+  },
+  color: $fg.reference,
+  lineHeight: "normal",
+  fontSize: "sm",
+});
+
+const baseStyle = definePartsStyle({
+  container: {
+    width: "100%",
+    position: "relative",
+  },
+  requiredIndicator: baseStyleRequiredIndicator,
+  helperText: baseStyleHelperText,
+});
+
+export const formsTheme = defineMultiStyleConfig({
+  baseStyle,
+});

--- a/enclave-manager/web/src/components/theme/tabsTheme.ts
+++ b/enclave-manager/web/src/components/theme/tabsTheme.ts
@@ -23,11 +23,8 @@ export const tabsTheme = defineMultiStyleConfig({
           bg: `gray.800`,
         },
       },
-      tablist: {
-        marginBottom: "8px",
-      },
       tabpanel: {
-        padding: "12px",
+        padding: "32px 0px",
       },
     }),
   },

--- a/enclave-manager/web/src/emui/App.tsx
+++ b/enclave-manager/web/src/emui/App.tsx
@@ -5,7 +5,7 @@ import { KurtosisClientProvider, useKurtosisClient } from "../client/enclaveMana
 import { KurtosisPackageIndexerProvider } from "../client/packageIndexer/KurtosisPackageIndexerClientContext";
 import { AppLayout } from "../components/AppLayout";
 import { KurtosisThemeProvider } from "../components/KurtosisThemeProvider";
-import { enclaveRoutes } from "./enclaves/Enclaves";
+import { enclaveRoutes } from "./enclaves/EnclaveRoutes";
 import { Navbar } from "./Navbar";
 
 export const EmuiApp = () => {

--- a/enclave-manager/web/src/emui/App.tsx
+++ b/enclave-manager/web/src/emui/App.tsx
@@ -1,10 +1,13 @@
-import { Box } from "@chakra-ui/react";
 import { useMemo } from "react";
 import { createBrowserRouter, Outlet, RouterProvider } from "react-router-dom";
 import { KurtosisClientProvider, useKurtosisClient } from "../client/enclaveManager/KurtosisClientContext";
-import { KurtosisPackageIndexerProvider } from "../client/packageIndexer/KurtosisPackageIndexerClientContext";
+import {
+  KurtosisPackageIndexerProvider,
+  useKurtosisPackageIndexerClient,
+} from "../client/packageIndexer/KurtosisPackageIndexerClientContext";
 import { AppLayout } from "../components/AppLayout";
 import { KurtosisThemeProvider } from "../components/KurtosisThemeProvider";
+import { catalogRoutes } from "./catalog/CatalogRoutes";
 import { enclaveRoutes } from "./enclaves/EnclaveRoutes";
 import { Navbar } from "./Navbar";
 
@@ -22,6 +25,7 @@ export const EmuiApp = () => {
 
 const KurtosisRouter = () => {
   const kurtosisClient = useKurtosisClient();
+  const kurtosisIndexerClient = useKurtosisPackageIndexerClient();
   const router = useMemo(
     () =>
       createBrowserRouter([
@@ -33,7 +37,7 @@ const KurtosisRouter = () => {
           ),
           children: [
             { path: "/", children: enclaveRoutes(kurtosisClient) },
-            { path: "/catalog", element: <Box>Goodby World</Box> },
+            { path: "/catalog", children: catalogRoutes(kurtosisIndexerClient) },
           ],
         },
       ]),

--- a/enclave-manager/web/src/emui/catalog/Catalog.tsx
+++ b/enclave-manager/web/src/emui/catalog/Catalog.tsx
@@ -1,0 +1,33 @@
+import { Box, Flex } from "@chakra-ui/react";
+import { Suspense } from "react";
+import { Await, useLoaderData } from "react-router-dom";
+import { KurtosisAlert } from "../../components/KurtosisAlert";
+import { CatalogLoaderResolved } from "./loader";
+
+export const Catalog = () => {
+  const { catalog } = useLoaderData() as CatalogLoaderResolved;
+
+  return (
+    <Suspense>
+      <Await resolve={catalog} children={(catalog) => <CatalogImpl catalog={catalog} />} />
+    </Suspense>
+  );
+};
+
+type CatalogImplProps = {
+  catalog: CatalogLoaderResolved["catalog"];
+};
+
+const CatalogImpl = ({ catalog }: CatalogImplProps) => {
+  if (catalog.isErr) {
+    return <KurtosisAlert message={catalog.error} />;
+  }
+
+  return (
+    <Flex flexDirection={"column"}>
+      {catalog.value.map((kurtosisPackage) => (
+        <Box key={kurtosisPackage.url}>{kurtosisPackage.name}</Box>
+      ))}
+    </Flex>
+  );
+};

--- a/enclave-manager/web/src/emui/catalog/CatalogRoutes.tsx
+++ b/enclave-manager/web/src/emui/catalog/CatalogRoutes.tsx
@@ -1,0 +1,15 @@
+import { RouteObject } from "react-router-dom";
+
+import { KurtosisPackageIndexerClient } from "../../client/packageIndexer/KurtosisPackageIndexerClient";
+import { Catalog } from "./Catalog";
+import { catalogLoader } from "./loader";
+
+export const catalogRoutes = (kurtosisIndexerClient: KurtosisPackageIndexerClient): RouteObject[] => [
+  {
+    path: "/catalog",
+    handle: { crumb: () => ({ name: "Catalog", destination: "/catalog" }) },
+    loader: catalogLoader(kurtosisIndexerClient),
+    id: "catalog",
+    element: <Catalog />,
+  },
+];

--- a/enclave-manager/web/src/emui/catalog/loader.ts
+++ b/enclave-manager/web/src/emui/catalog/loader.ts
@@ -1,0 +1,23 @@
+import { defer } from "react-router-dom";
+import { Result } from "true-myth";
+import { KurtosisPackage } from "../../client/packageIndexer/api/kurtosis_package_indexer_pb";
+import { KurtosisPackageIndexerClient } from "../../client/packageIndexer/KurtosisPackageIndexerClient";
+
+const loadCatalog = async (
+  kurtosisIndexerClient: KurtosisPackageIndexerClient,
+): Promise<Result<KurtosisPackage[], string>> => {
+  const packagesResponse = await kurtosisIndexerClient.getPackages();
+  if (packagesResponse.isErr) {
+    return Result.err(packagesResponse.error.message || "Unknown api error");
+  }
+
+  return Result.ok(packagesResponse.value.packages);
+};
+
+export type CatalogLoaderResolved = {
+  catalog: Awaited<ReturnType<typeof loadCatalog>>;
+};
+
+export const catalogLoader = (kurtosisIndexerClient: KurtosisPackageIndexerClient) => async () => {
+  return defer({ catalog: loadCatalog(kurtosisIndexerClient) });
+};

--- a/enclave-manager/web/src/emui/enclaves/EnclaveList.tsx
+++ b/enclave-manager/web/src/emui/enclaves/EnclaveList.tsx
@@ -1,79 +1,12 @@
 import { Button, ButtonGroup, Flex, Spinner, Tab, TabList, TabPanel, TabPanels, Tabs } from "@chakra-ui/react";
 import { Suspense, useEffect, useState } from "react";
 import { FiPlus } from "react-icons/fi";
-import { ActionFunction, Await, defer, json, redirect, useRouteLoaderData } from "react-router-dom";
-import { Result, ResultNS } from "true-myth";
-import { KurtosisClient } from "../../client/enclaveManager/KurtosisClient";
+import { Await, useRouteLoaderData } from "react-router-dom";
 import { EnclavesTable } from "../../components/enclaves/tables/EnclavesTable";
 import { DeleteEnclavesButton } from "../../components/enclaves/widgets/DeleteEnclavesButton";
 import { KurtosisAlert } from "../../components/KurtosisAlert";
-import { isDefined } from "../../utils";
+import { EnclavesLoaderResolved } from "./loader";
 import { EnclaveFullInfo } from "./types";
-
-const loadEnclaves = async (kurtosisClient: KurtosisClient): Promise<Result<EnclaveFullInfo[], string>> => {
-  const enclavesResponse = await kurtosisClient.getEnclaves();
-  if (enclavesResponse.isErr) {
-    return Result.err(enclavesResponse.error.message || "Unknown api error");
-  }
-  const enclaves = Object.values(enclavesResponse.value.enclaveInfo);
-  const [starlarkRuns, services, filesAndArtifacts] = await Promise.all([
-    Promise.all(enclaves.map((enclave) => kurtosisClient.getStarlarkRun(enclave))),
-    Promise.all(enclaves.map((enclave) => kurtosisClient.getServices(enclave))),
-    Promise.all(enclaves.map((enclave) => kurtosisClient.listFilesArtifactNamesAndUuids(enclave))),
-  ]);
-
-  const starlarkErrors = starlarkRuns.filter(ResultNS.isErr);
-  const servicesErrors = services.filter(ResultNS.isErr);
-  const filesAndArtifactErrors = filesAndArtifacts.filter(ResultNS.isErr);
-  if (starlarkErrors.length + servicesErrors.length + filesAndArtifactErrors.length > 0) {
-    return Result.err(
-      `Starlark errors: ${
-        starlarkErrors.length > 0 ? starlarkErrors.map((r) => r.error.message).join("\n") : "None"
-      }\nServices errors: ${
-        servicesErrors.length > 0 ? servicesErrors.map((r) => r.error.message).join("\n") : "None"
-      }\nFiles and Artifacts errors: ${
-        filesAndArtifactErrors.length > 0 ? filesAndArtifactErrors.map((r) => r.error.message).join("\n") : "None"
-      }`,
-    );
-  }
-
-  return Result.ok(
-    enclaves.map((enclave, i) => ({
-      ...enclave,
-      // These values are never actually null because of the checking above
-      starlarkRun: starlarkRuns[i].unwrapOr(null)!,
-      services: services[i].unwrapOr(null)!,
-      filesAndArtifacts: filesAndArtifacts[i].unwrapOr(null)!,
-    })),
-  );
-};
-
-export type EnclavesLoaderResolved = {
-  enclaves: Awaited<ReturnType<typeof loadEnclaves>>;
-};
-
-export const enclavesLoader = (kurtosisClient: KurtosisClient) => async () => {
-  return defer({ enclaves: loadEnclaves(kurtosisClient) });
-};
-
-export const enclavesAction =
-  (kurtosisClient: KurtosisClient): ActionFunction =>
-  async ({ params, request }) => {
-    const formData = await request.json();
-    const intent = formData["intent"];
-    if (intent === "delete") {
-      const uuids = formData["enclaveUUIDs"];
-      if (!isDefined(uuids)) {
-        throw json({ message: "Missing enclaveUUIDs" }, { status: 400 });
-      }
-      console.log(uuids);
-      await Promise.all(uuids.map((uuid: string) => kurtosisClient.destroy(uuid)));
-      return redirect("/enclaves");
-    } else {
-      console.log("blep");
-      throw json({ message: "Invalid intent" }, { status: 400 });
-    }
-  };
 
 export const EnclaveList = () => {
   const { enclaves } = useRouteLoaderData("enclaves") as EnclavesLoaderResolved;

--- a/enclave-manager/web/src/emui/enclaves/EnclaveList.tsx
+++ b/enclave-manager/web/src/emui/enclaves/EnclaveList.tsx
@@ -1,58 +1,106 @@
 import { Button, ButtonGroup, Flex, Spinner, Tab, TabList, TabPanel, TabPanels, Tabs } from "@chakra-ui/react";
-import { useState } from "react";
-import { FiPlus, FiTrash2 } from "react-icons/fi";
-import { useRouteLoaderData } from "react-router-dom";
+import { Suspense, useEffect, useState } from "react";
+import { FiPlus } from "react-icons/fi";
+import { ActionFunction, Await, defer, json, redirect, useRouteLoaderData } from "react-router-dom";
 import { Result, ResultNS } from "true-myth";
 import { KurtosisClient } from "../../client/enclaveManager/KurtosisClient";
 import { EnclavesTable } from "../../components/enclaves/tables/EnclavesTable";
+import { DeleteEnclavesButton } from "../../components/enclaves/widgets/DeleteEnclavesButton";
 import { KurtosisAlert } from "../../components/KurtosisAlert";
 import { isDefined } from "../../utils";
 import { EnclaveFullInfo } from "./types";
 
-export const enclavesLoader =
-  (kurtosisClient: KurtosisClient) => async (): Promise<Result<EnclaveFullInfo[], string>> => {
-    const enclavesResponse = await kurtosisClient.getEnclaves();
-    if (enclavesResponse.isErr) {
-      return Result.err(enclavesResponse.error.message || "Unknown api error");
-    }
-    const enclaves = Object.values(enclavesResponse.value.enclaveInfo);
-    const [starlarkRuns, services, filesAndArtifacts] = await Promise.all([
-      Promise.all(enclaves.map((enclave) => kurtosisClient.getStarlarkRun(enclave))),
-      Promise.all(enclaves.map((enclave) => kurtosisClient.getServices(enclave))),
-      Promise.all(enclaves.map((enclave) => kurtosisClient.listFilesArtifactNamesAndUuids(enclave))),
-    ]);
+const loadEnclaves = async (kurtosisClient: KurtosisClient): Promise<Result<EnclaveFullInfo[], string>> => {
+  const enclavesResponse = await kurtosisClient.getEnclaves();
+  if (enclavesResponse.isErr) {
+    return Result.err(enclavesResponse.error.message || "Unknown api error");
+  }
+  const enclaves = Object.values(enclavesResponse.value.enclaveInfo);
+  const [starlarkRuns, services, filesAndArtifacts] = await Promise.all([
+    Promise.all(enclaves.map((enclave) => kurtosisClient.getStarlarkRun(enclave))),
+    Promise.all(enclaves.map((enclave) => kurtosisClient.getServices(enclave))),
+    Promise.all(enclaves.map((enclave) => kurtosisClient.listFilesArtifactNamesAndUuids(enclave))),
+  ]);
 
-    const starlarkErrors = starlarkRuns.filter(ResultNS.isErr);
-    const servicesErrors = services.filter(ResultNS.isErr);
-    const filesAndArtifactErrors = filesAndArtifacts.filter(ResultNS.isErr);
-    if (starlarkErrors.length + servicesErrors.length + filesAndArtifactErrors.length > 0) {
-      return Result.err(
-        `Starlark errors: ${
-          starlarkErrors.length > 0 ? starlarkErrors.map((r) => r.error.message).join("\n") : "None"
-        }\nServices errors: ${
-          servicesErrors.length > 0 ? servicesErrors.map((r) => r.error.message).join("\n") : "None"
-        }\nFiles and Artifacts errors: ${
-          filesAndArtifactErrors.length > 0 ? filesAndArtifactErrors.map((r) => r.error.message).join("\n") : "None"
-        }`,
-      );
-    }
-
-    return Result.ok(
-      enclaves.map((enclave, i) => ({
-        ...enclave,
-        // These values are never actually null because of the checking above
-        starlarkRun: starlarkRuns[i].unwrapOr(null)!,
-        services: services[i].unwrapOr(null)!,
-        filesAndArtifacts: filesAndArtifacts[i].unwrapOr(null)!,
-      })),
+  const starlarkErrors = starlarkRuns.filter(ResultNS.isErr);
+  const servicesErrors = services.filter(ResultNS.isErr);
+  const filesAndArtifactErrors = filesAndArtifacts.filter(ResultNS.isErr);
+  if (starlarkErrors.length + servicesErrors.length + filesAndArtifactErrors.length > 0) {
+    return Result.err(
+      `Starlark errors: ${
+        starlarkErrors.length > 0 ? starlarkErrors.map((r) => r.error.message).join("\n") : "None"
+      }\nServices errors: ${
+        servicesErrors.length > 0 ? servicesErrors.map((r) => r.error.message).join("\n") : "None"
+      }\nFiles and Artifacts errors: ${
+        filesAndArtifactErrors.length > 0 ? filesAndArtifactErrors.map((r) => r.error.message).join("\n") : "None"
+      }`,
     );
+  }
+
+  return Result.ok(
+    enclaves.map((enclave, i) => ({
+      ...enclave,
+      // These values are never actually null because of the checking above
+      starlarkRun: starlarkRuns[i].unwrapOr(null)!,
+      services: services[i].unwrapOr(null)!,
+      filesAndArtifacts: filesAndArtifacts[i].unwrapOr(null)!,
+    })),
+  );
+};
+
+export type EnclavesLoaderResolved = {
+  enclaves: Awaited<ReturnType<typeof loadEnclaves>>;
+};
+
+export const enclavesLoader = (kurtosisClient: KurtosisClient) => async () => {
+  return defer({ enclaves: loadEnclaves(kurtosisClient) });
+};
+
+export const enclavesAction =
+  (kurtosisClient: KurtosisClient): ActionFunction =>
+  async ({ params, request }) => {
+    const formData = await request.json();
+    const intent = formData["intent"];
+    if (intent === "delete") {
+      const uuids = formData["enclaveUUIDs"];
+      if (!isDefined(uuids)) {
+        throw json({ message: "Missing enclaveUUIDs" }, { status: 400 });
+      }
+      console.log(uuids);
+      await Promise.all(uuids.map((uuid: string) => kurtosisClient.destroy(uuid)));
+      return redirect("/enclaves");
+    } else {
+      console.log("blep");
+      throw json({ message: "Invalid intent" }, { status: 400 });
+    }
   };
 
 export const EnclaveList = () => {
-  const maybeEnclaves = useRouteLoaderData("enclaves") as Awaited<ReturnType<ReturnType<typeof enclavesLoader>>>;
+  const { enclaves } = useRouteLoaderData("enclaves") as EnclavesLoaderResolved;
 
-  const [enclaves, setEnclaves] = useState<EnclaveFullInfo[]>();
+  return (
+    <Suspense
+      fallback={
+        <Flex justifyContent={"center"} p={"20px"}>
+          <Spinner size={"xl"} />
+        </Flex>
+      }
+    >
+      <Await resolve={enclaves} children={(enclaves) => <EnclaveListImpl enclaves={enclaves} />} />
+    </Suspense>
+  );
+};
+
+type EnclaveListImplProps = {
+  enclaves: EnclavesLoaderResolved["enclaves"];
+};
+
+const EnclaveListImpl = ({ enclaves }: EnclaveListImplProps) => {
   const [selectedEnclaves, setSelectedEnclaves] = useState<EnclaveFullInfo[]>([]);
+
+  useEffect(() => {
+    setSelectedEnclaves([]);
+  }, [enclaves]);
 
   return (
     <Flex direction="column">
@@ -67,9 +115,7 @@ export const EnclaveList = () => {
                 <Button variant={"kurtosisDisabled"} colorScheme={"gray"}>
                   {selectedEnclaves.length} selected
                 </Button>
-                <Button colorScheme={"red"} leftIcon={<FiTrash2 />}>
-                  Delete
-                </Button>
+                <DeleteEnclavesButton enclaves={selectedEnclaves} />
               </ButtonGroup>
             )}
             <Button colorScheme={"kurtosisGreen"} leftIcon={<FiPlus />} size={"md"}>
@@ -79,19 +125,14 @@ export const EnclaveList = () => {
         </Flex>
         <TabPanels>
           <TabPanel>
-            {isDefined(maybeEnclaves) && maybeEnclaves.isOk && (
+            {enclaves.isOk && (
               <EnclavesTable
-                enclavesData={maybeEnclaves.value}
+                enclavesData={enclaves.value}
                 selection={selectedEnclaves}
                 onSelectionChange={setSelectedEnclaves}
               />
             )}
-            {isDefined(maybeEnclaves) && maybeEnclaves.isErr && <KurtosisAlert message={maybeEnclaves.error} />}
-            {!isDefined(maybeEnclaves) && (
-              <Flex justifyContent={"center"} p={"20px"}>
-                <Spinner size={"xl"} />
-              </Flex>
-            )}
+            {enclaves.isErr && <KurtosisAlert message={enclaves.error} />}
           </TabPanel>
         </TabPanels>
       </Tabs>

--- a/enclave-manager/web/src/emui/enclaves/EnclaveList.tsx
+++ b/enclave-manager/web/src/emui/enclaves/EnclaveList.tsx
@@ -1,7 +1,7 @@
 import { Button, ButtonGroup, Flex, Spinner, Tab, TabList, TabPanel, TabPanels, Tabs } from "@chakra-ui/react";
 import { Suspense, useEffect, useState } from "react";
-import { FiPlus } from "react-icons/fi";
 import { Await, useRouteLoaderData } from "react-router-dom";
+import { CreateEnclaveButton } from "../../components/enclaves/CreateEnclaveButton";
 import { EnclavesTable } from "../../components/enclaves/tables/EnclavesTable";
 import { DeleteEnclavesButton } from "../../components/enclaves/widgets/DeleteEnclavesButton";
 import { KurtosisAlert } from "../../components/KurtosisAlert";
@@ -51,9 +51,7 @@ const EnclaveListImpl = ({ enclaves }: EnclaveListImplProps) => {
                 <DeleteEnclavesButton enclaves={selectedEnclaves} />
               </ButtonGroup>
             )}
-            <Button colorScheme={"kurtosisGreen"} leftIcon={<FiPlus />} size={"md"}>
-              Create Enclave
-            </Button>
+            <CreateEnclaveButton />
           </Flex>
         </Flex>
         <TabPanels>

--- a/enclave-manager/web/src/emui/enclaves/EnclaveRoutes.tsx
+++ b/enclave-manager/web/src/emui/enclaves/EnclaveRoutes.tsx
@@ -2,6 +2,8 @@ import { Params, RouteObject } from "react-router-dom";
 import { KurtosisClient } from "../../client/enclaveManager/KurtosisClient";
 import { enclavesAction } from "./action";
 import { Enclave, enclaveLoader, enclaveTabLoader } from "./enclave";
+import { enclaveAction } from "./enclave/action";
+import { EnclaveLoaderDeferred } from "./enclave/loader";
 import { EnclaveList } from "./EnclaveList";
 import { enclavesLoader } from "./loader";
 
@@ -17,11 +19,15 @@ export const enclaveRoutes = (kurtosisClient: KurtosisClient): RouteObject[] => 
       {
         path: "enclave/:enclaveUUID",
         loader: enclaveLoader(kurtosisClient),
+        id: "enclave",
         handle: {
-          crumb: (data: Awaited<ReturnType<ReturnType<typeof enclaveLoader>>>, params: Params<string>) => ({
-            name: data.routeName,
-            destination: `/enclave/${params.enclaveUUID}`,
-          }),
+          crumb: async (data: EnclaveLoaderDeferred, params: Params) => {
+            const resolvedData = await data.data;
+            return {
+              name: resolvedData.routeName,
+              destination: `/enclave/${params.enclaveUUID}`,
+            };
+          },
         },
         children: [
           {
@@ -33,6 +39,7 @@ export const enclaveRoutes = (kurtosisClient: KurtosisClient): RouteObject[] => 
           {
             path: ":activeTab?",
             loader: enclaveTabLoader,
+            action: enclaveAction(kurtosisClient),
             element: <Enclave />,
             handle: {
               crumb: (data: Awaited<ReturnType<typeof enclaveTabLoader>>, params: Params<string>) => ({

--- a/enclave-manager/web/src/emui/enclaves/EnclaveRoutes.tsx
+++ b/enclave-manager/web/src/emui/enclaves/EnclaveRoutes.tsx
@@ -1,7 +1,9 @@
 import { Params, RouteObject } from "react-router-dom";
 import { KurtosisClient } from "../../client/enclaveManager/KurtosisClient";
-import { Enclave, enclaveLoader, enclaveTabLoader } from "./Enclave";
-import { EnclaveList, enclavesAction, enclavesLoader } from "./EnclaveList";
+import { enclavesAction } from "./action";
+import { Enclave, enclaveLoader, enclaveTabLoader } from "./enclave";
+import { EnclaveList } from "./EnclaveList";
+import { enclavesLoader } from "./loader";
 
 export const enclaveRoutes = (kurtosisClient: KurtosisClient): RouteObject[] => [
   {

--- a/enclave-manager/web/src/emui/enclaves/Enclaves.tsx
+++ b/enclave-manager/web/src/emui/enclaves/Enclaves.tsx
@@ -1,13 +1,14 @@
 import { Params, RouteObject } from "react-router-dom";
 import { KurtosisClient } from "../../client/enclaveManager/KurtosisClient";
 import { Enclave, enclaveLoader, enclaveTabLoader } from "./Enclave";
-import { EnclaveList, enclavesLoader } from "./EnclaveList";
+import { EnclaveList, enclavesAction, enclavesLoader } from "./EnclaveList";
 
 export const enclaveRoutes = (kurtosisClient: KurtosisClient): RouteObject[] => [
   {
-    path: "",
+    path: "/enclaves?",
     handle: { crumb: () => ({ name: "Enclaves", destination: "/" }) },
     loader: enclavesLoader(kurtosisClient),
+    action: enclavesAction(kurtosisClient),
     id: "enclaves",
     children: [
       { path: "", element: <EnclaveList /> },

--- a/enclave-manager/web/src/emui/enclaves/action.ts
+++ b/enclave-manager/web/src/emui/enclaves/action.ts
@@ -12,11 +12,9 @@ export const enclavesAction =
       if (!isDefined(uuids)) {
         throw json({ message: "Missing enclaveUUIDs" }, { status: 400 });
       }
-      console.log(uuids);
       await Promise.all(uuids.map((uuid: string) => kurtosisClient.destroy(uuid)));
       return redirect("/enclaves");
     } else {
-      console.log("blep");
       throw json({ message: "Invalid intent" }, { status: 400 });
     }
   };

--- a/enclave-manager/web/src/emui/enclaves/action.ts
+++ b/enclave-manager/web/src/emui/enclaves/action.ts
@@ -1,0 +1,22 @@
+import { ActionFunction, json, redirect } from "react-router-dom";
+import { KurtosisClient } from "../../client/enclaveManager/KurtosisClient";
+import { isDefined } from "../../utils";
+
+export const enclavesAction =
+  (kurtosisClient: KurtosisClient): ActionFunction =>
+  async ({ params, request }) => {
+    const formData = await request.json();
+    const intent = formData["intent"];
+    if (intent === "delete") {
+      const uuids = formData["enclaveUUIDs"];
+      if (!isDefined(uuids)) {
+        throw json({ message: "Missing enclaveUUIDs" }, { status: 400 });
+      }
+      console.log(uuids);
+      await Promise.all(uuids.map((uuid: string) => kurtosisClient.destroy(uuid)));
+      return redirect("/enclaves");
+    } else {
+      console.log("blep");
+      throw json({ message: "Invalid intent" }, { status: 400 });
+    }
+  };

--- a/enclave-manager/web/src/emui/enclaves/enclave/Enclave.tsx
+++ b/enclave-manager/web/src/emui/enclaves/enclave/Enclave.tsx
@@ -1,57 +1,13 @@
 import { Button, Flex, Spinner, Tab, TabList, TabPanel, TabPanels, Tabs } from "@chakra-ui/react";
 import { FiEdit2 } from "react-icons/fi";
-import { Await, LoaderFunctionArgs, useParams, useRouteLoaderData } from "react-router-dom";
-import { KurtosisClient } from "../../client/enclaveManager/KurtosisClient";
-import { EnclaveOverview } from "../../components/enclaves/EnclaveOverview";
+import { Await, useParams, useRouteLoaderData } from "react-router-dom";
+import { EnclaveOverview } from "../../../components/enclaves/EnclaveOverview";
 
 import { Suspense } from "react";
-import { DeleteEnclavesButton } from "../../components/enclaves/widgets/DeleteEnclavesButton";
-import { KurtosisAlert } from "../../components/KurtosisAlert";
-import { isDefined } from "../../utils";
-import { EnclavesLoaderResolved } from "./EnclaveList";
-
-export const enclaveLoader =
-  (kurtosisClient: KurtosisClient) =>
-  async ({ params }: LoaderFunctionArgs): Promise<{ routeName: string }> => {
-    const uuid = params.enclaveUUID;
-
-    if (!isDefined(uuid)) {
-      return {
-        routeName: "Missing uuid",
-      };
-    }
-
-    const enclavesResult = await kurtosisClient.getEnclaves();
-    if (enclavesResult.isErr) {
-      return {
-        routeName: uuid,
-      };
-    }
-
-    const enclave = Object.values(enclavesResult.value.enclaveInfo).find((enclave) => enclave.shortenedUuid === uuid);
-    if (!isDefined(enclave)) {
-      return {
-        routeName: uuid,
-      };
-    }
-
-    return {
-      routeName: enclave.name,
-    };
-  };
-
-export const enclaveTabLoader = async ({ params }: LoaderFunctionArgs): Promise<{ routeName: string }> => {
-  const activeTab = params.activeTab;
-
-  switch (activeTab?.toLowerCase()) {
-    case "overview":
-      return { routeName: "Overview" };
-    case "source":
-      return { routeName: "Source" };
-    default:
-      return { routeName: "Overview" };
-  }
-};
+import { DeleteEnclavesButton } from "../../../components/enclaves/widgets/DeleteEnclavesButton";
+import { KurtosisAlert } from "../../../components/KurtosisAlert";
+import { isDefined } from "../../../utils";
+import { EnclavesLoaderResolved } from "../loader";
 
 export const Enclave = () => {
   const { enclaves } = useRouteLoaderData("enclaves") as EnclavesLoaderResolved;

--- a/enclave-manager/web/src/emui/enclaves/enclave/action.ts
+++ b/enclave-manager/web/src/emui/enclaves/enclave/action.ts
@@ -1,0 +1,29 @@
+import { StarlarkRunResponseLine } from "enclave-manager-sdk/build/api_container_service_pb";
+import { EnclaveInfo } from "enclave-manager-sdk/build/engine_service_pb";
+import { ActionFunction, ActionFunctionArgs } from "react-router-dom";
+import { KurtosisClient } from "../../../client/enclaveManager/KurtosisClient";
+import { ConfigureEnclaveForm } from "../../../components/enclaves/configuration/types";
+import { RemoveFunctions } from "../../../utils/types";
+
+const handleEnclaveAction = async (
+  kurtosisClient: KurtosisClient,
+  { params, request }: ActionFunctionArgs,
+): Promise<{ logs: AsyncIterable<StarlarkRunResponseLine> }> => {
+  const { config, enclave, packageId } = (await request.json()) as {
+    config: ConfigureEnclaveForm;
+    packageId: string;
+    enclave: RemoveFunctions<EnclaveInfo>;
+  };
+  console.log(enclave);
+
+  const logs = await kurtosisClient.runStarlarkPackage(enclave, packageId, config.args);
+  return { logs };
+};
+
+export const enclaveAction =
+  (kurtosisClient: KurtosisClient): ActionFunction =>
+  async (args) => {
+    return handleEnclaveAction(kurtosisClient, args);
+  };
+
+export type EnclaveActionResolvedType = Awaited<ReturnType<typeof handleEnclaveAction>>;

--- a/enclave-manager/web/src/emui/enclaves/enclave/index.ts
+++ b/enclave-manager/web/src/emui/enclaves/enclave/index.ts
@@ -1,0 +1,3 @@
+export { Enclave } from "./Enclave";
+export { enclaveLoader } from "./loader";
+export { enclaveTabLoader } from "./tabLoader";

--- a/enclave-manager/web/src/emui/enclaves/enclave/loader.ts
+++ b/enclave-manager/web/src/emui/enclaves/enclave/loader.ts
@@ -1,33 +1,81 @@
-import { LoaderFunctionArgs } from "react-router-dom";
+import { defer, LoaderFunctionArgs } from "react-router-dom";
+
+import { Result } from "true-myth";
 import { KurtosisClient } from "../../../client/enclaveManager/KurtosisClient";
 import { isDefined } from "../../../utils";
+import { EnclaveFullInfo } from "../types";
+
+export const loadEnclave = async (
+  kurtosisClient: KurtosisClient,
+  uuid?: string,
+): Promise<{ routeName: string; enclave?: Result<EnclaveFullInfo, string> }> => {
+  if (!isDefined(uuid)) {
+    return {
+      routeName: "Missing uuid",
+    };
+  }
+
+  const enclavesResult = await kurtosisClient.getEnclaves();
+  if (enclavesResult.isErr) {
+    return {
+      routeName: uuid,
+    };
+  }
+
+  const enclave = Object.values(enclavesResult.value.enclaveInfo).find((enclave) => enclave.shortenedUuid === uuid);
+  if (!isDefined(enclave)) {
+    return {
+      routeName: uuid,
+    };
+  }
+
+  const [services, starlarkRun, filesAndArtifacts] = await Promise.all([
+    kurtosisClient.getServices(enclave),
+    kurtosisClient.getStarlarkRun(enclave),
+    kurtosisClient.listFilesArtifactNamesAndUuids(enclave),
+  ]);
+
+  if (services.isErr) {
+    return {
+      routeName: enclave.name,
+      enclave: Result.err(`Could not get services for enclave ${enclave.shortenedUuid}: ${services.error.message}`),
+    };
+  }
+
+  if (starlarkRun.isErr) {
+    return {
+      routeName: enclave.name,
+      enclave: Result.err(
+        `Could not get starlark run for enclave ${enclave.shortenedUuid}: ${starlarkRun.error.message}`,
+      ),
+    };
+  }
+
+  if (filesAndArtifacts.isErr) {
+    return {
+      routeName: enclave.name,
+      enclave: Result.err(
+        `Could not get files for enclave ${enclave.shortenedUuid}: ${filesAndArtifacts.error.message}`,
+      ),
+    };
+  }
+
+  return {
+    routeName: enclave.name,
+    enclave: Result.ok({
+      ...enclave,
+      starlarkRun: starlarkRun.value,
+      services: services.value,
+      filesAndArtifacts: filesAndArtifacts.value,
+    }),
+  };
+};
 
 export const enclaveLoader =
   (kurtosisClient: KurtosisClient) =>
-  async ({ params }: LoaderFunctionArgs): Promise<{ routeName: string }> => {
-    const uuid = params.enclaveUUID;
-
-    if (!isDefined(uuid)) {
-      return {
-        routeName: "Missing uuid",
-      };
-    }
-
-    const enclavesResult = await kurtosisClient.getEnclaves();
-    if (enclavesResult.isErr) {
-      return {
-        routeName: uuid,
-      };
-    }
-
-    const enclave = Object.values(enclavesResult.value.enclaveInfo).find((enclave) => enclave.shortenedUuid === uuid);
-    if (!isDefined(enclave)) {
-      return {
-        routeName: uuid,
-      };
-    }
-
-    return {
-      routeName: enclave.name,
-    };
+  ({ params }: LoaderFunctionArgs) => {
+    return defer({ data: loadEnclave(kurtosisClient, params.enclaveUUID) });
   };
+
+export type EnclaveLoaderDeferred = { data: ReturnType<typeof loadEnclave> };
+export type EnclaveLoaderResolved = { data: Awaited<ReturnType<typeof loadEnclave>> };

--- a/enclave-manager/web/src/emui/enclaves/enclave/loader.ts
+++ b/enclave-manager/web/src/emui/enclaves/enclave/loader.ts
@@ -1,0 +1,33 @@
+import { LoaderFunctionArgs } from "react-router-dom";
+import { KurtosisClient } from "../../../client/enclaveManager/KurtosisClient";
+import { isDefined } from "../../../utils";
+
+export const enclaveLoader =
+  (kurtosisClient: KurtosisClient) =>
+  async ({ params }: LoaderFunctionArgs): Promise<{ routeName: string }> => {
+    const uuid = params.enclaveUUID;
+
+    if (!isDefined(uuid)) {
+      return {
+        routeName: "Missing uuid",
+      };
+    }
+
+    const enclavesResult = await kurtosisClient.getEnclaves();
+    if (enclavesResult.isErr) {
+      return {
+        routeName: uuid,
+      };
+    }
+
+    const enclave = Object.values(enclavesResult.value.enclaveInfo).find((enclave) => enclave.shortenedUuid === uuid);
+    if (!isDefined(enclave)) {
+      return {
+        routeName: uuid,
+      };
+    }
+
+    return {
+      routeName: enclave.name,
+    };
+  };

--- a/enclave-manager/web/src/emui/enclaves/enclave/tabLoader.ts
+++ b/enclave-manager/web/src/emui/enclaves/enclave/tabLoader.ts
@@ -1,0 +1,14 @@
+import { LoaderFunctionArgs } from "react-router-dom";
+
+export const enclaveTabLoader = async ({ params }: LoaderFunctionArgs): Promise<{ routeName: string }> => {
+  const activeTab = params.activeTab;
+
+  switch (activeTab?.toLowerCase()) {
+    case "overview":
+      return { routeName: "Overview" };
+    case "source":
+      return { routeName: "Source" };
+    default:
+      return { routeName: "Overview" };
+  }
+};

--- a/enclave-manager/web/src/emui/enclaves/loader.ts
+++ b/enclave-manager/web/src/emui/enclaves/loader.ts
@@ -1,0 +1,50 @@
+import { defer } from "react-router-dom";
+import { Result, ResultNS } from "true-myth";
+import { KurtosisClient } from "../../client/enclaveManager/KurtosisClient";
+import { EnclaveFullInfo } from "./types";
+
+const loadEnclaves = async (kurtosisClient: KurtosisClient): Promise<Result<EnclaveFullInfo[], string>> => {
+  const enclavesResponse = await kurtosisClient.getEnclaves();
+  if (enclavesResponse.isErr) {
+    return Result.err(enclavesResponse.error.message || "Unknown api error");
+  }
+  const enclaves = Object.values(enclavesResponse.value.enclaveInfo);
+  const [starlarkRuns, services, filesAndArtifacts] = await Promise.all([
+    Promise.all(enclaves.map((enclave) => kurtosisClient.getStarlarkRun(enclave))),
+    Promise.all(enclaves.map((enclave) => kurtosisClient.getServices(enclave))),
+    Promise.all(enclaves.map((enclave) => kurtosisClient.listFilesArtifactNamesAndUuids(enclave))),
+  ]);
+
+  const starlarkErrors = starlarkRuns.filter(ResultNS.isErr);
+  const servicesErrors = services.filter(ResultNS.isErr);
+  const filesAndArtifactErrors = filesAndArtifacts.filter(ResultNS.isErr);
+  if (starlarkErrors.length + servicesErrors.length + filesAndArtifactErrors.length > 0) {
+    return Result.err(
+      `Starlark errors: ${
+        starlarkErrors.length > 0 ? starlarkErrors.map((r) => r.error.message).join("\n") : "None"
+      }\nServices errors: ${
+        servicesErrors.length > 0 ? servicesErrors.map((r) => r.error.message).join("\n") : "None"
+      }\nFiles and Artifacts errors: ${
+        filesAndArtifactErrors.length > 0 ? filesAndArtifactErrors.map((r) => r.error.message).join("\n") : "None"
+      }`,
+    );
+  }
+
+  return Result.ok(
+    enclaves.map((enclave, i) => ({
+      ...enclave,
+      // These values are never actually null because of the checking above
+      starlarkRun: starlarkRuns[i].unwrapOr(null)!,
+      services: services[i].unwrapOr(null)!,
+      filesAndArtifacts: filesAndArtifacts[i].unwrapOr(null)!,
+    })),
+  );
+};
+
+export type EnclavesLoaderResolved = {
+  enclaves: Awaited<ReturnType<typeof loadEnclaves>>;
+};
+
+export const enclavesLoader = (kurtosisClient: KurtosisClient) => async () => {
+  return defer({ enclaves: loadEnclaves(kurtosisClient) });
+};

--- a/enclave-manager/web/src/emui/enclaves/types.ts
+++ b/enclave-manager/web/src/emui/enclaves/types.ts
@@ -4,15 +4,7 @@ import {
   ListFilesArtifactNamesAndUuidsResponse,
 } from "enclave-manager-sdk/build/api_container_service_pb";
 import { EnclaveInfo } from "enclave-manager-sdk/build/engine_service_pb";
-
-type NonFunctionKeyNames<T> = Exclude<
-  {
-    [key in keyof T]: T[key] extends Function ? never : key;
-  }[keyof T],
-  undefined
->;
-
-type RemoveFunctions<T> = Pick<T, NonFunctionKeyNames<T>>;
+import { RemoveFunctions } from "../../utils/types";
 
 export type EnclaveFullInfo = RemoveFunctions<EnclaveInfo> & {
   starlarkRun: RemoveFunctions<GetStarlarkRunResponse>;

--- a/enclave-manager/web/src/utils/types.ts
+++ b/enclave-manager/web/src/utils/types.ts
@@ -1,0 +1,8 @@
+type NonFunctionKeyNames<T> = Exclude<
+  {
+    [key in keyof T]: T[key] extends Function ? never : key;
+  }[keyof T],
+  undefined
+>;
+
+export type RemoveFunctions<T> = Pick<T, NonFunctionKeyNames<T>>;

--- a/enclave-manager/web/yarn.lock
+++ b/enclave-manager/web/yarn.lock
@@ -2841,6 +2841,13 @@
   dependencies:
     "@types/node" "*"
 
+"@types/debug@^4.0.0":
+  version "4.1.10"
+  resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.10.tgz#f23148a6eb771a34c466a4fc28379d8101e84494"
+  integrity sha512-tOSCru6s732pofZ+sMv9o4o3Zc+Sa8l3bxd/tweTQudFn06vAzb13ZX46Zi6m6EJ+RUbRTHvgQJ1gBtSgkaUYA==
+  dependencies:
+    "@types/ms" "*"
+
 "@types/eslint-scope@^3.7.3":
   version "3.7.5"
   resolved "https://registry.yarnpkg.com/@types/eslint-scope/-/eslint-scope-3.7.5.tgz#e28b09dbb1d9d35fdfa8a884225f00440dfc5a3e"
@@ -2893,6 +2900,13 @@
   integrity sha512-MhzcwU8aUygZroVwL2jeYk6JisJrPl/oov/gsgGCue9mkgl9wjGbzReYQClxiUgFDnib9FuHqTndccKeZKxTRw==
   dependencies:
     "@types/node" "*"
+
+"@types/hast@^3.0.0":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@types/hast/-/hast-3.0.2.tgz#e6c1126a33955cb9493a5074ddf1873fb48248c7"
+  integrity sha512-B5hZHgHsXvfCoO3xgNJvBnX7N8p86TqQeGKXcokW4XXi+qY4vxxPSFYofytvVmpFxzPv7oxDQzjg5Un5m2/xiw==
+  dependencies:
+    "@types/unist" "*"
 
 "@types/html-minifier-terser@^6.0.0":
   version "6.1.0"
@@ -2957,6 +2971,13 @@
   resolved "https://registry.yarnpkg.com/@types/luxon/-/luxon-3.3.3.tgz#b2e20a9536f91ab3e6e7895c91883e1a7ad49a6e"
   integrity sha512-/BJF3NT0pRMuxrenr42emRUF67sXwcZCd+S1ksG/Fcf9O7C3kKCY4uJSbKBE4KDUIYr3WMsvfmWD8hRjXExBJQ==
 
+"@types/mdast@^4.0.0":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@types/mdast/-/mdast-4.0.2.tgz#4695661024ffbd9e52cf71e05c69a1f08c0792f6"
+  integrity sha512-tYR83EignvhYO9iU3kDg8V28M0jqyh9zzp5GV+EO+AYnyUl3P5ltkTeJuTiFZQFz670FSb3EwT/6LQdX+UdKfw==
+  dependencies:
+    "@types/unist" "*"
+
 "@types/mime@*":
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-3.0.2.tgz#c1ae807f13d308ee7511a5b81c74f327028e66e8"
@@ -2966,6 +2987,11 @@
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-1.3.3.tgz#bbe64987e0eb05de150c305005055c7ad784a9ce"
   integrity sha512-Ys+/St+2VF4+xuY6+kDIXGxbNRO0mesVg0bbxEfB97Od1Vjpjx9KD1qxs64Gcb3CWPirk9Xe+PT4YiiHQ9T+eg==
+
+"@types/ms@*":
+  version "0.7.33"
+  resolved "https://registry.yarnpkg.com/@types/ms/-/ms-0.7.33.tgz#80bf1da64b15f21fd8c1dc387c31929317d99ee9"
+  integrity sha512-AuHIyzR5Hea7ij0P9q7vx7xu4z0C28ucwjAZC0ja7JhINyCnOw8/DnvAPQQ9TfOlCtZAmCERKQX9+o1mgQhuOQ==
 
 "@types/node@*":
   version "20.8.6"
@@ -3088,6 +3114,11 @@
   resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.4.tgz#2b38784cd16957d3782e8e2b31c03bc1d13b4d65"
   integrity sha512-IDaobHimLQhjwsQ/NMwRVfa/yL7L/wriQPMhw1ZJall0KX6E1oxk29XMDeilW5qTIg5aoiqf5Udy8U/51aNoQQ==
 
+"@types/unist@*", "@types/unist@^3.0.0":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@types/unist/-/unist-3.0.1.tgz#778652d02ddec1bfc9e5e938fec8d407b8e56cba"
+  integrity sha512-ue/hDUpPjC85m+PM9OQDMZr3LywT+CT6mPsQq8OJtCLiERkGRcQUFvu9XASF5XWqyZFXbf15lvb3JFJ4dRLWPg==
+
 "@types/ws@^8.5.5":
   version "8.5.7"
   resolved "https://registry.yarnpkg.com/@types/ws/-/ws-8.5.7.tgz#1ca585074fe5d2c81dec7a3d451f244a2a6d83cb"
@@ -3204,6 +3235,11 @@
   dependencies:
     "@typescript-eslint/types" "5.62.0"
     eslint-visitor-keys "^3.3.0"
+
+"@ungap/structured-clone@^1.0.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.2.0.tgz#756641adb587851b5ccb3e095daf27ae581c8406"
+  integrity sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==
 
 "@webassemblyjs/ast@1.11.6", "@webassemblyjs/ast@^1.11.5":
   version "1.11.6"
@@ -3840,6 +3876,11 @@ babel-preset-react-app@^10.0.1:
     babel-plugin-macros "^3.1.0"
     babel-plugin-transform-react-remove-prop-types "^0.4.24"
 
+bail@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/bail/-/bail-2.0.2.tgz#d26f5cd8fe5d6f832a31517b9f7c356040ba6d5d"
+  integrity sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==
+
 balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
@@ -4056,6 +4097,11 @@ char-regex@^2.0.0:
   resolved "https://registry.yarnpkg.com/char-regex/-/char-regex-2.0.1.tgz#6dafdb25f9d3349914079f010ba8d0e6ff9cd01e"
   integrity sha512-oSvEeo6ZUD7NepqAat3RqoucZ5SeqLJgOvVIwkafu6IP3V0pO38s/ypdVUmDDK6qIIHNlYHJAKX9E7R7HoKElw==
 
+character-entities@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/character-entities/-/character-entities-2.0.2.tgz#2d09c2e72cd9523076ccb21157dff66ad43fcc22"
+  integrity sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==
+
 check-types@^11.2.3:
   version "11.2.3"
   resolved "https://registry.yarnpkg.com/check-types/-/check-types-11.2.3.tgz#1ffdf68faae4e941fce252840b1787b8edc93b71"
@@ -4171,6 +4217,11 @@ combined-stream@^1.0.8:
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
   dependencies:
     delayed-stream "~1.0.0"
+
+comma-separated-tokens@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz#4e89c9458acb61bc8fef19f4529973b2392839ee"
+  integrity sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==
 
 commander@^2.20.0:
   version "2.20.3"
@@ -4562,7 +4613,7 @@ debug@2.6.9, debug@^2.6.0:
   dependencies:
     ms "2.0.0"
 
-debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.2, debug@^4.3.4:
+debug@4, debug@^4.0.0, debug@^4.1.0, debug@^4.1.1, debug@^4.3.2, debug@^4.3.4:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
@@ -4580,6 +4631,13 @@ decimal.js@^10.2.1:
   version "10.4.3"
   resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.4.3.tgz#1044092884d245d1b7f65725fa4ad4c6f781cc23"
   integrity sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==
+
+decode-named-character-reference@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/decode-named-character-reference/-/decode-named-character-reference-1.0.2.tgz#daabac9690874c394c81e4162a0304b35d824f0e"
+  integrity sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==
+  dependencies:
+    character-entities "^2.0.0"
 
 dedent@^0.7.0:
   version "0.7.0"
@@ -4641,7 +4699,7 @@ depd@~1.1.2:
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
   integrity sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==
 
-dequal@^2.0.3:
+dequal@^2.0.0, dequal@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.3.tgz#2644214f1997d39ed0ee0ece72335490a7ac67be"
   integrity sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==
@@ -4673,6 +4731,13 @@ detect-port-alt@^1.1.6:
   dependencies:
     address "^1.0.1"
     debug "^2.6.0"
+
+devlop@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/devlop/-/devlop-1.1.0.tgz#4db7c2ca4dc6e0e834c30be70c94bbc976dc7018"
+  integrity sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==
+  dependencies:
+    dequal "^2.0.0"
 
 didyoumean@^1.2.2:
   version "1.2.2"
@@ -5382,6 +5447,11 @@ express@^4.17.3:
     utils-merge "1.0.1"
     vary "~1.1.2"
 
+extend@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
+  integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
+
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
@@ -5875,6 +5945,28 @@ has@^1.0.3:
   resolved "https://registry.yarnpkg.com/has/-/has-1.0.4.tgz#2eb2860e000011dae4f1406a86fe80e530fb2ec6"
   integrity sha512-qdSAmqLF6209RFj4VVItywPMbm3vWylknmB3nvNiUIs72xAimcM8nVYxYr7ncvZq5qzk9MKIZR8ijqD/1QuYjQ==
 
+hast-util-to-jsx-runtime@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.2.0.tgz#ffd59bfcf0eb8321c6ed511bfc4b399ac3404bc2"
+  integrity sha512-wSlp23N45CMjDg/BPW8zvhEi3R+8eRE1qFbjEyAUzMCzu2l1Wzwakq+Tlia9nkCtEl5mDxa7nKHsvYJ6Gfn21A==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    "@types/unist" "^3.0.0"
+    comma-separated-tokens "^2.0.0"
+    hast-util-whitespace "^3.0.0"
+    property-information "^6.0.0"
+    space-separated-tokens "^2.0.0"
+    style-to-object "^0.4.0"
+    unist-util-position "^5.0.0"
+    vfile-message "^4.0.0"
+
+hast-util-whitespace@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz#7778ed9d3c92dd9e8c5c8f648a49c21fc51cb621"
+  integrity sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==
+  dependencies:
+    "@types/hast" "^3.0.0"
+
 he@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
@@ -5931,6 +6023,11 @@ html-minifier-terser@^6.0.2:
     param-case "^3.0.4"
     relateurl "^0.2.7"
     terser "^5.10.0"
+
+html-url-attributes@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/html-url-attributes/-/html-url-attributes-3.0.0.tgz#fc4abf0c3fb437e2329c678b80abb3c62cff6f08"
+  integrity sha512-/sXbVCWayk6GDVg3ctOX6nxaVj7So40FcFAnWlWGNAB1LpYKcV5Cd10APjPjW80O7zYW2MsjBV4zZ7IZO5fVow==
 
 html-webpack-plugin@^5.5.0:
   version "5.5.3"
@@ -6111,6 +6208,11 @@ ini@^1.3.5:
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
   integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
 
+inline-style-parser@0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/inline-style-parser/-/inline-style-parser-0.1.1.tgz#ec8a3b429274e9c0a1f1c4ffa9453a7fef72cea1"
+  integrity sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q==
+
 internal-slot@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/internal-slot/-/internal-slot-1.0.5.tgz#f2a2ee21f668f8627a4667f309dc0f4fb6674986"
@@ -6281,6 +6383,11 @@ is-plain-obj@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-3.0.0.tgz#af6f2ea14ac5a646183a5bbdb5baabbc156ad9d7"
   integrity sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==
+
+is-plain-obj@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-4.1.0.tgz#d65025edec3657ce032fd7db63c97883eaed71f0"
+  integrity sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==
 
 is-potential-custom-element-name@^1.0.1:
   version "1.0.1"
@@ -7288,6 +7395,45 @@ makeerror@1.0.12:
   dependencies:
     tmpl "1.0.5"
 
+mdast-util-from-markdown@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.0.tgz#52f14815ec291ed061f2922fd14d6689c810cb88"
+  integrity sha512-n7MTOr/z+8NAX/wmhhDji8O3bRvPTV/U0oTCaZJkjhPSKTPhS3xufVhKGF8s1pJ7Ox4QgoIU7KHseh09S+9rTA==
+  dependencies:
+    "@types/mdast" "^4.0.0"
+    "@types/unist" "^3.0.0"
+    decode-named-character-reference "^1.0.0"
+    devlop "^1.0.0"
+    mdast-util-to-string "^4.0.0"
+    micromark "^4.0.0"
+    micromark-util-decode-numeric-character-reference "^2.0.0"
+    micromark-util-decode-string "^2.0.0"
+    micromark-util-normalize-identifier "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
+    unist-util-stringify-position "^4.0.0"
+
+mdast-util-to-hast@^13.0.0:
+  version "13.0.2"
+  resolved "https://registry.yarnpkg.com/mdast-util-to-hast/-/mdast-util-to-hast-13.0.2.tgz#74c0a9f014bb2340cae6118f6fccd75467792be7"
+  integrity sha512-U5I+500EOOw9e3ZrclN3Is3fRpw8c19SMyNZlZ2IS+7vLsNzb2Om11VpIVOR+/0137GhZsFEF6YiKD5+0Hr2Og==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    "@types/mdast" "^4.0.0"
+    "@ungap/structured-clone" "^1.0.0"
+    devlop "^1.0.0"
+    micromark-util-sanitize-uri "^2.0.0"
+    trim-lines "^3.0.0"
+    unist-util-position "^5.0.0"
+    unist-util-visit "^5.0.0"
+
+mdast-util-to-string@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz#7a5121475556a04e7eddeb67b264aae79d312814"
+  integrity sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==
+  dependencies:
+    "@types/mdast" "^4.0.0"
+
 mdn-data@2.0.14:
   version "2.0.14"
   resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.0.14.tgz#7113fc4281917d63ce29b43446f701e68c25ba50"
@@ -7329,6 +7475,200 @@ methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==
+
+micromark-core-commonmark@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/micromark-core-commonmark/-/micromark-core-commonmark-2.0.0.tgz#50740201f0ee78c12a675bf3e68ffebc0bf931a3"
+  integrity sha512-jThOz/pVmAYUtkroV3D5c1osFXAMv9e0ypGDOIZuCeAe91/sD6BoE2Sjzt30yuXtwOYUmySOhMas/PVyh02itA==
+  dependencies:
+    decode-named-character-reference "^1.0.0"
+    devlop "^1.0.0"
+    micromark-factory-destination "^2.0.0"
+    micromark-factory-label "^2.0.0"
+    micromark-factory-space "^2.0.0"
+    micromark-factory-title "^2.0.0"
+    micromark-factory-whitespace "^2.0.0"
+    micromark-util-character "^2.0.0"
+    micromark-util-chunked "^2.0.0"
+    micromark-util-classify-character "^2.0.0"
+    micromark-util-html-tag-name "^2.0.0"
+    micromark-util-normalize-identifier "^2.0.0"
+    micromark-util-resolve-all "^2.0.0"
+    micromark-util-subtokenize "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
+
+micromark-factory-destination@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/micromark-factory-destination/-/micromark-factory-destination-2.0.0.tgz#857c94debd2c873cba34e0445ab26b74f6a6ec07"
+  integrity sha512-j9DGrQLm/Uhl2tCzcbLhy5kXsgkHUrjJHg4fFAeoMRwJmJerT9aw4FEhIbZStWN8A3qMwOp1uzHr4UL8AInxtA==
+  dependencies:
+    micromark-util-character "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
+
+micromark-factory-label@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/micromark-factory-label/-/micromark-factory-label-2.0.0.tgz#17c5c2e66ce39ad6f4fc4cbf40d972f9096f726a"
+  integrity sha512-RR3i96ohZGde//4WSe/dJsxOX6vxIg9TimLAS3i4EhBAFx8Sm5SmqVfR8E87DPSR31nEAjZfbt91OMZWcNgdZw==
+  dependencies:
+    devlop "^1.0.0"
+    micromark-util-character "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
+
+micromark-factory-space@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/micromark-factory-space/-/micromark-factory-space-2.0.0.tgz#5e7afd5929c23b96566d0e1ae018ae4fcf81d030"
+  integrity sha512-TKr+LIDX2pkBJXFLzpyPyljzYK3MtmllMUMODTQJIUfDGncESaqB90db9IAUcz4AZAJFdd8U9zOp9ty1458rxg==
+  dependencies:
+    micromark-util-character "^2.0.0"
+    micromark-util-types "^2.0.0"
+
+micromark-factory-title@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/micromark-factory-title/-/micromark-factory-title-2.0.0.tgz#726140fc77892af524705d689e1cf06c8a83ea95"
+  integrity sha512-jY8CSxmpWLOxS+t8W+FG3Xigc0RDQA9bKMY/EwILvsesiRniiVMejYTE4wumNc2f4UbAa4WsHqe3J1QS1sli+A==
+  dependencies:
+    micromark-factory-space "^2.0.0"
+    micromark-util-character "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
+
+micromark-factory-whitespace@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.0.tgz#9e92eb0f5468083381f923d9653632b3cfb5f763"
+  integrity sha512-28kbwaBjc5yAI1XadbdPYHX/eDnqaUFVikLwrO7FDnKG7lpgxnvk/XGRhX/PN0mOZ+dBSZ+LgunHS+6tYQAzhA==
+  dependencies:
+    micromark-factory-space "^2.0.0"
+    micromark-util-character "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
+
+micromark-util-character@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/micromark-util-character/-/micromark-util-character-2.0.1.tgz#52b824c2e2633b6fb33399d2ec78ee2a90d6b298"
+  integrity sha512-3wgnrmEAJ4T+mGXAUfMvMAbxU9RDG43XmGce4j6CwPtVxB3vfwXSZ6KhFwDzZ3mZHhmPimMAXg71veiBGzeAZw==
+  dependencies:
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
+
+micromark-util-chunked@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-chunked/-/micromark-util-chunked-2.0.0.tgz#e51f4db85fb203a79dbfef23fd41b2f03dc2ef89"
+  integrity sha512-anK8SWmNphkXdaKgz5hJvGa7l00qmcaUQoMYsBwDlSKFKjc6gjGXPDw3FNL3Nbwq5L8gE+RCbGqTw49FK5Qyvg==
+  dependencies:
+    micromark-util-symbol "^2.0.0"
+
+micromark-util-classify-character@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-classify-character/-/micromark-util-classify-character-2.0.0.tgz#8c7537c20d0750b12df31f86e976d1d951165f34"
+  integrity sha512-S0ze2R9GH+fu41FA7pbSqNWObo/kzwf8rN/+IGlW/4tC6oACOs8B++bh+i9bVyNnwCcuksbFwsBme5OCKXCwIw==
+  dependencies:
+    micromark-util-character "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
+
+micromark-util-combine-extensions@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.0.tgz#75d6ab65c58b7403616db8d6b31315013bfb7ee5"
+  integrity sha512-vZZio48k7ON0fVS3CUgFatWHoKbbLTK/rT7pzpJ4Bjp5JjkZeasRfrS9wsBdDJK2cJLHMckXZdzPSSr1B8a4oQ==
+  dependencies:
+    micromark-util-chunked "^2.0.0"
+    micromark-util-types "^2.0.0"
+
+micromark-util-decode-numeric-character-reference@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.1.tgz#2698bbb38f2a9ba6310e359f99fcb2b35a0d2bd5"
+  integrity sha512-bmkNc7z8Wn6kgjZmVHOX3SowGmVdhYS7yBpMnuMnPzDq/6xwVA604DuOXMZTO1lvq01g+Adfa0pE2UKGlxL1XQ==
+  dependencies:
+    micromark-util-symbol "^2.0.0"
+
+micromark-util-decode-string@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-decode-string/-/micromark-util-decode-string-2.0.0.tgz#7dfa3a63c45aecaa17824e656bcdb01f9737154a"
+  integrity sha512-r4Sc6leeUTn3P6gk20aFMj2ntPwn6qpDZqWvYmAG6NgvFTIlj4WtrAudLi65qYoaGdXYViXYw2pkmn7QnIFasA==
+  dependencies:
+    decode-named-character-reference "^1.0.0"
+    micromark-util-character "^2.0.0"
+    micromark-util-decode-numeric-character-reference "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+
+micromark-util-encode@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-encode/-/micromark-util-encode-2.0.0.tgz#0921ac7953dc3f1fd281e3d1932decfdb9382ab1"
+  integrity sha512-pS+ROfCXAGLWCOc8egcBvT0kf27GoWMqtdarNfDcjb6YLuV5cM3ioG45Ys2qOVqeqSbjaKg72vU+Wby3eddPsA==
+
+micromark-util-html-tag-name@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.0.tgz#ae34b01cbe063363847670284c6255bb12138ec4"
+  integrity sha512-xNn4Pqkj2puRhKdKTm8t1YHC/BAjx6CEwRFXntTaRf/x16aqka6ouVoutm+QdkISTlT7e2zU7U4ZdlDLJd2Mcw==
+
+micromark-util-normalize-identifier@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.0.tgz#91f9a4e65fe66cc80c53b35b0254ad67aa431d8b"
+  integrity sha512-2xhYT0sfo85FMrUPtHcPo2rrp1lwbDEEzpx7jiH2xXJLqBuy4H0GgXk5ToU8IEwoROtXuL8ND0ttVa4rNqYK3w==
+  dependencies:
+    micromark-util-symbol "^2.0.0"
+
+micromark-util-resolve-all@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.0.tgz#189656e7e1a53d0c86a38a652b284a252389f364"
+  integrity sha512-6KU6qO7DZ7GJkaCgwBNtplXCvGkJToU86ybBAUdavvgsCiG8lSSvYxr9MhwmQ+udpzywHsl4RpGJsYWG1pDOcA==
+  dependencies:
+    micromark-util-types "^2.0.0"
+
+micromark-util-sanitize-uri@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.0.tgz#ec8fbf0258e9e6d8f13d9e4770f9be64342673de"
+  integrity sha512-WhYv5UEcZrbAtlsnPuChHUAsu/iBPOVaEVsntLBIdpibO0ddy8OzavZz3iL2xVvBZOpolujSliP65Kq0/7KIYw==
+  dependencies:
+    micromark-util-character "^2.0.0"
+    micromark-util-encode "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+
+micromark-util-subtokenize@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-subtokenize/-/micromark-util-subtokenize-2.0.0.tgz#9f412442d77e0c5789ffdf42377fa8a2bcbdf581"
+  integrity sha512-vc93L1t+gpR3p8jxeVdaYlbV2jTYteDje19rNSS/H5dlhxUYll5Fy6vJ2cDwP8RnsXi818yGty1ayP55y3W6fg==
+  dependencies:
+    devlop "^1.0.0"
+    micromark-util-chunked "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
+
+micromark-util-symbol@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-symbol/-/micromark-util-symbol-2.0.0.tgz#12225c8f95edf8b17254e47080ce0862d5db8044"
+  integrity sha512-8JZt9ElZ5kyTnO94muPxIGS8oyElRJaiJO8EzV6ZSyGQ1Is8xwl4Q45qU5UOg+bGH4AikWziz0iN4sFLWs8PGw==
+
+micromark-util-types@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-types/-/micromark-util-types-2.0.0.tgz#63b4b7ffeb35d3ecf50d1ca20e68fc7caa36d95e"
+  integrity sha512-oNh6S2WMHWRZrmutsRmDDfkzKtxF+bc2VxLC9dvtrDIRFln627VsFP6fLMgTryGDljgLPjkrzQSDcPrjPyDJ5w==
+
+micromark@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/micromark/-/micromark-4.0.0.tgz#84746a249ebd904d9658cfabc1e8e5f32cbc6249"
+  integrity sha512-o/sd0nMof8kYff+TqcDx3VSrgBTcZpSvYcAHIfHhv5VAuNmisCxjhx6YmxS8PFEpb9z5WKWKPdzf0jM23ro3RQ==
+  dependencies:
+    "@types/debug" "^4.0.0"
+    debug "^4.0.0"
+    decode-named-character-reference "^1.0.0"
+    devlop "^1.0.0"
+    micromark-core-commonmark "^2.0.0"
+    micromark-factory-space "^2.0.0"
+    micromark-util-character "^2.0.0"
+    micromark-util-chunked "^2.0.0"
+    micromark-util-combine-extensions "^2.0.0"
+    micromark-util-decode-numeric-character-reference "^2.0.0"
+    micromark-util-encode "^2.0.0"
+    micromark-util-normalize-identifier "^2.0.0"
+    micromark-util-resolve-all "^2.0.0"
+    micromark-util-sanitize-uri "^2.0.0"
+    micromark-util-subtokenize "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
 
 micromatch@^4.0.2, micromatch@^4.0.4, micromatch@^4.0.5:
   version "4.0.5"
@@ -8472,6 +8812,11 @@ prop-types@^15.6.2, prop-types@^15.8.1:
     object-assign "^4.1.1"
     react-is "^16.13.1"
 
+property-information@^6.0.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/property-information/-/property-information-6.3.0.tgz#ba4a06ec6b4e1e90577df9931286953cdf4282c3"
+  integrity sha512-gVNZ74nqhRMiIUYWGQdosYetaKc83x8oT41a0LlV3AAFCAZwCpg4vmGkq8t34+cUhp3cnM4XDiU/7xlgK7HGrg==
+
 proxy-addr@~2.0.7:
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.7.tgz#f19fe69ceab311eeb94b42e70e8c2070f9ba1025"
@@ -8620,6 +8965,11 @@ react-focus-lock@^2.9.4:
     use-callback-ref "^1.3.0"
     use-sidecar "^1.1.2"
 
+react-hook-form@^7.47.0:
+  version "7.47.0"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.47.0.tgz#a42f07266bd297ddf1f914f08f4b5f9783262f31"
+  integrity sha512-F/TroLjTICipmHeFlMrLtNLceO2xr1jU3CyiNla5zdwsGUGu2UOxxR4UyJgLlhMwLW/Wzp4cpJ7CPfgJIeKdSg==
+
 react-icons@^4.11.0:
   version "4.11.0"
   resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-4.11.0.tgz#4b0e31c9bfc919608095cc429c4f1846f4d66c65"
@@ -8639,6 +8989,23 @@ react-is@^18.0.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
+
+react-markdown@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/react-markdown/-/react-markdown-9.0.0.tgz#7a41bde9e1b0b1d6911f6f9f8c3cdb4a3e9f9328"
+  integrity sha512-v6yNf3AB8GfJ8lCpUvzxAXKxgsHpdmWPlcVRQ6Nocsezp255E/IDrF31kLQsPJeB/cKto/geUwjU36wH784FCA==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    devlop "^1.0.0"
+    hast-util-to-jsx-runtime "^2.0.0"
+    html-url-attributes "^3.0.0"
+    mdast-util-to-hast "^13.0.0"
+    micromark-util-sanitize-uri "^2.0.0"
+    remark-parse "^11.0.0"
+    remark-rehype "^11.0.0"
+    unified "^11.0.0"
+    unist-util-visit "^5.0.0"
+    vfile "^6.0.0"
 
 react-refresh@^0.11.0:
   version "0.11.0"
@@ -8871,6 +9238,27 @@ relateurl@^0.2.7:
   version "0.2.7"
   resolved "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"
   integrity sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog==
+
+remark-parse@^11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/remark-parse/-/remark-parse-11.0.0.tgz#aa60743fcb37ebf6b069204eb4da304e40db45a1"
+  integrity sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==
+  dependencies:
+    "@types/mdast" "^4.0.0"
+    mdast-util-from-markdown "^2.0.0"
+    micromark-util-types "^2.0.0"
+    unified "^11.0.0"
+
+remark-rehype@^11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/remark-rehype/-/remark-rehype-11.0.0.tgz#7f21c08738bde024be5f16e4a8b13e5d7a04cf6b"
+  integrity sha512-vx8x2MDMcxuE4lBmQ46zYUDfcFMmvg80WYX+UNLeG6ixjdCCLcw1lrgAukwBTuOFsS78eoAedHGn9sNM0w7TPw==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    "@types/mdast" "^4.0.0"
+    mdast-util-to-hast "^13.0.0"
+    unified "^11.0.0"
+    vfile "^6.0.0"
 
 renderkid@^3.0.0:
   version "3.0.0"
@@ -9301,6 +9689,11 @@ sourcemap-codec@^1.4.8:
   resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz#ea804bd94857402e6992d05a38ef1ae35a9ab4c4"
   integrity sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==
 
+space-separated-tokens@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz#1ecd9d2350a3844572c3f4a312bceb018348859f"
+  integrity sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==
+
 spdy-transport@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/spdy-transport/-/spdy-transport-3.0.0.tgz#00d4863a6400ad75df93361a1608605e5dcdcf31"
@@ -9501,6 +9894,13 @@ style-loader@^3.3.1:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-3.3.3.tgz#bba8daac19930169c0c9c96706749a597ae3acff"
   integrity sha512-53BiGLXAcll9maCYtZi2RCQZKa8NQQai5C4horqKyRmHj9H7QmcUyucrH+4KW/gBQbXM2AsB0axoEcFZPlfPcw==
+
+style-to-object@^0.4.0:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/style-to-object/-/style-to-object-0.4.4.tgz#266e3dfd56391a7eefb7770423612d043c3f33ec"
+  integrity sha512-HYNoHZa2GorYNyqiCaBgsxvcJIn7OHq6inEga+E6Ke3m5JkoqpQbnFssk4jwe+K7AhGa2fcha4wSOf1Kn01dMg==
+  dependencies:
+    inline-style-parser "0.1.1"
 
 stylehacks@^5.1.1:
   version "5.1.1"
@@ -9780,6 +10180,16 @@ tr46@^2.1.0:
   dependencies:
     punycode "^2.1.1"
 
+trim-lines@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/trim-lines/-/trim-lines-3.0.1.tgz#d802e332a07df861c48802c04321017b1bd87338"
+  integrity sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==
+
+trough@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/trough/-/trough-2.1.0.tgz#0f7b511a4fde65a46f18477ab38849b22c554876"
+  integrity sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g==
+
 "true-myth@^7.1.0":
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/true-myth/-/true-myth-7.1.0.tgz#79077b5f1848af1ea0c241234aec2c4d0c11b91a"
@@ -9963,12 +10373,63 @@ unicode-property-aliases-ecmascript@^2.0.0:
   resolved "https://registry.yarnpkg.com/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.1.0.tgz#43d41e3be698bd493ef911077c9b131f827e8ccd"
   integrity sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w==
 
+unified@^11.0.0:
+  version "11.0.4"
+  resolved "https://registry.yarnpkg.com/unified/-/unified-11.0.4.tgz#f4be0ac0fe4c88cb873687c07c64c49ed5969015"
+  integrity sha512-apMPnyLjAX+ty4OrNap7yumyVAMlKx5IWU2wlzzUdYJO9A8f1p9m/gywF/GM2ZDFcjQPrx59Mc90KwmxsoklxQ==
+  dependencies:
+    "@types/unist" "^3.0.0"
+    bail "^2.0.0"
+    devlop "^1.0.0"
+    extend "^3.0.0"
+    is-plain-obj "^4.0.0"
+    trough "^2.0.0"
+    vfile "^6.0.0"
+
 unique-string@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/unique-string/-/unique-string-2.0.0.tgz#39c6451f81afb2749de2b233e3f7c5e8843bd89d"
   integrity sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==
   dependencies:
     crypto-random-string "^2.0.0"
+
+unist-util-is@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-6.0.0.tgz#b775956486aff107a9ded971d996c173374be424"
+  integrity sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==
+  dependencies:
+    "@types/unist" "^3.0.0"
+
+unist-util-position@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/unist-util-position/-/unist-util-position-5.0.0.tgz#678f20ab5ca1207a97d7ea8a388373c9cf896be4"
+  integrity sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==
+  dependencies:
+    "@types/unist" "^3.0.0"
+
+unist-util-stringify-position@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz#449c6e21a880e0855bf5aabadeb3a740314abac2"
+  integrity sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==
+  dependencies:
+    "@types/unist" "^3.0.0"
+
+unist-util-visit-parents@^6.0.0:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz#4d5f85755c3b8f0dc69e21eca5d6d82d22162815"
+  integrity sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==
+  dependencies:
+    "@types/unist" "^3.0.0"
+    unist-util-is "^6.0.0"
+
+unist-util-visit@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-5.0.0.tgz#a7de1f31f72ffd3519ea71814cccf5fd6a9217d6"
+  integrity sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==
+  dependencies:
+    "@types/unist" "^3.0.0"
+    unist-util-is "^6.0.0"
+    unist-util-visit-parents "^6.0.0"
 
 universalify@^0.2.0:
   version "0.2.0"
@@ -10076,6 +10537,23 @@ vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==
+
+vfile-message@^4.0.0:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/vfile-message/-/vfile-message-4.0.2.tgz#c883c9f677c72c166362fd635f21fc165a7d1181"
+  integrity sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==
+  dependencies:
+    "@types/unist" "^3.0.0"
+    unist-util-stringify-position "^4.0.0"
+
+vfile@^6.0.0:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/vfile/-/vfile-6.0.1.tgz#1e8327f41eac91947d4fe9d237a2dd9209762536"
+  integrity sha512-1bYqc7pt6NIADBJ98UiG0Bn/CHIVOoZ/IyEkqIruLg0mE1BKzkOXY2D6CSqQIcKqgadppE5lrxgWXJmXd7zZJw==
+  dependencies:
+    "@types/unist" "^3.0.0"
+    unist-util-stringify-position "^4.0.0"
+    vfile-message "^4.0.0"
 
 w3c-hr-time@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
## Description:
This PR adds support for enclave deletion to the new enclave manager ui. The delete action is handled in a react router action on the /enclaves path.

This PR also includes a change to the loaders to use `defer` so that loading states can be displayed with suspense - https://reactrouter.com/en/main/guides/deferred.

### Demo

_The positioning of the modal is a little off due to my screen size - it is centered on the window_ 

https://github.com/kurtosis-tech/kurtosis/assets/4419574/905481ea-aeef-4367-a5a1-466de250772c

## Is this change user facing?
NO (this ui is not currently deployed

## References (if applicable):
This PR sits on top of https://github.com/kurtosis-tech/kurtosis/pull/1643
