### PR TITLE
build: build the right architecture locally

### DIFF
--- a/core/files_artifacts_expander/scripts/build.sh
+++ b/core/files_artifacts_expander/scripts/build.sh
@@ -15,7 +15,7 @@ source "${script_dirpath}/_constants.env"
 BUILD_DIRNAME="build"
 
 DEFAULT_SKIP_DOCKER_IMAGE_BUILDING=false
-DEFAULT_ARCHITECTURE_TO_BUILD=amd64
+DEFAULT_ARCHITECTURE_TO_BUILD="$(arch)"
 
 MAIN_GO_FILEPATH="${expander_root_dirpath}/main.go"
 MAIN_BINARY_OUTPUT_FILENAME="files-artifacts-expander"

--- a/core/files_artifacts_expander/scripts/build.sh
+++ b/core/files_artifacts_expander/scripts/build.sh
@@ -17,16 +17,12 @@ BUILD_DIRNAME="build"
 
 DEFAULT_SKIP_DOCKER_IMAGE_BUILDING=false
 
-# Set the default architecture to unknown
 DEFAULT_ARCHITECTURE_TO_BUILD="unknown"
 
-# Check if the architecture is amd64 or x86_64
 if [ "$uname_arch" == "x86_64" ] || [ "$uname_arch" == "amd64" ]; then
     DEFAULT_ARCHITECTURE_TO_BUILD="amd64"
-# Check if the architecture is arm64
 elif [ "$uname_arch" == "aarch64" ] || [ "$uname_arch" == "arm64" ]; then
     DEFAULT_ARCHITECTURE_TO_BUILD="arm64"
-# Add more conditions for other architectures if needed
 fi
 
 MAIN_GO_FILEPATH="${expander_root_dirpath}/main.go"

--- a/core/files_artifacts_expander/scripts/build.sh
+++ b/core/files_artifacts_expander/scripts/build.sh
@@ -7,6 +7,7 @@ set -euo pipefail   # Bash "strict mode"
 script_dirpath="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 expander_root_dirpath="$(dirname "${script_dirpath}")"
 git_repo_dirpath="$(dirname "$(dirname "${expander_root_dirpath}")")"
+uname_arch=$(uname -m)
 # ==================================================================================================
 #                                             Constants
 # ==================================================================================================
@@ -15,7 +16,18 @@ source "${script_dirpath}/_constants.env"
 BUILD_DIRNAME="build"
 
 DEFAULT_SKIP_DOCKER_IMAGE_BUILDING=false
-DEFAULT_ARCHITECTURE_TO_BUILD="$(arch)"
+
+# Set the default architecture to unknown
+DEFAULT_ARCHITECTURE_TO_BUILD="unknown"
+
+# Check if the architecture is amd64 or x86_64
+if [ "$uname_arch" == "x86_64" ] || [ "$uname_arch" == "amd64" ]; then
+    DEFAULT_ARCHITECTURE_TO_BUILD="amd64"
+# Check if the architecture is arm64
+elif [ "$uname_arch" == "aarch64" ] || [ "$uname_arch" == "arm64" ]; then
+    DEFAULT_ARCHITECTURE_TO_BUILD="arm64"
+# Add more conditions for other architectures if needed
+fi
 
 MAIN_GO_FILEPATH="${expander_root_dirpath}/main.go"
 MAIN_BINARY_OUTPUT_FILENAME="files-artifacts-expander"

--- a/core/server/scripts/build.sh
+++ b/core/server/scripts/build.sh
@@ -13,7 +13,7 @@ source "${script_dirpath}/_constants.env"
 BUILD_DIRNAME="build"
 
 DEFAULT_SKIP_DOCKER_IMAGE_BUILDING=false
-DEFAULT_ARCHITECTURE_TO_BUILD=amd64
+DEFAULT_ARCHITECTURE_TO_BUILD="$(arch)"
 
 MAIN_DIRNAME="api_container"
 MAIN_GO_FILEPATH="${server_root_dirpath}/${MAIN_DIRNAME}/main.go"

