### PR TITLE
docs: update docs discord links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ If you notice an issue in our docs (e.g. typo, grammar, conflicting information)
 ### Questions, help, or feedback
 
 If you have a question around how Kurtosis works and the [docs](https://docs.kurtosis.com) aren't enough, we're more than happy to help and chat about your use case via the following ways:
-- Get help in our [Discord server](https://discord.gg/Es7QHbY4)
+- Get help in our [Discord server](https://discord.gg/6Jjp9c89z9)
 - Email us at [feedback@kurtosistech.com](mailto:feedback@kurtosistech.com)
 - Schedule a 1:1 session with us [here](https://calendly.com/d/zgt-f2c-66p/kurtosis-onboarding)
 

--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ kurtosis enclave add
 [enclave]: https://docs.kurtosis.com/explanations/architecture#enclaves
 [awesome-kurtosis]: https://github.com/kurtosis-tech/awesome-kurtosis#readme
 [quickstart-reference]: https://docs.kurtosis.com/quickstart
-[discord]: https://discord.gg/Es7QHbY4
+[discord]: https://discord.gg/6Jjp9c89z9
 [kurtosis-tech]: https://github.com/kurtosis-tech
 [docs]: https://docs.kurtosis.com
 [twitter]: https://twitter.com/KurtosisTech

--- a/docs/docs/get-started/quickstart-author.md
+++ b/docs/docs/get-started/quickstart-author.md
@@ -32,7 +32,7 @@ Click on the "New Workspace" button! You don't have to worry about the Context U
  
 </details>
 
-If you ever get stuck, every Kurtosis command accepts a `-h` flag to print helptext. If that doesn't help, you can get in touch with us in our [Discord server](https://discord.com/channels/783719264308953108/783719264308953111) or on [Github](https://github.com/kurtosis-tech/kurtosis/issues/new/choose)!
+If you ever get stuck, every Kurtosis command accepts a `-h` flag to print helptext. If that doesn't help, you can get in touch with us in our [Discord server](https://discord.gg/6Jjp9c89z9) or on [Github](https://github.com/kurtosis-tech/kurtosis/issues/new/choose)!
 
 Setup
 -----
@@ -914,7 +914,7 @@ This was still just an introduction to Kurtosis. To dig deeper, visit other sect
 
 Finally, we'd love to hear from you. Please don't hesitate to share with us what went well, and what didn't, using `kurtosis feedback` to file an issue in our [Github](https://github.com/kurtosis-tech/kurtosis/issues/new/choose) or to [chat with our cofounder, Kevin](https://calendly.com/d/zgt-f2c-66p/kurtosis-onboarding).
 
-Lastly, feel free to [star us on Github](https://github.com/kurtosis-tech/kurtosis), [join the community in our Discord](https://discord.com/channels/783719264308953108/783719264308953111), and [follow us on Twitter](https://twitter.com/KurtosisTech)!
+Lastly, feel free to [star us on Github](https://github.com/kurtosis-tech/kurtosis), [join the community in our Discord](https://discord.gg/6Jjp9c89z9), and [follow us on Twitter](https://twitter.com/KurtosisTech)!
 
 <!-- !!!!!!!!!!!!!!!!!!!!!!!!!!! ONLY LINKS BELOW HERE !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
 

--- a/docs/docs/get-started/quickstart.md
+++ b/docs/docs/get-started/quickstart.md
@@ -33,7 +33,7 @@ Click on the "New Workspace" button! You don't have to worry about the Context U
  
 </details>
 
-If you ever get stuck, every Kurtosis command accepts a `-h` flag to print helptext. If that doesn't help, you can get in touch with us in our [Discord server](https://discord.gg/jJFG7XBqcY) or on [Github](https://github.com/kurtosis-tech/kurtosis/issues/new/choose)!
+If you ever get stuck, every Kurtosis command accepts a `-h` flag to print helptext. If that doesn't help, you can get in touch with us in our [Discord server](https://discord.gg/6Jjp9c89z9) or on [Github](https://github.com/kurtosis-tech/kurtosis/issues/new/choose)!
 
 Install dependencies
 --------------------
@@ -185,7 +185,7 @@ To learn more about how Kurtosis is used, we encourage you to check out our [`aw
 
 Finally, we'd love to hear from you. Please don't hesitate to share with us what went well, and what didn't, using `kurtosis feedback` to file an issue in our [Github](https://github.com/kurtosis-tech/kurtosis/issues/new/choose) or to [chat with our cofounder, Kevin](https://calendly.com/d/zgt-f2c-66p/kurtosis-onboarding).
 
-Lastly, feel free to [star us on Github](https://github.com/kurtosis-tech/kurtosis), [join the community in our Discord](https://discord.com/channels/783719264308953108/783719264308953111), and [follow us on Twitter](https://twitter.com/KurtosisTech)!
+Lastly, feel free to [star us on Github](https://github.com/kurtosis-tech/kurtosis), [join the community in our Discord](https://discord.gg/6Jjp9c89z9), and [follow us on Twitter](https://twitter.com/KurtosisTech)!
 
 Thank you for trying our quickstart. We hope you enjoyed it. 
 

--- a/docs/docs/guides/how-to-parameterize-cassandra.md
+++ b/docs/docs/guides/how-to-parameterize-cassandra.md
@@ -368,7 +368,7 @@ And that’s it! To recap this short guide, you:
 2. Added a few lines of code to our `main.star` file to parametrize your environment definition to increase the flexibility and use cases with which it can be used, and,
 3. Executed a remotely-hosted Starlark file that was part of what's called a [Kurtosis Package][packages] to demonstrate how your environment definition can be shared with other developers.
 
-We’d love to hear from you on what went well for you, what could be improved, or to answer any of your questions. Don’t hesitate to reach out via Github (`kurtosis feedback`) or in our [Discord server](https://discord.com/channels/783719264308953108/783719264308953111).
+We’d love to hear from you on what went well for you, what could be improved, or to answer any of your questions. Don’t hesitate to reach out via Github (`kurtosis feedback`) or in our [Discord server](https://discord.gg/6Jjp9c89z9).
 
 ### Other exercises you can do with your Cassandra cluster
 With your parameterized, reusable environment definition for a multi-node Cassandra cluster, feel free to:

--- a/docs/docs/guides/running-in-kurtosis-cloud.md
+++ b/docs/docs/guides/running-in-kurtosis-cloud.md
@@ -37,5 +37,5 @@ name, as well as the specific user folder the AWS user is authorized to access.
 
 :::tip AWS user permissions
 The AWS user created has a very restricted set of permissions by default. It can only read and write to its user folder
-inside the S3 bucket. But it is possible to request more access, reach out to us via Discord or by email.
+inside the S3 bucket. But it is possible to request more access, reach out to us via [Discord](https://discord.gg/6Jjp9c89z9).
 :::


### PR DESCRIPTION
## Description:
We had some broken discord links across our docs, readme, and github issue forms. This PR updates all those links with working ones AND makes them all the same for consistency.

## Is this change user facing?
YES

## References (if applicable):
https://github.com/kurtosis-tech/kurtosis/issues/1575 