### PR TITLE
feat: preload package in new enclave manager

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1151,6 +1151,9 @@ workflows:
                     },
                     {
                         "pattern": "https://twitter.com/.*"
+                    },
+                    {
+                        "pattern": "https://github.com/kurtosis-tech/kurtosis/enclave-manager/web/README.md"
                     }
                 ]
             }

--- a/enclave-manager/web/src/client/enclaveManager/KurtosisClient.ts
+++ b/enclave-manager/web/src/client/enclaveManager/KurtosisClient.ts
@@ -3,6 +3,7 @@ import { RunStarlarkPackageArgs } from "enclave-manager-sdk/build/api_container_
 import {
   CreateEnclaveArgs,
   DestroyEnclaveArgs,
+  EnclaveAPIContainerInfo,
   EnclaveInfo,
   EnclaveMode,
 } from "enclave-manager-sdk/build/engine_service_pb";
@@ -99,13 +100,12 @@ export abstract class KurtosisClient {
     });
   }
 
-  async runStarlarkPackage(enclave: RemoveFunctions<EnclaveInfo>, packageId: string, args: Record<string, any>) {
+  async runStarlarkPackage(
+    apicInfo: RemoveFunctions<EnclaveAPIContainerInfo>,
+    packageId: string,
+    args: Record<string, any>,
+  ) {
     // Not currently using asyncResult as the return type here is an asyncIterable
-    const apicInfo = enclave.apiContainerInfo;
-    assertDefined(
-      apicInfo,
-      `Cannot listFilesArtifactNamesAndUuids because the passed enclave '${enclave.name}' does not have apicInfo`,
-    );
     const request = new RunStarlarkPackageRequest({
       apicIpAddress: apicInfo.bridgeIpAddress,
       apicPort: apicInfo.grpcPortInsideEnclave,

--- a/enclave-manager/web/src/client/enclaveManager/KurtosisClientContext.tsx
+++ b/enclave-manager/web/src/client/enclaveManager/KurtosisClientContext.tsx
@@ -1,4 +1,4 @@
-import { Flex, Heading, Spinner, useToast } from "@chakra-ui/react";
+import { Flex, Heading, Spinner } from "@chakra-ui/react";
 import { createContext, PropsWithChildren, useContext, useEffect, useMemo, useState } from "react";
 import { KurtosisAlert } from "../../components/KurtosisAlert";
 import { assertDefined, isDefined, isStringTrue, stringifyError } from "../../utils";
@@ -13,7 +13,6 @@ type KurtosisClientContextState = {
 const KurtosisClientContext = createContext<KurtosisClientContextState>({ client: null });
 
 export const KurtosisClientProvider = ({ children }: PropsWithChildren) => {
-  const toast = useToast();
   const [client, setClient] = useState<KurtosisClient>();
   const [jwtToken, setJwtToken] = useState<string>();
   const [error, setError] = useState<string>();
@@ -33,12 +32,7 @@ export const KurtosisClientProvider = ({ children }: PropsWithChildren) => {
                 const methodResult = Reflect.apply(target, thisArg, argumentsList) as ReturnType<typeof target>;
                 return methodResult.then((r) => {
                   if (r.isErr) {
-                    toast({
-                      title: "Error",
-                      description: r.error.message,
-                      status: "error",
-                      variant: "solid",
-                    });
+                    console.error(r.error);
                   }
                   return r;
                 });
@@ -51,7 +45,7 @@ export const KurtosisClientProvider = ({ children }: PropsWithChildren) => {
       });
     }
     return undefined;
-  }, [client, toast]);
+  }, [client]);
 
   useEffect(() => {
     const receiveMessage = (event: MessageEvent) => {
@@ -74,8 +68,6 @@ export const KurtosisClientProvider = ({ children }: PropsWithChildren) => {
       const searchParams = new URLSearchParams(window.location.search);
       const requireAuth = isStringTrue(searchParams.get("require_authentication"));
       const requestedApiHost = searchParams.get("api_host");
-      // eslint-disable-next-line
-      const preloadedPackage = searchParams.get("package");
       try {
         setError(undefined);
         let newClient: KurtosisClient | null = null;

--- a/enclave-manager/web/src/client/packageIndexer/KurtosisPackageIndexerClientContext.tsx
+++ b/enclave-manager/web/src/client/packageIndexer/KurtosisPackageIndexerClientContext.tsx
@@ -1,4 +1,3 @@
-import { useToast } from "@chakra-ui/react";
 import { createContext, PropsWithChildren, useContext, useMemo } from "react";
 import { assertDefined } from "../../utils";
 import { KurtosisPackageIndexerClient } from "./KurtosisPackageIndexerClient";
@@ -10,8 +9,6 @@ type KurtosisPackageIndexerClientContextState = {
 const KurtosisPackageIndexerClientContext = createContext<KurtosisPackageIndexerClientContextState>({ client: null });
 
 export const KurtosisPackageIndexerProvider = ({ children }: PropsWithChildren) => {
-  const toast = useToast();
-
   const errorHandlingClient = useMemo(() => {
     return new Proxy(new KurtosisPackageIndexerClient(), {
       get(target, prop: string | symbol) {
@@ -21,12 +18,7 @@ export const KurtosisPackageIndexerProvider = ({ children }: PropsWithChildren) 
               const methodResult = Reflect.apply(target, thisArg, argumentsList) as ReturnType<typeof target>;
               return methodResult.then((r) => {
                 if (r.isErr) {
-                  toast({
-                    title: "Error",
-                    description: r.error.message,
-                    status: "error",
-                    variant: "solid",
-                  });
+                  console.error(r.error);
                 }
                 return r;
               });
@@ -37,7 +29,7 @@ export const KurtosisPackageIndexerProvider = ({ children }: PropsWithChildren) 
         }
       },
     });
-  }, [toast]);
+  }, []);
 
   return (
     <KurtosisPackageIndexerClientContext.Provider value={{ client: errorHandlingClient }}>

--- a/enclave-manager/web/src/components/CopyButton.tsx
+++ b/enclave-manager/web/src/components/CopyButton.tsx
@@ -3,17 +3,19 @@ import { FiCopy } from "react-icons/fi";
 import { isDefined } from "../utils";
 
 type CopyButtonProps = ButtonProps & {
-  valueToCopy?: string | null;
+  valueToCopy?: (() => string) | string | null;
+  text?: string;
 };
 
-export const CopyButton = ({ valueToCopy, ...buttonProps }: CopyButtonProps) => {
+export const CopyButton = ({ valueToCopy, text, ...buttonProps }: CopyButtonProps) => {
   const toast = useToast();
 
   const handleCopyClick = () => {
     if (isDefined(valueToCopy)) {
-      navigator.clipboard.writeText(valueToCopy);
+      const v = typeof valueToCopy === "string" ? valueToCopy : valueToCopy();
+      navigator.clipboard.writeText(v);
       toast({
-        title: `Copied '${valueToCopy}' to the clipboard`,
+        title: `Copied '${v}' to the clipboard`,
         status: `success`,
       });
     }
@@ -25,7 +27,7 @@ export const CopyButton = ({ valueToCopy, ...buttonProps }: CopyButtonProps) => 
 
   return (
     <Button leftIcon={<FiCopy />} size={"xs"} colorScheme={"darkBlue"} onClick={handleCopyClick} {...buttonProps}>
-      Copy
+      {text || "Copy"}
     </Button>
   );
 };

--- a/enclave-manager/web/src/components/enclaves/CreateEnclaveButton.tsx
+++ b/enclave-manager/web/src/components/enclaves/CreateEnclaveButton.tsx
@@ -1,11 +1,12 @@
 import { Button, Menu, MenuButton, MenuItem, MenuList } from "@chakra-ui/react";
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import { FiPackage, FiPlus, FiSettings } from "react-icons/fi";
 import { useNavigate } from "react-router-dom";
 import { KurtosisPackage } from "../../client/packageIndexer/api/kurtosis_package_indexer_pb";
 import { isDefined } from "../../utils";
 import { ConfigureEnclaveModal } from "./modals/ConfigureEnclaveModal";
 import { ManualCreateEnclaveModal } from "./modals/ManualCreateEnclaveModal";
+import { PreloadEnclave } from "./PreloadEnclave";
 
 export const CreateEnclaveButton = () => {
   const navigate = useNavigate();
@@ -24,6 +25,11 @@ export const CreateEnclaveButton = () => {
     setConfigureEnclaveOpen(true);
   };
 
+  const handlePreloadEnclave = useCallback((kurtosisPackage: KurtosisPackage) => {
+    setKurtosisPackage(kurtosisPackage);
+    setConfigureEnclaveOpen(true);
+  }, []);
+
   return (
     <>
       <Menu matchWidth>
@@ -39,6 +45,7 @@ export const CreateEnclaveButton = () => {
           </MenuItem>
         </MenuList>
       </Menu>
+      <PreloadEnclave onPackageLoaded={handlePreloadEnclave} />
       <ManualCreateEnclaveModal
         isOpen={manualCreateEnclaveOpen}
         onClose={() => setManualCreateEnclaveOpen(false)}

--- a/enclave-manager/web/src/components/enclaves/EditEnclaveButton.tsx
+++ b/enclave-manager/web/src/components/enclaves/EditEnclaveButton.tsx
@@ -1,0 +1,51 @@
+import { Button, Tooltip } from "@chakra-ui/react";
+import { useState } from "react";
+import { FiEdit2 } from "react-icons/fi";
+import { KurtosisPackage } from "../../client/packageIndexer/api/kurtosis_package_indexer_pb";
+import { EnclaveFullInfo } from "../../emui/enclaves/types";
+import { isDefined } from "../../utils";
+import { ConfigureEnclaveModal } from "./modals/ConfigureEnclaveModal";
+import { PackageLoadingModal } from "./modals/PackageLoadingModal";
+
+type EditEnclaveButtonProps = {
+  enclave: EnclaveFullInfo;
+};
+
+export const EditEnclaveButton = ({ enclave }: EditEnclaveButtonProps) => {
+  const [showPackageLoader, setShowPackageLoader] = useState(false);
+  const [kurtosisPackage, setKurtosisPackage] = useState<KurtosisPackage>();
+
+  const handlePackageLoaded = (kurtosisPackage: KurtosisPackage) => {
+    setShowPackageLoader(false);
+    setKurtosisPackage(kurtosisPackage);
+  };
+
+  if (enclave.starlarkRun.isErr) {
+    return (
+      <Tooltip label={"Cannot find previous run config to edit"}>
+        <Button disabled={true} colorScheme={"blue"} leftIcon={<FiEdit2 />} size={"md"}>
+          Edit
+        </Button>
+      </Tooltip>
+    );
+  }
+
+  return (
+    <>
+      <Button onClick={() => setShowPackageLoader(true)} colorScheme={"blue"} leftIcon={<FiEdit2 />} size={"md"}>
+        Edit
+      </Button>
+      {showPackageLoader && (
+        <PackageLoadingModal packageId={enclave.starlarkRun.value.packageId} onPackageLoaded={handlePackageLoaded} />
+      )}
+      {isDefined(kurtosisPackage) && (
+        <ConfigureEnclaveModal
+          isOpen={true}
+          onClose={() => setKurtosisPackage(undefined)}
+          kurtosisPackage={kurtosisPackage}
+          existingEnclave={enclave}
+        />
+      )}
+    </>
+  );
+};

--- a/enclave-manager/web/src/components/enclaves/EnclaveOverview.tsx
+++ b/enclave-manager/web/src/components/enclaves/EnclaveOverview.tsx
@@ -3,6 +3,7 @@ import { DateTime } from "luxon";
 import { EnclaveFullInfo } from "../../emui/enclaves/types";
 import { isDefined } from "../../utils";
 import { FormatDateTime } from "../FormatDateTime";
+import { KurtosisAlert } from "../KurtosisAlert";
 import { FLEX_STANDARD_GAP } from "../theme/constants";
 import { TitledCard } from "../TitledCard";
 import { ValueCard } from "../ValueCard";
@@ -47,10 +48,16 @@ export const EnclaveOverview = ({ enclave }: EnclaveOverviewProps) => {
         </GridItem>
       </Grid>
       <TitledCard title={"Services"}>
-        <ServicesTable enclave={enclave} />
+        {enclave.services.isOk && (
+          <ServicesTable servicesResponse={enclave.services.value} enclaveShortUUID={enclave.shortenedUuid} />
+        )}
+        {enclave.services.isErr && <KurtosisAlert message={enclave.services.error} />}
       </TitledCard>
       <TitledCard title={"Files"}>
-        <FilesTable enclave={enclave} />
+        {enclave.filesAndArtifacts.isOk && (
+          <FilesTable filesAndArtifacts={enclave.filesAndArtifacts.value} enclaveShortUUID={enclave.shortenedUuid} />
+        )}
+        {enclave.filesAndArtifacts.isErr && <KurtosisAlert message={enclave.filesAndArtifacts.error} />}
       </TitledCard>
     </Flex>
   );

--- a/enclave-manager/web/src/components/enclaves/PreloadEnclave.tsx
+++ b/enclave-manager/web/src/components/enclaves/PreloadEnclave.tsx
@@ -1,0 +1,86 @@
+import {
+  Button,
+  Flex,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Spinner,
+  Text,
+} from "@chakra-ui/react";
+import { useEffect, useState } from "react";
+import { KurtosisPackage } from "../../client/packageIndexer/api/kurtosis_package_indexer_pb";
+import { useKurtosisPackageIndexerClient } from "../../client/packageIndexer/KurtosisPackageIndexerClientContext";
+import { isDefined } from "../../utils";
+import { KurtosisAlert } from "../KurtosisAlert";
+
+type PreloadEnclaveProps = {
+  onPackageLoaded: (kurtosisPackage: KurtosisPackage) => void;
+};
+
+export const PreloadEnclave = ({ onPackageLoaded }: PreloadEnclaveProps) => {
+  const kurtosisIndexer = useKurtosisPackageIndexerClient();
+  const [modalOpen, setModalOpen] = useState(false);
+  const [isPreloading, setIsPreloading] = useState(false);
+  const [preloadError, setPreloadError] = useState<string>();
+
+  const searchParams = new URLSearchParams(window.location.search);
+  const preloadPackage = searchParams.get("preloadPackage");
+
+  useEffect(() => {
+    (async () => {
+      if (isDefined(preloadPackage)) {
+        setModalOpen(true);
+        setIsPreloading(true);
+        setPreloadError(undefined);
+        const readPackageResponse = await kurtosisIndexer.readPackage(preloadPackage);
+        setIsPreloading(false);
+
+        if (readPackageResponse.isErr) {
+          setPreloadError(readPackageResponse.error);
+          return;
+        }
+        if (!isDefined(readPackageResponse.value.package)) {
+          setPreloadError(`Could not find package ${preloadPackage}`);
+          return;
+        }
+
+        setModalOpen(false);
+        onPackageLoaded(readPackageResponse.value.package);
+      }
+    })();
+  }, [preloadPackage, onPackageLoaded]);
+
+  if (!isDefined(preloadPackage)) {
+    return null;
+  }
+
+  return (
+    <Modal isOpen={modalOpen} onClose={() => !isPreloading && setModalOpen(false)} isCentered>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>Loading</ModalHeader>
+        <ModalCloseButton />
+        <ModalBody>
+          {isPreloading && (
+            <Flex flexDirection={"column"} alignItems={"center"} gap={"32px"}>
+              <Spinner size={"xl"} />
+              <Text>Fetching {preloadPackage}</Text>
+            </Flex>
+          )}
+          {isDefined(preloadError) && <KurtosisAlert message={preloadError} />}
+        </ModalBody>
+        <ModalFooter>
+          <Flex justifyContent={"flex-end"} gap={"12px"}>
+            <Button color={"gray.100"} onClick={() => setModalOpen(false)} disabled={isPreloading}>
+              Close
+            </Button>
+          </Flex>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+};

--- a/enclave-manager/web/src/components/enclaves/PreloadEnclave.tsx
+++ b/enclave-manager/web/src/components/enclaves/PreloadEnclave.tsx
@@ -1,86 +1,18 @@
-import {
-  Button,
-  Flex,
-  Modal,
-  ModalBody,
-  ModalCloseButton,
-  ModalContent,
-  ModalFooter,
-  ModalHeader,
-  ModalOverlay,
-  Spinner,
-  Text,
-} from "@chakra-ui/react";
-import { useEffect, useState } from "react";
 import { KurtosisPackage } from "../../client/packageIndexer/api/kurtosis_package_indexer_pb";
-import { useKurtosisPackageIndexerClient } from "../../client/packageIndexer/KurtosisPackageIndexerClientContext";
 import { isDefined } from "../../utils";
-import { KurtosisAlert } from "../KurtosisAlert";
+import { PackageLoadingModal } from "./modals/PackageLoadingModal";
 
 type PreloadEnclaveProps = {
   onPackageLoaded: (kurtosisPackage: KurtosisPackage) => void;
 };
 
 export const PreloadEnclave = ({ onPackageLoaded }: PreloadEnclaveProps) => {
-  const kurtosisIndexer = useKurtosisPackageIndexerClient();
-  const [modalOpen, setModalOpen] = useState(false);
-  const [isPreloading, setIsPreloading] = useState(false);
-  const [preloadError, setPreloadError] = useState<string>();
-
   const searchParams = new URLSearchParams(window.location.search);
   const preloadPackage = searchParams.get("preloadPackage");
-
-  useEffect(() => {
-    (async () => {
-      if (isDefined(preloadPackage)) {
-        setModalOpen(true);
-        setIsPreloading(true);
-        setPreloadError(undefined);
-        const readPackageResponse = await kurtosisIndexer.readPackage(preloadPackage);
-        setIsPreloading(false);
-
-        if (readPackageResponse.isErr) {
-          setPreloadError(readPackageResponse.error);
-          return;
-        }
-        if (!isDefined(readPackageResponse.value.package)) {
-          setPreloadError(`Could not find package ${preloadPackage}`);
-          return;
-        }
-
-        setModalOpen(false);
-        onPackageLoaded(readPackageResponse.value.package);
-      }
-    })();
-  }, [preloadPackage, onPackageLoaded]);
 
   if (!isDefined(preloadPackage)) {
     return null;
   }
 
-  return (
-    <Modal isOpen={modalOpen} onClose={() => !isPreloading && setModalOpen(false)} isCentered>
-      <ModalOverlay />
-      <ModalContent>
-        <ModalHeader>Loading</ModalHeader>
-        <ModalCloseButton />
-        <ModalBody>
-          {isPreloading && (
-            <Flex flexDirection={"column"} alignItems={"center"} gap={"32px"}>
-              <Spinner size={"xl"} />
-              <Text>Fetching {preloadPackage}</Text>
-            </Flex>
-          )}
-          {isDefined(preloadError) && <KurtosisAlert message={preloadError} />}
-        </ModalBody>
-        <ModalFooter>
-          <Flex justifyContent={"flex-end"} gap={"12px"}>
-            <Button color={"gray.100"} onClick={() => setModalOpen(false)} disabled={isPreloading}>
-              Close
-            </Button>
-          </Flex>
-        </ModalFooter>
-      </ModalContent>
-    </Modal>
-  );
+  return <PackageLoadingModal packageId={preloadPackage} onPackageLoaded={onPackageLoaded} />;
 };

--- a/enclave-manager/web/src/components/enclaves/configuration/EnclaveConfigurationForm.tsx
+++ b/enclave-manager/web/src/components/enclaves/configuration/EnclaveConfigurationForm.tsx
@@ -1,4 +1,4 @@
-import { PropsWithChildren } from "react";
+import { forwardRef, PropsWithChildren, useImperativeHandle } from "react";
 import { FormProvider, SubmitHandler, useForm, useFormContext } from "react-hook-form";
 import {
   ArgumentValueType,
@@ -8,13 +8,31 @@ import {
 import { isDefined, isStringTrue } from "../../../utils";
 import { ConfigureEnclaveForm } from "./types";
 
-type PackageConfigurationFormProps = PropsWithChildren<{
+type EnclaveConfigurationFormProps = PropsWithChildren<{
   onSubmit: SubmitHandler<ConfigureEnclaveForm>;
   kurtosisPackage: KurtosisPackage;
+  initialValues?: ConfigureEnclaveForm;
 }>;
 
-export const EnclaveConfigurationForm = ({ children, kurtosisPackage, onSubmit }: PackageConfigurationFormProps) => {
-  const methods = useForm<ConfigureEnclaveForm>();
+export type EnclaveConfigurationFormImperativeAttributes = {
+  getValues: () => ConfigureEnclaveForm;
+};
+
+export const EnclaveConfigurationForm = forwardRef<
+  EnclaveConfigurationFormImperativeAttributes,
+  EnclaveConfigurationFormProps
+>(({ children, kurtosisPackage, onSubmit, initialValues }: EnclaveConfigurationFormProps, ref) => {
+  const methods = useForm<ConfigureEnclaveForm>({ values: initialValues });
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      getValues: () => {
+        return methods.getValues();
+      },
+    }),
+    [methods],
+  );
 
   const handleSubmit: SubmitHandler<ConfigureEnclaveForm> = (data) => {
     const transformValue = (
@@ -88,6 +106,6 @@ export const EnclaveConfigurationForm = ({ children, kurtosisPackage, onSubmit }
       <form onSubmit={methods.handleSubmit(handleSubmit)}>{children}</form>
     </FormProvider>
   );
-};
+});
 
 export const useEnclaveConfigurationFormContext = () => useFormContext<ConfigureEnclaveForm>();

--- a/enclave-manager/web/src/components/enclaves/modals/ConfigureEnclaveModal.tsx
+++ b/enclave-manager/web/src/components/enclaves/modals/ConfigureEnclaveModal.tsx
@@ -13,12 +13,14 @@ import {
   Text,
   Tooltip,
 } from "@chakra-ui/react";
+import { EnclaveMode } from "enclave-manager-sdk/build/engine_service_pb";
 import { useMemo, useRef, useState } from "react";
 import { SubmitHandler } from "react-hook-form";
 import { useNavigate, useSubmit } from "react-router-dom";
 import { useKurtosisClient } from "../../../client/enclaveManager/KurtosisClientContext";
-import { KurtosisPackage } from "../../../client/packageIndexer/api/kurtosis_package_indexer_pb";
-import { isDefined } from "../../../utils";
+import { ArgumentValueType, KurtosisPackage } from "../../../client/packageIndexer/api/kurtosis_package_indexer_pb";
+import { EnclaveFullInfo } from "../../../emui/enclaves/types";
+import { assertDefined, isDefined, stringifyError } from "../../../utils";
 import { CopyButton } from "../../CopyButton";
 import { KurtosisAlert } from "../../KurtosisAlert";
 import {
@@ -36,9 +38,15 @@ type ConfigureEnclaveModalProps = {
   isOpen: boolean;
   onClose: () => void;
   kurtosisPackage: KurtosisPackage;
+  existingEnclave?: EnclaveFullInfo;
 };
 
-export const ConfigureEnclaveModal = ({ isOpen, onClose, kurtosisPackage }: ConfigureEnclaveModalProps) => {
+export const ConfigureEnclaveModal = ({
+  isOpen,
+  onClose,
+  kurtosisPackage,
+  existingEnclave,
+}: ConfigureEnclaveModalProps) => {
   const kurtosisClient = useKurtosisClient();
   const navigator = useNavigate();
   const submit = useSubmit();
@@ -47,13 +55,72 @@ export const ConfigureEnclaveModal = ({ isOpen, onClose, kurtosisPackage }: Conf
   const formRef = useRef<EnclaveConfigurationFormImperativeAttributes>(null);
 
   const initialValues = useMemo(() => {
+    if (isDefined(existingEnclave)) {
+      if (existingEnclave.starlarkRun.isErr) {
+        setError(
+          `Could not retrieve starlark run for previous configuration, got error: ${existingEnclave.starlarkRun.isErr}`,
+        );
+        return undefined;
+      }
+      try {
+        const parsedArgs = JSON.parse(existingEnclave.starlarkRun.value.serializedParams);
+        const convertArgValue = (
+          argType: ArgumentValueType | undefined,
+          value: any,
+          innerType1?: ArgumentValueType,
+          innerType2?: ArgumentValueType,
+        ): any => {
+          switch (argType) {
+            case ArgumentValueType.BOOL:
+              return !!value ? "true" : "false";
+            case ArgumentValueType.INTEGER:
+              return isDefined(value) ? `${value}` : "";
+            case ArgumentValueType.STRING:
+              return value || "";
+            case ArgumentValueType.JSON:
+              return isDefined(value) ? JSON.stringify(value) : "{}";
+            case ArgumentValueType.LIST:
+              assertDefined(innerType1, `Cannot parse a list argument type without knowing innerType1`);
+              return isDefined(value) ? value.map((v: any) => convertArgValue(innerType1, v)) : [];
+            case ArgumentValueType.DICT:
+              assertDefined(innerType2, `Cannot parse a dict argument type without knowing innterType2`);
+              return isDefined(value)
+                ? Object.entries(value).map(([k, v]) => ({ key: k, value: convertArgValue(innerType2, v) }), {})
+                : {};
+            default:
+              return value;
+          }
+        };
+
+        const args = kurtosisPackage.args.reduce(
+          (acc, arg) => ({
+            ...acc,
+            [arg.name]: convertArgValue(
+              arg.typeV2?.topLevelType,
+              parsedArgs[arg.name],
+              arg.typeV2?.innerType1,
+              arg.typeV2?.innerType2,
+            ),
+          }),
+          {},
+        );
+        return {
+          enclaveName: existingEnclave.name,
+          restartServices: existingEnclave.mode === EnclaveMode.PRODUCTION,
+          args,
+        } as ConfigureEnclaveForm;
+      } catch (err: any) {
+        setError(`Could not reuse previous configuration, got error: ${stringifyError(err)}`);
+        return undefined;
+      }
+    }
     const searchParams = new URLSearchParams(window.location.search);
     const preloadArgs = searchParams.get("preloadArgs");
     if (!isDefined(preloadArgs)) {
       return undefined;
     }
     return JSON.parse(atob(preloadArgs)) as ConfigureEnclaveForm;
-  }, [window.location.search]);
+  }, [window.location.search, existingEnclave]);
 
   // TODO: Improve for cloud config
   const getLinkToCurrentConfig = () =>
@@ -69,27 +136,40 @@ export const ConfigureEnclaveModal = ({ isOpen, onClose, kurtosisPackage }: Conf
   };
 
   const handleLoadSubmit: SubmitHandler<ConfigureEnclaveForm> = async (formData) => {
-    setIsLoading(true);
     setError(undefined);
-    const newEnclave = await kurtosisClient.createEnclave(formData.enclaveName, "info", formData.restartServices);
-    setIsLoading(false);
 
-    if (newEnclave.isErr) {
-      setError(`Could not create enclave, got: ${newEnclave.error}`);
-      return;
+    let apicInfo = existingEnclave?.apiContainerInfo;
+    let enclaveUUID = existingEnclave?.shortenedUuid;
+    if (!isDefined(existingEnclave)) {
+      setIsLoading(true);
+      const newEnclave = await kurtosisClient.createEnclave(formData.enclaveName, "info", formData.restartServices);
+      setIsLoading(false);
+
+      if (newEnclave.isErr) {
+        setError(`Could not create enclave, got: ${newEnclave.error}`);
+        return;
+      }
+      if (!isDefined(newEnclave.value.enclaveInfo)) {
+        setError(`Did not receive enclave info when running createEnclave`);
+        return;
+      }
+      apicInfo = newEnclave.value.enclaveInfo.apiContainerInfo;
+      enclaveUUID = newEnclave.value.enclaveInfo.shortenedUuid;
     }
-    if (!isDefined(newEnclave.value.enclaveInfo)) {
-      setError(`Did not receive enclave info when running createEnclave`);
+
+    if (!isDefined(apicInfo)) {
+      setError(`Cannot trigger starlark run as apic info cannot be found`);
       return;
     }
     submit(
-      { config: formData, packageId: kurtosisPackage.name, enclave: newEnclave.value.enclaveInfo.toJson() },
+      { config: formData, packageId: kurtosisPackage.name, apicInfo: apicInfo.toJson() },
       {
         method: "post",
-        action: `/enclave/${newEnclave.value.enclaveInfo.shortenedUuid}`,
+        action: `/enclave/${enclaveUUID}`,
         encType: "application/json",
       },
     );
+    onClose();
   };
 
   return (
@@ -110,8 +190,8 @@ export const ConfigureEnclaveModal = ({ isOpen, onClose, kurtosisPackage }: Conf
               <EnclaveSourceButton source={kurtosisPackage.name} size={"sm"} variant={"outline"} color={"gray.100"} />
               <Text>to</Text>
               <Input size={"sm"} placeholder={"an unamed environment"} width={"auto"} />
-              {isDefined(error) && <KurtosisAlert message={error} />}
             </Flex>
+            {isDefined(error) && <KurtosisAlert message={error} />}
             <Flex flexDirection={"column"} gap={"24px"} p={"12px 24px"} bg={"gray.900"}>
               <Flex justifyContent={"space-between"} alignItems={"center"}>
                 <FormControl display={"flex"} alignItems={"center"} gap={"16px"}>

--- a/enclave-manager/web/src/components/enclaves/modals/ManualCreateEnclaveModal.tsx
+++ b/enclave-manager/web/src/components/enclaves/modals/ManualCreateEnclaveModal.tsx
@@ -53,7 +53,7 @@ export const ManualCreateEnclaveModal = ({ isOpen, onClose, onConfirm }: ManualC
     const packageResponse = await kurtosisIndexerClient.readPackage(form.url);
     setIsLoading(false);
     if (packageResponse.isErr) {
-      setError("url", { message: `Could not load '${form.url}', got error ${packageResponse.error.message}` });
+      setError("url", { message: `Could not load '${form.url}', got error ${packageResponse.error}` });
       return;
     }
     if (!isDefined(packageResponse.value.package)) {

--- a/enclave-manager/web/src/components/enclaves/modals/ManualCreateEnclaveModal.tsx
+++ b/enclave-manager/web/src/components/enclaves/modals/ManualCreateEnclaveModal.tsx
@@ -82,7 +82,6 @@ export const ManualCreateEnclaveModal = ({ isOpen, onClose, onConfirm }: ManualC
                   {...register("url", {
                     disabled: isLoading,
                     required: true,
-                    value: "github.com/kurtosis-tech/etcd-package",
                   })}
                 />
               </InputGroup>

--- a/enclave-manager/web/src/components/enclaves/modals/ManualCreateEnclaveModal.tsx
+++ b/enclave-manager/web/src/components/enclaves/modals/ManualCreateEnclaveModal.tsx
@@ -94,7 +94,7 @@ export const ManualCreateEnclaveModal = ({ isOpen, onClose, onConfirm }: ManualC
                 Cancel
               </Button>
               <Button type={"submit"} isLoading={isLoading} colorScheme={"kurtosisGreen"}>
-                Load
+                Configure
               </Button>
             </Flex>
           </ModalFooter>

--- a/enclave-manager/web/src/components/enclaves/modals/PackageLoadingModal.tsx
+++ b/enclave-manager/web/src/components/enclaves/modals/PackageLoadingModal.tsx
@@ -1,0 +1,78 @@
+import {
+  Button,
+  Flex,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Spinner,
+  Text,
+} from "@chakra-ui/react";
+import { useEffect, useState } from "react";
+import { KurtosisPackage } from "../../../client/packageIndexer/api/kurtosis_package_indexer_pb";
+import { useKurtosisPackageIndexerClient } from "../../../client/packageIndexer/KurtosisPackageIndexerClientContext";
+import { isDefined } from "../../../utils";
+import { KurtosisAlert } from "../../KurtosisAlert";
+
+export type PackageLoadingModalProps = {
+  packageId: string;
+  onPackageLoaded: (kurtosisPackage: KurtosisPackage) => void;
+};
+
+export const PackageLoadingModal = ({ packageId, onPackageLoaded }: PackageLoadingModalProps) => {
+  const kurtosisIndexer = useKurtosisPackageIndexerClient();
+  const [modalOpen, setModalOpen] = useState(false);
+  const [isPreloading, setIsPreloading] = useState(false);
+  const [loadError, setLoadError] = useState<string>();
+
+  useEffect(() => {
+    (async () => {
+      setModalOpen(true);
+      setIsPreloading(true);
+      setLoadError(undefined);
+      const readPackageResponse = await kurtosisIndexer.readPackage(packageId);
+      setIsPreloading(false);
+
+      if (readPackageResponse.isErr) {
+        setLoadError(readPackageResponse.error);
+        return;
+      }
+      if (!isDefined(readPackageResponse.value.package)) {
+        setLoadError(`Could not find package ${packageId}`);
+        return;
+      }
+
+      setModalOpen(false);
+      onPackageLoaded(readPackageResponse.value.package);
+    })();
+  }, [packageId, onPackageLoaded]);
+
+  return (
+    <Modal isOpen={modalOpen} onClose={() => !isPreloading && setModalOpen(false)} isCentered>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>Loading</ModalHeader>
+        <ModalCloseButton />
+        <ModalBody>
+          {isPreloading && (
+            <Flex flexDirection={"column"} alignItems={"center"} gap={"32px"}>
+              <Spinner size={"xl"} />
+              <Text>Fetching {packageId}</Text>
+            </Flex>
+          )}
+          {isDefined(loadError) && <KurtosisAlert message={loadError} />}
+        </ModalBody>
+        <ModalFooter>
+          <Flex justifyContent={"flex-end"} gap={"12px"}>
+            <Button color={"gray.100"} onClick={() => setModalOpen(false)} disabled={isPreloading}>
+              Close
+            </Button>
+          </Flex>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+};

--- a/enclave-manager/web/src/components/enclaves/tables/EnclavesTable.tsx
+++ b/enclave-manager/web/src/components/enclaves/tables/EnclavesTable.tsx
@@ -18,9 +18,9 @@ type EnclaveTableRow = {
   name: string;
   status: EnclaveContainersStatus;
   created: DateTime | null;
-  source: string;
-  services: ServiceInfo[];
-  artifacts: FilesArtifactNameAndUuid[];
+  source: string | null;
+  services: ServiceInfo[] | null;
+  artifacts: FilesArtifactNameAndUuid[] | null;
 };
 
 const enclaveToRow = (enclave: EnclaveFullInfo): EnclaveTableRow => {
@@ -29,9 +29,9 @@ const enclaveToRow = (enclave: EnclaveFullInfo): EnclaveTableRow => {
     name: enclave.name,
     status: enclave.containersStatus,
     created: enclave.creationTime ? DateTime.fromJSDate(enclave.creationTime.toDate()) : null,
-    source: enclave.starlarkRun.packageId,
-    services: Object.values(enclave.services.serviceInfo),
-    artifacts: enclave.filesAndArtifacts.fileNamesAndUuids,
+    source: enclave.starlarkRun.isOk ? enclave.starlarkRun.value.packageId : null,
+    services: enclave.services.isOk ? Object.values(enclave.services.value.serviceInfo) : null,
+    artifacts: enclave.filesAndArtifacts.isOk ? enclave.filesAndArtifacts.value.fileNamesAndUuids : null,
   };
 };
 

--- a/enclave-manager/web/src/components/enclaves/tables/FilesTable.tsx
+++ b/enclave-manager/web/src/components/enclaves/tables/FilesTable.tsx
@@ -1,9 +1,12 @@
 import { Button } from "@chakra-ui/react";
 import { ColumnDef, createColumnHelper } from "@tanstack/react-table";
-import { FilesArtifactNameAndUuid } from "enclave-manager-sdk/build/api_container_service_pb";
+import {
+  FilesArtifactNameAndUuid,
+  ListFilesArtifactNamesAndUuidsResponse,
+} from "enclave-manager-sdk/build/api_container_service_pb";
 import { useMemo } from "react";
 import { Link } from "react-router-dom";
-import { EnclaveFullInfo } from "../../../emui/enclaves/types";
+import { RemoveFunctions } from "../../../utils/types";
 import { DataTable } from "../../DataTable";
 
 type FilesTableRow = {
@@ -23,18 +26,19 @@ const fileToRow = (file: FilesArtifactNameAndUuid): FilesTableRow => {
 const columnHelper = createColumnHelper<FilesTableRow>();
 
 type FilesTableProps = {
-  enclave: EnclaveFullInfo;
+  enclaveShortUUID: string;
+  filesAndArtifacts: RemoveFunctions<ListFilesArtifactNamesAndUuidsResponse>;
 };
 
-export const FilesTable = ({ enclave }: FilesTableProps) => {
-  const services = enclave.filesAndArtifacts.fileNamesAndUuids.map(fileToRow);
+export const FilesTable = ({ filesAndArtifacts, enclaveShortUUID }: FilesTableProps) => {
+  const services = filesAndArtifacts.fileNamesAndUuids.map(fileToRow);
 
   const columns = useMemo<ColumnDef<FilesTableRow, any>[]>(
     () => [
       columnHelper.accessor("name", {
         header: "Name",
         cell: ({ row, getValue }) => (
-          <Link to={`/enclave/${enclave.enclaveUuid}/file/${row.original.uuid}`}>
+          <Link to={`/enclave/${enclaveShortUUID}/file/${row.original.uuid}`}>
             <Button size={"sm"} variant={"ghost"}>
               {getValue()}
             </Button>

--- a/enclave-manager/web/src/components/enclaves/tables/ServicesTable.tsx
+++ b/enclave-manager/web/src/components/enclaves/tables/ServicesTable.tsx
@@ -1,9 +1,14 @@
 import { Button } from "@chakra-ui/react";
 import { ColumnDef, createColumnHelper } from "@tanstack/react-table";
-import { Port, ServiceInfo, ServiceStatus } from "enclave-manager-sdk/build/api_container_service_pb";
+import {
+  GetServicesResponse,
+  Port,
+  ServiceInfo,
+  ServiceStatus,
+} from "enclave-manager-sdk/build/api_container_service_pb";
 import { useMemo } from "react";
 import { Link } from "react-router-dom";
-import { EnclaveFullInfo } from "../../../emui/enclaves/types";
+import { RemoveFunctions } from "../../../utils/types";
 import { DataTable } from "../../DataTable";
 import { ImageButton } from "../widgets/ImageButton";
 import { PortsSummary } from "../widgets/PortsSummary";
@@ -34,18 +39,19 @@ const serviceToRow = (service: ServiceInfo): ServicesTableRow => {
 const columnHelper = createColumnHelper<ServicesTableRow>();
 
 type EnclavesTableProps = {
-  enclave: EnclaveFullInfo;
+  enclaveShortUUID: string;
+  servicesResponse: RemoveFunctions<GetServicesResponse>;
 };
 
-export const ServicesTable = ({ enclave }: EnclavesTableProps) => {
-  const services = Object.values(enclave.services.serviceInfo).map(serviceToRow);
+export const ServicesTable = ({ enclaveShortUUID, servicesResponse }: EnclavesTableProps) => {
+  const services = Object.values(servicesResponse.serviceInfo).map(serviceToRow);
 
   const columns = useMemo<ColumnDef<ServicesTableRow, any>[]>(
     () => [
       columnHelper.accessor("name", {
         header: "Name",
         cell: ({ row, getValue }) => (
-          <Link to={`/enclave/${enclave.shortenedUuid}/service/${row.original.serviceUUID}`}>
+          <Link to={`/enclave/${enclaveShortUUID}/service/${row.original.serviceUUID}`}>
             <Button size={"sm"} variant={"ghost"}>
               {getValue()}
             </Button>
@@ -77,7 +83,7 @@ export const ServicesTable = ({ enclave }: EnclavesTableProps) => {
       columnHelper.accessor("serviceUUID", {
         header: "Logs",
         cell: (portsCell) => (
-          <Link to={`/enclave/${enclave.enclaveUuid}/service/${portsCell.getValue()}/logs`}>
+          <Link to={`/enclave/${enclaveShortUUID}/service/${portsCell.getValue()}/logs`}>
             <Button size={"xs"} variant={"ghost"}>
               View
             </Button>

--- a/enclave-manager/web/src/components/enclaves/widgets/EnclaveArtifactsSummary.tsx
+++ b/enclave-manager/web/src/components/enclaves/widgets/EnclaveArtifactsSummary.tsx
@@ -1,11 +1,16 @@
-import { Button } from "@chakra-ui/react";
+import { Button, Tag } from "@chakra-ui/react";
 import { FilesArtifactNameAndUuid } from "enclave-manager-sdk/build/api_container_service_pb";
+import { isDefined } from "../../../utils";
 
 type EnclaveArtifactsSummaryProps = {
-  artifacts: FilesArtifactNameAndUuid[];
+  artifacts: FilesArtifactNameAndUuid[] | null;
 };
 
 export const EnclaveArtifactsSummary = ({ artifacts }: EnclaveArtifactsSummaryProps) => {
+  if (!isDefined(artifacts)) {
+    return <Tag>Unknown</Tag>;
+  }
+
   return (
     <Button variant={"ghost"} size={"xs"}>
       {artifacts.length}

--- a/enclave-manager/web/src/components/enclaves/widgets/EnclaveServicesSummary.tsx
+++ b/enclave-manager/web/src/components/enclaves/widgets/EnclaveServicesSummary.tsx
@@ -1,12 +1,16 @@
-import { Button, ButtonGroup, Text, Tooltip } from "@chakra-ui/react";
+import { Button, ButtonGroup, Tag, Text, Tooltip } from "@chakra-ui/react";
 import { ServiceInfo, ServiceStatus } from "enclave-manager-sdk/build/api_container_service_pb";
 import { isDefined } from "../../../utils";
 
 type ServicesSummaryProps = {
-  services: ServiceInfo[];
+  services: ServiceInfo[] | null;
 };
 
 export const EnclaveServicesSummary = ({ services }: ServicesSummaryProps) => {
+  if (!isDefined(services)) {
+    return <Tag>Unknown</Tag>;
+  }
+
   const runningServices = services.filter(({ serviceStatus }) => serviceStatus === ServiceStatus.RUNNING).length;
   const stopppedServices = services.filter(({ serviceStatus }) => serviceStatus === ServiceStatus.STOPPED).length;
   const unknownServices = services.filter(({ serviceStatus }) => serviceStatus === ServiceStatus.UNKNOWN).length;

--- a/enclave-manager/web/src/components/enclaves/widgets/EnclaveServicesSummary.tsx
+++ b/enclave-manager/web/src/components/enclaves/widgets/EnclaveServicesSummary.tsx
@@ -1,4 +1,4 @@
-import { Button, ButtonGroup, Tag, Text, Tooltip } from "@chakra-ui/react";
+import { Button, ButtonGroup, Tag, Tooltip } from "@chakra-ui/react";
 import { ServiceInfo, ServiceStatus } from "enclave-manager-sdk/build/api_container_service_pb";
 import { isDefined } from "../../../utils";
 
@@ -15,13 +15,7 @@ export const EnclaveServicesSummary = ({ services }: ServicesSummaryProps) => {
   const stopppedServices = services.filter(({ serviceStatus }) => serviceStatus === ServiceStatus.STOPPED).length;
   const unknownServices = services.filter(({ serviceStatus }) => serviceStatus === ServiceStatus.UNKNOWN).length;
 
-  if (runningServices + stopppedServices + unknownServices === 0) {
-    return (
-      <Text fontSize={"xs"} as={"i"}>
-        No Services
-      </Text>
-    );
-  }
+  const totalServices = runningServices + stopppedServices + unknownServices;
 
   const tooltipLabel = [
     runningServices > 0 ? `${runningServices} running` : null,
@@ -33,7 +27,8 @@ export const EnclaveServicesSummary = ({ services }: ServicesSummaryProps) => {
 
   return (
     <Tooltip label={tooltipLabel} size={"xs"}>
-      <ButtonGroup size={"xs"} variant={"solid"}>
+      <ButtonGroup size={"xs"} isAttached variant={"solid"}>
+        {totalServices === 0 && <Button color={"#A0AEC0"}>NONE</Button>}
         {runningServices > 0 && <Button colorScheme={"green"}>{runningServices}</Button>}
         {stopppedServices > 0 && <Button colorScheme={"red"}>{stopppedServices}</Button>}
         {unknownServices > 0 && <Button colorScheme={"orange"}>{unknownServices}</Button>}

--- a/enclave-manager/web/src/components/enclaves/widgets/EnclaveSourceButton.tsx
+++ b/enclave-manager/web/src/components/enclaves/widgets/EnclaveSourceButton.tsx
@@ -1,11 +1,16 @@
-import { Button, ButtonProps, Icon } from "@chakra-ui/react";
+import { Button, ButtonProps, Icon, Tag } from "@chakra-ui/react";
 import { IoLogoGithub } from "react-icons/io";
+import { isDefined } from "../../../utils";
 
 type EnclaveSourceProps = ButtonProps & {
-  source: string;
+  source: string | null;
 };
 
 export const EnclaveSourceButton = ({ source, ...buttonProps }: EnclaveSourceProps) => {
+  if (!isDefined(source)) {
+    return <Tag>Unknown</Tag>;
+  }
+
   if (source.startsWith("github.com/")) {
     return (
       <Button leftIcon={<Icon as={IoLogoGithub} color={"gray.400"} />} variant={"ghost"} size={"xs"} {...buttonProps}>

--- a/enclave-manager/web/src/emui/catalog/loader.ts
+++ b/enclave-manager/web/src/emui/catalog/loader.ts
@@ -8,7 +8,7 @@ const loadCatalog = async (
 ): Promise<Result<KurtosisPackage[], string>> => {
   const packagesResponse = await kurtosisIndexerClient.getPackages();
   if (packagesResponse.isErr) {
-    return Result.err(packagesResponse.error.message || "Unknown api error");
+    return Result.err(packagesResponse.error || "Unknown api error");
   }
 
   return Result.ok(packagesResponse.value.packages);

--- a/enclave-manager/web/src/emui/enclaves/enclave/Enclave.tsx
+++ b/enclave-manager/web/src/emui/enclaves/enclave/Enclave.tsx
@@ -51,7 +51,6 @@ type EnclaveImpl = {
 
 const EnclaveImpl = ({ enclave }: EnclaveImpl) => {
   const actionData = useActionData() as undefined | EnclaveActionResolvedType;
-  console.log("action", actionData);
 
   useEffect(() => {
     if (actionData) {

--- a/enclave-manager/web/src/emui/enclaves/enclave/Enclave.tsx
+++ b/enclave-manager/web/src/emui/enclaves/enclave/Enclave.tsx
@@ -1,9 +1,9 @@
-import { Button, Flex, Spinner, Tab, TabList, TabPanel, TabPanels, Tabs } from "@chakra-ui/react";
-import { FiEdit2 } from "react-icons/fi";
+import { Flex, Spinner, Tab, TabList, TabPanel, TabPanels, Tabs } from "@chakra-ui/react";
 import { Await, useActionData, useParams, useRouteLoaderData } from "react-router-dom";
 import { EnclaveOverview } from "../../../components/enclaves/EnclaveOverview";
 
 import { Suspense, useEffect } from "react";
+import { EditEnclaveButton } from "../../../components/enclaves/EditEnclaveButton";
 import { DeleteEnclavesButton } from "../../../components/enclaves/widgets/DeleteEnclavesButton";
 import { KurtosisAlert } from "../../../components/KurtosisAlert";
 import { isDefined } from "../../../utils";
@@ -73,9 +73,7 @@ const EnclaveImpl = ({ enclave }: EnclaveImpl) => {
             </TabList>
             <Flex gap={"8px"} alignItems={"center"}>
               <DeleteEnclavesButton enclaves={[enclave]} />
-              <Button colorScheme={"blue"} leftIcon={<FiEdit2 />} size={"md"}>
-                Edit
-              </Button>
+              <EditEnclaveButton enclave={enclave} />
             </Flex>
           </Flex>
         </TabList>

--- a/enclave-manager/web/src/emui/enclaves/enclave/action.ts
+++ b/enclave-manager/web/src/emui/enclaves/enclave/action.ts
@@ -1,5 +1,5 @@
 import { StarlarkRunResponseLine } from "enclave-manager-sdk/build/api_container_service_pb";
-import { EnclaveInfo } from "enclave-manager-sdk/build/engine_service_pb";
+import { EnclaveAPIContainerInfo } from "enclave-manager-sdk/build/engine_service_pb";
 import { ActionFunction, ActionFunctionArgs } from "react-router-dom";
 import { KurtosisClient } from "../../../client/enclaveManager/KurtosisClient";
 import { ConfigureEnclaveForm } from "../../../components/enclaves/configuration/types";
@@ -9,13 +9,13 @@ const handleEnclaveAction = async (
   kurtosisClient: KurtosisClient,
   { params, request }: ActionFunctionArgs,
 ): Promise<{ logs: AsyncIterable<StarlarkRunResponseLine> }> => {
-  const { config, enclave, packageId } = (await request.json()) as {
+  const { config, apicInfo, packageId } = (await request.json()) as {
     config: ConfigureEnclaveForm;
     packageId: string;
-    enclave: RemoveFunctions<EnclaveInfo>;
+    apicInfo: RemoveFunctions<EnclaveAPIContainerInfo>;
   };
 
-  const logs = await kurtosisClient.runStarlarkPackage(enclave, packageId, config.args);
+  const logs = await kurtosisClient.runStarlarkPackage(apicInfo, packageId, config.args);
   return { logs };
 };
 

--- a/enclave-manager/web/src/emui/enclaves/enclave/action.ts
+++ b/enclave-manager/web/src/emui/enclaves/enclave/action.ts
@@ -14,7 +14,6 @@ const handleEnclaveAction = async (
     packageId: string;
     enclave: RemoveFunctions<EnclaveInfo>;
   };
-  console.log(enclave);
 
   const logs = await kurtosisClient.runStarlarkPackage(enclave, packageId, config.args);
   return { logs };

--- a/enclave-manager/web/src/emui/enclaves/enclave/loader.ts
+++ b/enclave-manager/web/src/emui/enclaves/enclave/loader.ts
@@ -35,38 +35,13 @@ export const loadEnclave = async (
     kurtosisClient.listFilesArtifactNamesAndUuids(enclave),
   ]);
 
-  if (services.isErr) {
-    return {
-      routeName: enclave.name,
-      enclave: Result.err(`Could not get services for enclave ${enclave.shortenedUuid}: ${services.error.message}`),
-    };
-  }
-
-  if (starlarkRun.isErr) {
-    return {
-      routeName: enclave.name,
-      enclave: Result.err(
-        `Could not get starlark run for enclave ${enclave.shortenedUuid}: ${starlarkRun.error.message}`,
-      ),
-    };
-  }
-
-  if (filesAndArtifacts.isErr) {
-    return {
-      routeName: enclave.name,
-      enclave: Result.err(
-        `Could not get files for enclave ${enclave.shortenedUuid}: ${filesAndArtifacts.error.message}`,
-      ),
-    };
-  }
-
   return {
     routeName: enclave.name,
     enclave: Result.ok({
       ...enclave,
-      starlarkRun: starlarkRun.value,
-      services: services.value,
-      filesAndArtifacts: filesAndArtifacts.value,
+      starlarkRun: starlarkRun,
+      services: services,
+      filesAndArtifacts: filesAndArtifacts,
     }),
   };
 };

--- a/enclave-manager/web/src/emui/enclaves/loader.ts
+++ b/enclave-manager/web/src/emui/enclaves/loader.ts
@@ -1,12 +1,12 @@
 import { defer } from "react-router-dom";
-import { Result, ResultNS } from "true-myth";
+import { Result } from "true-myth";
 import { KurtosisClient } from "../../client/enclaveManager/KurtosisClient";
 import { EnclaveFullInfo } from "./types";
 
 const loadEnclaves = async (kurtosisClient: KurtosisClient): Promise<Result<EnclaveFullInfo[], string>> => {
   const enclavesResponse = await kurtosisClient.getEnclaves();
   if (enclavesResponse.isErr) {
-    return Result.err(enclavesResponse.error.message || "Unknown api error");
+    return Result.err(enclavesResponse.error || "Unknown api error");
   }
   const enclaves = Object.values(enclavesResponse.value.enclaveInfo);
   const [starlarkRuns, services, filesAndArtifacts] = await Promise.all([
@@ -15,28 +15,13 @@ const loadEnclaves = async (kurtosisClient: KurtosisClient): Promise<Result<Encl
     Promise.all(enclaves.map((enclave) => kurtosisClient.listFilesArtifactNamesAndUuids(enclave))),
   ]);
 
-  const starlarkErrors = starlarkRuns.filter(ResultNS.isErr);
-  const servicesErrors = services.filter(ResultNS.isErr);
-  const filesAndArtifactErrors = filesAndArtifacts.filter(ResultNS.isErr);
-  if (starlarkErrors.length + servicesErrors.length + filesAndArtifactErrors.length > 0) {
-    return Result.err(
-      `Starlark errors: ${
-        starlarkErrors.length > 0 ? starlarkErrors.map((r) => r.error.message).join("\n") : "None"
-      }\nServices errors: ${
-        servicesErrors.length > 0 ? servicesErrors.map((r) => r.error.message).join("\n") : "None"
-      }\nFiles and Artifacts errors: ${
-        filesAndArtifactErrors.length > 0 ? filesAndArtifactErrors.map((r) => r.error.message).join("\n") : "None"
-      }`,
-    );
-  }
-
   return Result.ok(
     enclaves.map((enclave, i) => ({
       ...enclave,
       // These values are never actually null because of the checking above
-      starlarkRun: starlarkRuns[i].unwrapOr(null)!,
-      services: services[i].unwrapOr(null)!,
-      filesAndArtifacts: filesAndArtifacts[i].unwrapOr(null)!,
+      starlarkRun: starlarkRuns[i],
+      services: services[i],
+      filesAndArtifacts: filesAndArtifacts[i],
     })),
   );
 };

--- a/enclave-manager/web/src/emui/enclaves/types.ts
+++ b/enclave-manager/web/src/emui/enclaves/types.ts
@@ -4,10 +4,11 @@ import {
   ListFilesArtifactNamesAndUuidsResponse,
 } from "enclave-manager-sdk/build/api_container_service_pb";
 import { EnclaveInfo } from "enclave-manager-sdk/build/engine_service_pb";
+import { Result } from "true-myth";
 import { RemoveFunctions } from "../../utils/types";
 
 export type EnclaveFullInfo = RemoveFunctions<EnclaveInfo> & {
-  starlarkRun: RemoveFunctions<GetStarlarkRunResponse>;
-  services: RemoveFunctions<GetServicesResponse>;
-  filesAndArtifacts: RemoveFunctions<ListFilesArtifactNamesAndUuidsResponse>;
+  starlarkRun: Result<RemoveFunctions<GetStarlarkRunResponse>, string>;
+  services: Result<RemoveFunctions<GetServicesResponse>, string>;
+  filesAndArtifacts: Result<RemoveFunctions<ListFilesArtifactNamesAndUuidsResponse>, string>;
 };

--- a/enclave-manager/web/src/utils/index.ts
+++ b/enclave-manager/web/src/utils/index.ts
@@ -49,19 +49,14 @@ export function stringifyError(err: any): string {
   }
 }
 
-export type ErrorAndMessage<E> = {
-  error: E;
-  message?: string;
-};
-
-export async function asyncResult<T, E = any>(
+export async function asyncResult<T>(
   p: Promise<T> | (() => Promise<T>),
   errorMessage?: string,
-): Promise<Result<T, ErrorAndMessage<E>>> {
+): Promise<Result<T, string>> {
   try {
     const r = await (typeof p === "function" ? p() : p);
-    return Result.ok<T, ErrorAndMessage<E>>(r);
+    return Result.ok<T, string>(r);
   } catch (e: any) {
-    return Result.err({ error: e, message: errorMessage || stringifyError(e) });
+    return Result.err(errorMessage || stringifyError(e));
   }
 }


### PR DESCRIPTION
## Description:
This PR implements the 'preload package' functionality in the new enclave manager. The package arguments are base64 encoded json representations of the configure form values - this means that invalid configuration can be copied (perhaps useful for debugging?)

Additionally this PR refactors the `EnclaveFullInfo` object to contain `true-myth` `Result` objects for the services, artifacts and starlark run properties. The error type for these Result objects is simplified to a `string` - I thought originally that having the actual Error object might be useful (hence `MessageAndError`, but I've not used the `error` property at all - instead just passing `message` to alerts.

### Demo

https://github.com/kurtosis-tech/kurtosis/assets/4419574/d068a8e9-fe0f-49ba-8eb4-e5e75545f268

## Is this change user facing?
NO (the new enclave manager is not deployed anywhere

## References (if applicable):