--- a/core/server/scripts/build.sh
+++ b/core/server/scripts/build.sh
@@ -5,6 +5,7 @@ set -euo pipefail   # Bash "strict mode"
 script_dirpath="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 server_root_dirpath="$(dirname "${script_dirpath}")"
 git_repo_dirpath="$(dirname "$(dirname "${server_root_dirpath}")")"
+uname_arch=$(uname -m)
 # ==================================================================================================
 #                                             Constants
 # ==================================================================================================
@@ -13,7 +14,18 @@ source "${script_dirpath}/_constants.env"
 BUILD_DIRNAME="build"
 
 DEFAULT_SKIP_DOCKER_IMAGE_BUILDING=false
-DEFAULT_ARCHITECTURE_TO_BUILD="$(arch)"
+
+# Set the default architecture to unknown
+DEFAULT_ARCHITECTURE_TO_BUILD="unknown"
+
+# Check if the architecture is amd64 or x86_64
+if [ "$uname_arch" == "x86_64" ] || [ "$uname_arch" == "amd64" ]; then
+    DEFAULT_ARCHITECTURE_TO_BUILD="amd64"
+# Check if the architecture is arm64
+elif [ "$uname_arch" == "aarch64" ] || [ "$uname_arch" == "arm64" ]; then
+    DEFAULT_ARCHITECTURE_TO_BUILD="arm64"
+# Add more conditions for other architectures if needed
+fi
 
 MAIN_DIRNAME="api_container"
 MAIN_GO_FILEPATH="${server_root_dirpath}/${MAIN_DIRNAME}/main.go"

--- a/core/server/scripts/build.sh
+++ b/core/server/scripts/build.sh
@@ -15,16 +15,12 @@ BUILD_DIRNAME="build"
 
 DEFAULT_SKIP_DOCKER_IMAGE_BUILDING=false
 
-# Set the default architecture to unknown
 DEFAULT_ARCHITECTURE_TO_BUILD="unknown"
 
-# Check if the architecture is amd64 or x86_64
 if [ "$uname_arch" == "x86_64" ] || [ "$uname_arch" == "amd64" ]; then
     DEFAULT_ARCHITECTURE_TO_BUILD="amd64"
-# Check if the architecture is arm64
 elif [ "$uname_arch" == "aarch64" ] || [ "$uname_arch" == "arm64" ]; then
     DEFAULT_ARCHITECTURE_TO_BUILD="arm64"
-# Add more conditions for other architectures if needed
 fi
 
 MAIN_DIRNAME="api_container"

--- a/engine/server/scripts/build.sh
+++ b/engine/server/scripts/build.sh
@@ -5,7 +5,7 @@ set -euo pipefail # Bash "strict mode"
 script_dirpath="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 engine_root_dirpath="$(dirname "${script_dirpath}")"
 git_repo_dirpath="$(dirname "$(dirname "${engine_root_dirpath}")")"
-
+uname_arch=$(uname -m)
 # ==================================================================================================
 #                                             Constants
 # ==================================================================================================
@@ -14,7 +14,18 @@ source "${script_dirpath}/_constants.env"
 BUILD_DIRNAME="build"
 
 DEFAULT_SKIP_DOCKER_IMAGE_BUILDING=false
-DEFAULT_ARCHITECTURE_TO_BUILD="$(arch)"
+
+# Set the default architecture to unknown
+DEFAULT_ARCHITECTURE_TO_BUILD="unknown"
+
+# Check if the architecture is amd64 or x86_64
+if [ "$uname_arch" == "x86_64" ] || [ "$uname_arch" == "amd64" ]; then
+    DEFAULT_ARCHITECTURE_TO_BUILD="amd64"
+# Check if the architecture is arm64
+elif [ "$uname_arch" == "aarch64" ] || [ "$uname_arch" == "arm64" ]; then
+    DEFAULT_ARCHITECTURE_TO_BUILD="arm64"
+# Add more conditions for other architectures if needed
+fi
 
 MAIN_DIRNAME="engine"
 MAIN_GO_FILEPATH="${engine_root_dirpath}/${MAIN_DIRNAME}/main.go"

