### PR TITLE
ci: limit index and index check on pr target label workflows

### DIFF
--- a/.github/workflows/push-docs.yml
+++ b/.github/workflows/push-docs.yml
@@ -70,7 +70,10 @@ jobs:
   reindex-website-main:
     runs-on: ubuntu-latest
     name: Update website search index via Algolia Crawler
-    if: github.ref == 'refs/heads/main'
+    if: ${{
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/main'
+      }}
     steps:
       - uses: fjogeleit/http-request-action@v1
         with:
@@ -83,7 +86,10 @@ jobs:
   check-index:
     runs-on: ubuntu-latest
     name: Checks that the latest index is still working
-    if: github.ref == 'refs/heads/main'
+    if: ${{
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/main'
+      }}
     steps:
       - uses: fjogeleit/http-request-action@v1
         id: search


### PR DESCRIPTION
Earlier we would run the indexing/check workflow if we labelled the PR as `request-cf-deploy` - we skip this now and only 
run on push + main;  i.e when a PR gets merged
