### PR TITLE
feat: edit packages in the new emui

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1151,6 +1151,9 @@ workflows:
                     },
                     {
                         "pattern": "https://twitter.com/.*"
+                    },
+                    {
+                        "pattern": "https://github.com/kurtosis-tech/kurtosis/enclave-manager/web/README.md"
                     }
                 ]
             }

--- a/enclave-manager/web/src/client/enclaveManager/KurtosisClient.ts
+++ b/enclave-manager/web/src/client/enclaveManager/KurtosisClient.ts
@@ -3,6 +3,7 @@ import { RunStarlarkPackageArgs } from "enclave-manager-sdk/build/api_container_
 import {
   CreateEnclaveArgs,
   DestroyEnclaveArgs,
+  EnclaveAPIContainerInfo,
   EnclaveInfo,
   EnclaveMode,
 } from "enclave-manager-sdk/build/engine_service_pb";
@@ -99,13 +100,12 @@ export abstract class KurtosisClient {
     });
   }
 
-  async runStarlarkPackage(enclave: RemoveFunctions<EnclaveInfo>, packageId: string, args: Record<string, any>) {
+  async runStarlarkPackage(
+    apicInfo: RemoveFunctions<EnclaveAPIContainerInfo>,
+    packageId: string,
+    args: Record<string, any>,
+  ) {
     // Not currently using asyncResult as the return type here is an asyncIterable
-    const apicInfo = enclave.apiContainerInfo;
-    assertDefined(
-      apicInfo,
-      `Cannot listFilesArtifactNamesAndUuids because the passed enclave '${enclave.name}' does not have apicInfo`,
-    );
     const request = new RunStarlarkPackageRequest({
       apicIpAddress: apicInfo.bridgeIpAddress,
       apicPort: apicInfo.grpcPortInsideEnclave,

--- a/enclave-manager/web/src/components/enclaves/EditEnclaveButton.tsx
+++ b/enclave-manager/web/src/components/enclaves/EditEnclaveButton.tsx
@@ -1,10 +1,9 @@
 import { Button, Tooltip } from "@chakra-ui/react";
-import { EnclaveMode } from "enclave-manager-sdk/build/engine_service_pb";
 import { useState } from "react";
 import { FiEdit2 } from "react-icons/fi";
-import { ArgumentValueType, KurtosisPackage } from "../../client/packageIndexer/api/kurtosis_package_indexer_pb";
+import { KurtosisPackage } from "../../client/packageIndexer/api/kurtosis_package_indexer_pb";
 import { EnclaveFullInfo } from "../../emui/enclaves/types";
-import { assertDefined, isDefined } from "../../utils";
+import { isDefined } from "../../utils";
 import { ConfigureEnclaveModal } from "./modals/ConfigureEnclaveModal";
 import { PackageLoadingModal } from "./modals/PackageLoadingModal";
 
@@ -40,80 +39,13 @@ export const EditEnclaveButton = ({ enclave }: EditEnclaveButtonProps) => {
         <PackageLoadingModal packageId={enclave.starlarkRun.value.packageId} onPackageLoaded={handlePackageLoaded} />
       )}
       {isDefined(kurtosisPackage) && (
-        <EditEnclaveModal
-          enclave={enclave}
-          kurtosisPackage={kurtosisPackage}
+        <ConfigureEnclaveModal
+          isOpen={true}
           onClose={() => setKurtosisPackage(undefined)}
+          kurtosisPackage={kurtosisPackage}
+          existingEnclave={enclave}
         />
       )}
     </>
-  );
-};
-
-type EditEnclaveModalProps = {
-  enclave: EnclaveFullInfo;
-  kurtosisPackage: KurtosisPackage;
-  onClose: () => void;
-};
-
-const EditEnclaveModal = ({ enclave, kurtosisPackage, onClose }: EditEnclaveModalProps) => {
-  if (enclave.starlarkRun.isErr) {
-    throw Error("Internal EditEnclaveModal passed enclave with error starlark run. This should not happen.");
-  }
-
-  const parsedArgs = JSON.parse(enclave.starlarkRun.value.serializedParams);
-  const convertArgValue = (
-    argType: ArgumentValueType | undefined,
-    value: any,
-    innerType1?: ArgumentValueType,
-    innerType2?: ArgumentValueType,
-  ): any => {
-    switch (argType) {
-      case ArgumentValueType.BOOL:
-        return !!value ? "true" : "false";
-      case ArgumentValueType.INTEGER:
-        return isDefined(value) ? `${value}` : "";
-      case ArgumentValueType.STRING:
-        return value || "";
-      case ArgumentValueType.JSON:
-        return isDefined(value) ? JSON.stringify(value) : "{}";
-      case ArgumentValueType.LIST:
-        assertDefined(innerType1, `Cannot parse a list argument type without knowing innerType1`);
-        return isDefined(value) ? value.map((v: any) => convertArgValue(innerType1, v)) : [];
-      case ArgumentValueType.DICT:
-        assertDefined(innerType2, `Cannot parse a dict argument type without knowing innterType2`);
-        return isDefined(value)
-          ? Object.entries(value).map(([k, v]) => ({ key: k, value: convertArgValue(innerType2, v) }), {})
-          : {};
-      default:
-        return value;
-    }
-  };
-
-  const formReadyArgs = kurtosisPackage.args.reduce(
-    (acc, arg) => ({
-      ...acc,
-      [arg.name]: convertArgValue(
-        arg.typeV2?.topLevelType,
-        parsedArgs[arg.name],
-        arg.typeV2?.innerType1,
-        arg.typeV2?.innerType2,
-      ),
-    }),
-    {},
-  );
-  console.log(formReadyArgs);
-
-  return (
-    <ConfigureEnclaveModal
-      isOpen={true}
-      onClose={onClose}
-      kurtosisPackage={kurtosisPackage}
-      existingValues={{
-        enclaveName: enclave.name,
-        restartServices: enclave.mode === EnclaveMode.PRODUCTION,
-        args: formReadyArgs,
-      }}
-    />
   );
 };

--- a/enclave-manager/web/src/components/enclaves/EditEnclaveButton.tsx
+++ b/enclave-manager/web/src/components/enclaves/EditEnclaveButton.tsx
@@ -1,0 +1,119 @@
+import { Button, Tooltip } from "@chakra-ui/react";
+import { EnclaveMode } from "enclave-manager-sdk/build/engine_service_pb";
+import { useState } from "react";
+import { FiEdit2 } from "react-icons/fi";
+import { ArgumentValueType, KurtosisPackage } from "../../client/packageIndexer/api/kurtosis_package_indexer_pb";
+import { EnclaveFullInfo } from "../../emui/enclaves/types";
+import { assertDefined, isDefined } from "../../utils";
+import { ConfigureEnclaveModal } from "./modals/ConfigureEnclaveModal";
+import { PackageLoadingModal } from "./modals/PackageLoadingModal";
+
+type EditEnclaveButtonProps = {
+  enclave: EnclaveFullInfo;
+};
+
+export const EditEnclaveButton = ({ enclave }: EditEnclaveButtonProps) => {
+  const [showPackageLoader, setShowPackageLoader] = useState(false);
+  const [kurtosisPackage, setKurtosisPackage] = useState<KurtosisPackage>();
+
+  const handlePackageLoaded = (kurtosisPackage: KurtosisPackage) => {
+    setShowPackageLoader(false);
+    setKurtosisPackage(kurtosisPackage);
+  };
+
+  if (enclave.starlarkRun.isErr) {
+    return (
+      <Tooltip label={"Cannot find previous run config to edit"}>
+        <Button disabled={true} colorScheme={"blue"} leftIcon={<FiEdit2 />} size={"md"}>
+          Edit
+        </Button>
+      </Tooltip>
+    );
+  }
+
+  return (
+    <>
+      <Button onClick={() => setShowPackageLoader(true)} colorScheme={"blue"} leftIcon={<FiEdit2 />} size={"md"}>
+        Edit
+      </Button>
+      {showPackageLoader && (
+        <PackageLoadingModal packageId={enclave.starlarkRun.value.packageId} onPackageLoaded={handlePackageLoaded} />
+      )}
+      {isDefined(kurtosisPackage) && (
+        <EditEnclaveModal
+          enclave={enclave}
+          kurtosisPackage={kurtosisPackage}
+          onClose={() => setKurtosisPackage(undefined)}
+        />
+      )}
+    </>
+  );
+};
+
+type EditEnclaveModalProps = {
+  enclave: EnclaveFullInfo;
+  kurtosisPackage: KurtosisPackage;
+  onClose: () => void;
+};
+
+const EditEnclaveModal = ({ enclave, kurtosisPackage, onClose }: EditEnclaveModalProps) => {
+  if (enclave.starlarkRun.isErr) {
+    throw Error("Internal EditEnclaveModal passed enclave with error starlark run. This should not happen.");
+  }
+
+  const parsedArgs = JSON.parse(enclave.starlarkRun.value.serializedParams);
+  const convertArgValue = (
+    argType: ArgumentValueType | undefined,
+    value: any,
+    innerType1?: ArgumentValueType,
+    innerType2?: ArgumentValueType,
+  ): any => {
+    switch (argType) {
+      case ArgumentValueType.BOOL:
+        return !!value ? "true" : "false";
+      case ArgumentValueType.INTEGER:
+        return isDefined(value) ? `${value}` : "";
+      case ArgumentValueType.STRING:
+        return value || "";
+      case ArgumentValueType.JSON:
+        return isDefined(value) ? JSON.stringify(value) : "{}";
+      case ArgumentValueType.LIST:
+        assertDefined(innerType1, `Cannot parse a list argument type without knowing innerType1`);
+        return isDefined(value) ? value.map((v: any) => convertArgValue(innerType1, v)) : [];
+      case ArgumentValueType.DICT:
+        assertDefined(innerType2, `Cannot parse a dict argument type without knowing innterType2`);
+        return isDefined(value)
+          ? Object.entries(value).map(([k, v]) => ({ key: k, value: convertArgValue(innerType2, v) }), {})
+          : {};
+      default:
+        return value;
+    }
+  };
+
+  const formReadyArgs = kurtosisPackage.args.reduce(
+    (acc, arg) => ({
+      ...acc,
+      [arg.name]: convertArgValue(
+        arg.typeV2?.topLevelType,
+        parsedArgs[arg.name],
+        arg.typeV2?.innerType1,
+        arg.typeV2?.innerType2,
+      ),
+    }),
+    {},
+  );
+  console.log(formReadyArgs);
+
+  return (
+    <ConfigureEnclaveModal
+      isOpen={true}
+      onClose={onClose}
+      kurtosisPackage={kurtosisPackage}
+      existingValues={{
+        enclaveName: enclave.name,
+        restartServices: enclave.mode === EnclaveMode.PRODUCTION,
+        args: formReadyArgs,
+      }}
+    />
+  );
+};

--- a/enclave-manager/web/src/components/enclaves/PreloadEnclave.tsx
+++ b/enclave-manager/web/src/components/enclaves/PreloadEnclave.tsx
@@ -1,86 +1,18 @@
-import {
-  Button,
-  Flex,
-  Modal,
-  ModalBody,
-  ModalCloseButton,
-  ModalContent,
-  ModalFooter,
-  ModalHeader,
-  ModalOverlay,
-  Spinner,
-  Text,
-} from "@chakra-ui/react";
-import { useEffect, useState } from "react";
 import { KurtosisPackage } from "../../client/packageIndexer/api/kurtosis_package_indexer_pb";
-import { useKurtosisPackageIndexerClient } from "../../client/packageIndexer/KurtosisPackageIndexerClientContext";
 import { isDefined } from "../../utils";
-import { KurtosisAlert } from "../KurtosisAlert";
+import { PackageLoadingModal } from "./modals/PackageLoadingModal";
 
 type PreloadEnclaveProps = {
   onPackageLoaded: (kurtosisPackage: KurtosisPackage) => void;
 };
 
 export const PreloadEnclave = ({ onPackageLoaded }: PreloadEnclaveProps) => {
-  const kurtosisIndexer = useKurtosisPackageIndexerClient();
-  const [modalOpen, setModalOpen] = useState(false);
-  const [isPreloading, setIsPreloading] = useState(false);
-  const [preloadError, setPreloadError] = useState<string>();
-
   const searchParams = new URLSearchParams(window.location.search);
   const preloadPackage = searchParams.get("preloadPackage");
-
-  useEffect(() => {
-    (async () => {
-      if (isDefined(preloadPackage)) {
-        setModalOpen(true);
-        setIsPreloading(true);
-        setPreloadError(undefined);
-        const readPackageResponse = await kurtosisIndexer.readPackage(preloadPackage);
-        setIsPreloading(false);
-
-        if (readPackageResponse.isErr) {
-          setPreloadError(readPackageResponse.error);
-          return;
-        }
-        if (!isDefined(readPackageResponse.value.package)) {
-          setPreloadError(`Could not find package ${preloadPackage}`);
-          return;
-        }
-
-        setModalOpen(false);
-        onPackageLoaded(readPackageResponse.value.package);
-      }
-    })();
-  }, [preloadPackage, onPackageLoaded]);
 
   if (!isDefined(preloadPackage)) {
     return null;
   }
 
-  return (
-    <Modal isOpen={modalOpen} onClose={() => !isPreloading && setModalOpen(false)} isCentered>
-      <ModalOverlay />
-      <ModalContent>
-        <ModalHeader>Loading</ModalHeader>
-        <ModalCloseButton />
-        <ModalBody>
-          {isPreloading && (
-            <Flex flexDirection={"column"} alignItems={"center"} gap={"32px"}>
-              <Spinner size={"xl"} />
-              <Text>Fetching {preloadPackage}</Text>
-            </Flex>
-          )}
-          {isDefined(preloadError) && <KurtosisAlert message={preloadError} />}
-        </ModalBody>
-        <ModalFooter>
-          <Flex justifyContent={"flex-end"} gap={"12px"}>
-            <Button color={"gray.100"} onClick={() => setModalOpen(false)} disabled={isPreloading}>
-              Close
-            </Button>
-          </Flex>
-        </ModalFooter>
-      </ModalContent>
-    </Modal>
-  );
+  return <PackageLoadingModal packageId={preloadPackage} onPackageLoaded={onPackageLoaded} />;
 };

--- a/enclave-manager/web/src/components/enclaves/modals/ConfigureEnclaveModal.tsx
+++ b/enclave-manager/web/src/components/enclaves/modals/ConfigureEnclaveModal.tsx
@@ -13,12 +13,14 @@ import {
   Text,
   Tooltip,
 } from "@chakra-ui/react";
+import { EnclaveMode } from "enclave-manager-sdk/build/engine_service_pb";
 import { useMemo, useRef, useState } from "react";
 import { SubmitHandler } from "react-hook-form";
 import { useNavigate, useSubmit } from "react-router-dom";
 import { useKurtosisClient } from "../../../client/enclaveManager/KurtosisClientContext";
-import { KurtosisPackage } from "../../../client/packageIndexer/api/kurtosis_package_indexer_pb";
-import { isDefined } from "../../../utils";
+import { ArgumentValueType, KurtosisPackage } from "../../../client/packageIndexer/api/kurtosis_package_indexer_pb";
+import { EnclaveFullInfo } from "../../../emui/enclaves/types";
+import { assertDefined, isDefined, stringifyError } from "../../../utils";
 import { CopyButton } from "../../CopyButton";
 import { KurtosisAlert } from "../../KurtosisAlert";
 import {
@@ -36,14 +38,14 @@ type ConfigureEnclaveModalProps = {
   isOpen: boolean;
   onClose: () => void;
   kurtosisPackage: KurtosisPackage;
-  existingValues?: ConfigureEnclaveForm;
+  existingEnclave?: EnclaveFullInfo;
 };
 
 export const ConfigureEnclaveModal = ({
   isOpen,
   onClose,
   kurtosisPackage,
-  existingValues,
+  existingEnclave,
 }: ConfigureEnclaveModalProps) => {
   const kurtosisClient = useKurtosisClient();
   const navigator = useNavigate();
@@ -53,8 +55,64 @@ export const ConfigureEnclaveModal = ({
   const formRef = useRef<EnclaveConfigurationFormImperativeAttributes>(null);
 
   const initialValues = useMemo(() => {
-    if (isDefined(existingValues)) {
-      return existingValues;
+    if (isDefined(existingEnclave)) {
+      if (existingEnclave.starlarkRun.isErr) {
+        setError(
+          `Could not retrieve starlark run for previous configuration, got error: ${existingEnclave.starlarkRun.isErr}`,
+        );
+        return undefined;
+      }
+      try {
+        const parsedArgs = JSON.parse(existingEnclave.starlarkRun.value.serializedParams);
+        const convertArgValue = (
+          argType: ArgumentValueType | undefined,
+          value: any,
+          innerType1?: ArgumentValueType,
+          innerType2?: ArgumentValueType,
+        ): any => {
+          switch (argType) {
+            case ArgumentValueType.BOOL:
+              return !!value ? "true" : "false";
+            case ArgumentValueType.INTEGER:
+              return isDefined(value) ? `${value}` : "";
+            case ArgumentValueType.STRING:
+              return value || "";
+            case ArgumentValueType.JSON:
+              return isDefined(value) ? JSON.stringify(value) : "{}";
+            case ArgumentValueType.LIST:
+              assertDefined(innerType1, `Cannot parse a list argument type without knowing innerType1`);
+              return isDefined(value) ? value.map((v: any) => convertArgValue(innerType1, v)) : [];
+            case ArgumentValueType.DICT:
+              assertDefined(innerType2, `Cannot parse a dict argument type without knowing innterType2`);
+              return isDefined(value)
+                ? Object.entries(value).map(([k, v]) => ({ key: k, value: convertArgValue(innerType2, v) }), {})
+                : {};
+            default:
+              return value;
+          }
+        };
+
+        const args = kurtosisPackage.args.reduce(
+          (acc, arg) => ({
+            ...acc,
+            [arg.name]: convertArgValue(
+              arg.typeV2?.topLevelType,
+              parsedArgs[arg.name],
+              arg.typeV2?.innerType1,
+              arg.typeV2?.innerType2,
+            ),
+          }),
+          {},
+        );
+        return {
+          enclaveName: existingEnclave.name,
+          restartServices: existingEnclave.mode === EnclaveMode.PRODUCTION,
+          args,
+        } as ConfigureEnclaveForm;
+      } catch (err: any) {
+        setError(`Could not reuse previous configuration, got error: ${stringifyError(err)}`);
+        return undefined;
+      }
     }
     const searchParams = new URLSearchParams(window.location.search);
     const preloadArgs = searchParams.get("preloadArgs");
@@ -62,7 +120,7 @@ export const ConfigureEnclaveModal = ({
       return undefined;
     }
     return JSON.parse(atob(preloadArgs)) as ConfigureEnclaveForm;
-  }, [window.location.search, existingValues]);
+  }, [window.location.search, existingEnclave]);
 
   // TODO: Improve for cloud config
   const getLinkToCurrentConfig = () =>
@@ -78,27 +136,40 @@ export const ConfigureEnclaveModal = ({
   };
 
   const handleLoadSubmit: SubmitHandler<ConfigureEnclaveForm> = async (formData) => {
-    setIsLoading(true);
     setError(undefined);
-    const newEnclave = await kurtosisClient.createEnclave(formData.enclaveName, "info", formData.restartServices);
-    setIsLoading(false);
 
-    if (newEnclave.isErr) {
-      setError(`Could not create enclave, got: ${newEnclave.error}`);
-      return;
+    let apicInfo = existingEnclave?.apiContainerInfo;
+    let enclaveUUID = existingEnclave?.shortenedUuid;
+    if (!isDefined(existingEnclave)) {
+      setIsLoading(true);
+      const newEnclave = await kurtosisClient.createEnclave(formData.enclaveName, "info", formData.restartServices);
+      setIsLoading(false);
+
+      if (newEnclave.isErr) {
+        setError(`Could not create enclave, got: ${newEnclave.error}`);
+        return;
+      }
+      if (!isDefined(newEnclave.value.enclaveInfo)) {
+        setError(`Did not receive enclave info when running createEnclave`);
+        return;
+      }
+      apicInfo = newEnclave.value.enclaveInfo.apiContainerInfo;
+      enclaveUUID = newEnclave.value.enclaveInfo.shortenedUuid;
     }
-    if (!isDefined(newEnclave.value.enclaveInfo)) {
-      setError(`Did not receive enclave info when running createEnclave`);
+
+    if (!isDefined(apicInfo)) {
+      setError(`Cannot trigger starlark run as apic info cannot be found`);
       return;
     }
     submit(
-      { config: formData, packageId: kurtosisPackage.name, enclave: newEnclave.value.enclaveInfo.toJson() },
+      { config: formData, packageId: kurtosisPackage.name, apicInfo: apicInfo.toJson() },
       {
         method: "post",
-        action: `/enclave/${newEnclave.value.enclaveInfo.shortenedUuid}`,
+        action: `/enclave/${enclaveUUID}`,
         encType: "application/json",
       },
     );
+    onClose();
   };
 
   return (
@@ -119,8 +190,8 @@ export const ConfigureEnclaveModal = ({
               <EnclaveSourceButton source={kurtosisPackage.name} size={"sm"} variant={"outline"} color={"gray.100"} />
               <Text>to</Text>
               <Input size={"sm"} placeholder={"an unamed environment"} width={"auto"} />
-              {isDefined(error) && <KurtosisAlert message={error} />}
             </Flex>
+            {isDefined(error) && <KurtosisAlert message={error} />}
             <Flex flexDirection={"column"} gap={"24px"} p={"12px 24px"} bg={"gray.900"}>
               <Flex justifyContent={"space-between"} alignItems={"center"}>
                 <FormControl display={"flex"} alignItems={"center"} gap={"16px"}>

--- a/enclave-manager/web/src/components/enclaves/modals/ConfigureEnclaveModal.tsx
+++ b/enclave-manager/web/src/components/enclaves/modals/ConfigureEnclaveModal.tsx
@@ -36,9 +36,15 @@ type ConfigureEnclaveModalProps = {
   isOpen: boolean;
   onClose: () => void;
   kurtosisPackage: KurtosisPackage;
+  existingValues?: ConfigureEnclaveForm;
 };
 
-export const ConfigureEnclaveModal = ({ isOpen, onClose, kurtosisPackage }: ConfigureEnclaveModalProps) => {
+export const ConfigureEnclaveModal = ({
+  isOpen,
+  onClose,
+  kurtosisPackage,
+  existingValues,
+}: ConfigureEnclaveModalProps) => {
   const kurtosisClient = useKurtosisClient();
   const navigator = useNavigate();
   const submit = useSubmit();
@@ -47,13 +53,16 @@ export const ConfigureEnclaveModal = ({ isOpen, onClose, kurtosisPackage }: Conf
   const formRef = useRef<EnclaveConfigurationFormImperativeAttributes>(null);
 
   const initialValues = useMemo(() => {
+    if (isDefined(existingValues)) {
+      return existingValues;
+    }
     const searchParams = new URLSearchParams(window.location.search);
     const preloadArgs = searchParams.get("preloadArgs");
     if (!isDefined(preloadArgs)) {
       return undefined;
     }
     return JSON.parse(atob(preloadArgs)) as ConfigureEnclaveForm;
-  }, [window.location.search]);
+  }, [window.location.search, existingValues]);
 
   // TODO: Improve for cloud config
   const getLinkToCurrentConfig = () =>

--- a/enclave-manager/web/src/components/enclaves/modals/PackageLoadingModal.tsx
+++ b/enclave-manager/web/src/components/enclaves/modals/PackageLoadingModal.tsx
@@ -1,0 +1,78 @@
+import {
+  Button,
+  Flex,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Spinner,
+  Text,
+} from "@chakra-ui/react";
+import { useEffect, useState } from "react";
+import { KurtosisPackage } from "../../../client/packageIndexer/api/kurtosis_package_indexer_pb";
+import { useKurtosisPackageIndexerClient } from "../../../client/packageIndexer/KurtosisPackageIndexerClientContext";
+import { isDefined } from "../../../utils";
+import { KurtosisAlert } from "../../KurtosisAlert";
+
+export type PackageLoadingModalProps = {
+  packageId: string;
+  onPackageLoaded: (kurtosisPackage: KurtosisPackage) => void;
+};
+
+export const PackageLoadingModal = ({ packageId, onPackageLoaded }: PackageLoadingModalProps) => {
+  const kurtosisIndexer = useKurtosisPackageIndexerClient();
+  const [modalOpen, setModalOpen] = useState(false);
+  const [isPreloading, setIsPreloading] = useState(false);
+  const [loadError, setLoadError] = useState<string>();
+
+  useEffect(() => {
+    (async () => {
+      setModalOpen(true);
+      setIsPreloading(true);
+      setLoadError(undefined);
+      const readPackageResponse = await kurtosisIndexer.readPackage(packageId);
+      setIsPreloading(false);
+
+      if (readPackageResponse.isErr) {
+        setLoadError(readPackageResponse.error);
+        return;
+      }
+      if (!isDefined(readPackageResponse.value.package)) {
+        setLoadError(`Could not find package ${packageId}`);
+        return;
+      }
+
+      setModalOpen(false);
+      onPackageLoaded(readPackageResponse.value.package);
+    })();
+  }, [packageId, onPackageLoaded]);
+
+  return (
+    <Modal isOpen={modalOpen} onClose={() => !isPreloading && setModalOpen(false)} isCentered>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>Loading</ModalHeader>
+        <ModalCloseButton />
+        <ModalBody>
+          {isPreloading && (
+            <Flex flexDirection={"column"} alignItems={"center"} gap={"32px"}>
+              <Spinner size={"xl"} />
+              <Text>Fetching {packageId}</Text>
+            </Flex>
+          )}
+          {isDefined(loadError) && <KurtosisAlert message={loadError} />}
+        </ModalBody>
+        <ModalFooter>
+          <Flex justifyContent={"flex-end"} gap={"12px"}>
+            <Button color={"gray.100"} onClick={() => setModalOpen(false)} disabled={isPreloading}>
+              Close
+            </Button>
+          </Flex>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+};

--- a/enclave-manager/web/src/components/enclaves/widgets/EnclaveServicesSummary.tsx
+++ b/enclave-manager/web/src/components/enclaves/widgets/EnclaveServicesSummary.tsx
@@ -1,4 +1,4 @@
-import { Button, ButtonGroup, Tag, Text, Tooltip } from "@chakra-ui/react";
+import { Button, ButtonGroup, Tag, Tooltip } from "@chakra-ui/react";
 import { ServiceInfo, ServiceStatus } from "enclave-manager-sdk/build/api_container_service_pb";
 import { isDefined } from "../../../utils";
 
@@ -15,13 +15,7 @@ export const EnclaveServicesSummary = ({ services }: ServicesSummaryProps) => {
   const stopppedServices = services.filter(({ serviceStatus }) => serviceStatus === ServiceStatus.STOPPED).length;
   const unknownServices = services.filter(({ serviceStatus }) => serviceStatus === ServiceStatus.UNKNOWN).length;
 
-  if (runningServices + stopppedServices + unknownServices === 0) {
-    return (
-      <Text fontSize={"xs"} as={"i"}>
-        No Services
-      </Text>
-    );
-  }
+  const totalServices = runningServices + stopppedServices + unknownServices;
 
   const tooltipLabel = [
     runningServices > 0 ? `${runningServices} running` : null,
@@ -33,7 +27,8 @@ export const EnclaveServicesSummary = ({ services }: ServicesSummaryProps) => {
 
   return (
     <Tooltip label={tooltipLabel} size={"xs"}>
-      <ButtonGroup size={"xs"} variant={"solid"}>
+      <ButtonGroup size={"xs"} isAttached variant={"solid"}>
+        {totalServices === 0 && <Button color={"#A0AEC0"}>NONE</Button>}
         {runningServices > 0 && <Button colorScheme={"green"}>{runningServices}</Button>}
         {stopppedServices > 0 && <Button colorScheme={"red"}>{stopppedServices}</Button>}
         {unknownServices > 0 && <Button colorScheme={"orange"}>{unknownServices}</Button>}

--- a/enclave-manager/web/src/emui/enclaves/enclave/Enclave.tsx
+++ b/enclave-manager/web/src/emui/enclaves/enclave/Enclave.tsx
@@ -1,9 +1,9 @@
-import { Button, Flex, Spinner, Tab, TabList, TabPanel, TabPanels, Tabs } from "@chakra-ui/react";
-import { FiEdit2 } from "react-icons/fi";
+import { Flex, Spinner, Tab, TabList, TabPanel, TabPanels, Tabs } from "@chakra-ui/react";
 import { Await, useActionData, useParams, useRouteLoaderData } from "react-router-dom";
 import { EnclaveOverview } from "../../../components/enclaves/EnclaveOverview";
 
 import { Suspense, useEffect } from "react";
+import { EditEnclaveButton } from "../../../components/enclaves/EditEnclaveButton";
 import { DeleteEnclavesButton } from "../../../components/enclaves/widgets/DeleteEnclavesButton";
 import { KurtosisAlert } from "../../../components/KurtosisAlert";
 import { isDefined } from "../../../utils";
@@ -73,9 +73,7 @@ const EnclaveImpl = ({ enclave }: EnclaveImpl) => {
             </TabList>
             <Flex gap={"8px"} alignItems={"center"}>
               <DeleteEnclavesButton enclaves={[enclave]} />
-              <Button colorScheme={"blue"} leftIcon={<FiEdit2 />} size={"md"}>
-                Edit
-              </Button>
+              <EditEnclaveButton enclave={enclave} />
             </Flex>
           </Flex>
         </TabList>

--- a/enclave-manager/web/src/emui/enclaves/enclave/action.ts
+++ b/enclave-manager/web/src/emui/enclaves/enclave/action.ts
@@ -1,5 +1,5 @@
 import { StarlarkRunResponseLine } from "enclave-manager-sdk/build/api_container_service_pb";
-import { EnclaveInfo } from "enclave-manager-sdk/build/engine_service_pb";
+import { EnclaveAPIContainerInfo } from "enclave-manager-sdk/build/engine_service_pb";
 import { ActionFunction, ActionFunctionArgs } from "react-router-dom";
 import { KurtosisClient } from "../../../client/enclaveManager/KurtosisClient";
 import { ConfigureEnclaveForm } from "../../../components/enclaves/configuration/types";
@@ -9,13 +9,13 @@ const handleEnclaveAction = async (
   kurtosisClient: KurtosisClient,
   { params, request }: ActionFunctionArgs,
 ): Promise<{ logs: AsyncIterable<StarlarkRunResponseLine> }> => {
-  const { config, enclave, packageId } = (await request.json()) as {
+  const { config, apicInfo, packageId } = (await request.json()) as {
     config: ConfigureEnclaveForm;
     packageId: string;
-    enclave: RemoveFunctions<EnclaveInfo>;
+    apicInfo: RemoveFunctions<EnclaveAPIContainerInfo>;
   };
 
-  const logs = await kurtosisClient.runStarlarkPackage(enclave, packageId, config.args);
+  const logs = await kurtosisClient.runStarlarkPackage(apicInfo, packageId, config.args);
   return { logs };
 };
 


### PR DESCRIPTION
## Description:
This PR adds support for editing existing enclaves in the new enclave manager ui.

The `PreloadEnclave` component is refactored to a more generic `PackageLoadingModal`, which is used to obtain kurtosis package definitions.

The configure enclave form can now optionally take an existing enclave and rehydrate based on the configuration from the last starlark run.

### Demo

https://github.com/kurtosis-tech/kurtosis/assets/4419574/c3ede6e4-c809-4242-8176-47d2fe5e8a65

## Is this change user facing?
NO (this change is not live anywhere yet)

## References (if applicable):

