### PR TITLE
fix: prefix warning to the image validation

### DIFF
--- a/core/server/api_container/server/startosis_engine/startosis_validator.go
+++ b/core/server/api_container/server/startosis_engine/startosis_validator.go
@@ -28,7 +28,7 @@ const (
 	containerDownloadedImagesMsgFromRemote = "remotely downloaded"
 	containerDownloadedImagesMsgLineFormat = "> %s - %s"
 
-	containerImageArchWarningHeaderFormat   = "Container images with different architecture than expected(%s):"
+	containerImageArchWarningHeaderFormat   = "WARNING: Container images with different architecture than expected(%s):"
 	containerImageArchitectureMsgLineFormat = "> %s - %s"
 
 	linebreak = "\n"


### PR DESCRIPTION
Improved messaging for the warning about image arch being different from expected