--- a/engine/server/scripts/build.sh
+++ b/engine/server/scripts/build.sh
@@ -15,16 +15,12 @@ BUILD_DIRNAME="build"
 
 DEFAULT_SKIP_DOCKER_IMAGE_BUILDING=false
 
-# Set the default architecture to unknown
 DEFAULT_ARCHITECTURE_TO_BUILD="unknown"
 
-# Check if the architecture is amd64 or x86_64
 if [ "$uname_arch" == "x86_64" ] || [ "$uname_arch" == "amd64" ]; then
     DEFAULT_ARCHITECTURE_TO_BUILD="amd64"
-# Check if the architecture is arm64
 elif [ "$uname_arch" == "aarch64" ] || [ "$uname_arch" == "arm64" ]; then
     DEFAULT_ARCHITECTURE_TO_BUILD="arm64"
-# Add more conditions for other architectures if needed
 fi
 
 MAIN_DIRNAME="engine"

--- a/engine/server/scripts/build.sh
+++ b/engine/server/scripts/build.sh
@@ -14,7 +14,7 @@ source "${script_dirpath}/_constants.env"
 BUILD_DIRNAME="build"
 
 DEFAULT_SKIP_DOCKER_IMAGE_BUILDING=false
-DEFAULT_ARCHITECTURE_TO_BUILD=amd64
+DEFAULT_ARCHITECTURE_TO_BUILD="$(arch)"
 
 MAIN_DIRNAME="engine"
 MAIN_GO_FILEPATH="${engine_root_dirpath}/${MAIN_DIRNAME}/main.go"

--- a/scripts/docker-image-builder.sh
+++ b/scripts/docker-image-builder.sh
@@ -36,7 +36,6 @@ if [ -z "${image_tags}" ]; then
     show_helptext_and_exit
 fi
 
-# Get the system architecture using uname
 uname_arch=$(uname -m)
 
 architecture="amd64"

--- a/scripts/docker-image-builder.sh
+++ b/scripts/docker-image-builder.sh
@@ -41,7 +41,8 @@ if "${push_to_registry_container}"; then
   buildx_platform_arg='linux/arm64/v8,linux/amd64'
   push_flag='--push'
 else
-  buildx_platform_arg='linux/amd64' # TODO: infer the local arch if that's reasonable
+  architecture="$(arch)"
+  buildx_platform_arg="linux/${architecture}"
   push_flag='--load'
 fi
 echo "Building docker image for architecture '${buildx_platform_arg}' with flag '${push_flag}'"

--- a/scripts/docker-image-builder.sh
+++ b/scripts/docker-image-builder.sh
@@ -36,12 +36,22 @@ if [ -z "${image_tags}" ]; then
     show_helptext_and_exit
 fi
 
+# Get the system architecture using uname
+uname_arch=$(uname -m)
+
+architecture="amd64"
+
+if [ "$uname_arch" == "x86_64" ] || [ "$uname_arch" == "amd64" ]; then
+    architecture="amd64"
+elif [ "$uname_arch" == "aarch64" ] || [ "$uname_arch" == "arm64" ]; then
+    architecture="arm64"
+fi
+
 # Argument processing
 if "${push_to_registry_container}"; then
   buildx_platform_arg='linux/arm64/v8,linux/amd64'
   push_flag='--push'
 else
-  architecture="$(arch)"
   buildx_platform_arg="linux/${architecture}"
   push_flag='--load'
 fi


### PR DESCRIPTION
## Description:
We would build amd64 even on our arm64 M1/M2 machines; this fixes that by building the local architecture by default for images and engine/core/files artifact expander servers

## Is this change user facing?
NO
