### PR TITLE
ci: allow pull requests labelled with request-cf-deploy to deploy GitHub pages

### DIFF
--- a/.github/workflows/push-docs.yml
+++ b/.github/workflows/push-docs.yml
@@ -3,6 +3,12 @@ name: Deploy documentation
 on:
   push:
   merge_group:
+  pull_request_target:
+    # this is for forked pull requests - we can't pass down secrets; this allows us to pass down secrets
+    # to build the cloudflare pages action
+    types:
+      - opened
+      - labeled
 
 jobs:
   publish:
@@ -11,6 +17,14 @@ jobs:
       contents: read
       deployments: write
     name: Publish to Cloudflare Pages
+    if: ${{
+      github.event_name == 'push' ||
+      github.event_name == 'merge_group' ||
+      (github.event_name == 'pull_request_target' &&
+      github.event.action == 'labeled' &&
+      github.event.pull_request.head.repo.fork == true &&
+      contains(github.event.label.name, 'request-cf-deploy'))
+      }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
## Description:
Earlier pull requests created via forks would get blocked as the pages action wouldn't run. This is a work around for it following - https://github.com/cloudflare/pages-action/issues/94