### PR TITLE
fix: actually create production enclaves

### DIFF
--- a/api/golang/engine/lib/kurtosis_context/kurtosis_context.go
+++ b/api/golang/engine/lib/kurtosis_context/kurtosis_context.go
@@ -131,7 +131,7 @@ func (kurtosisCtx *KurtosisContext) CreateProductionEnclave(
 	enclaveName string,
 ) (*enclaves.EnclaveContext, error) {
 
-	createEnclaveArgs := newCreateEnclaveArgsWithDefaultValues(enclaveName)
+	createEnclaveArgs := newCreateProductionEnclaveWithDefaultValues(enclaveName)
 
 	response, err := kurtosisCtx.engineClient.CreateEnclave(ctx, createEnclaveArgs)
 	if err != nil {
@@ -594,6 +594,22 @@ func newCreateEnclaveArgsWithDefaultValues(enclaveName string) *kurtosis_engine_
 	defaultApiContainerVersionTag := defaultApiContainerVersionTagStr
 	defaultApiContainerLogLevel := defaultApiContainerLogLevelStr
 	defaultEnclaveMode := kurtosis_engine_rpc_api_bindings.EnclaveMode_TEST
+
+	createEnclaveArgs := &kurtosis_engine_rpc_api_bindings.CreateEnclaveArgs{
+		EnclaveName:            &enclaveName,
+		ApiContainerVersionTag: &defaultApiContainerVersionTag,
+		ApiContainerLogLevel:   &defaultApiContainerLogLevel,
+		Mode:                   &defaultEnclaveMode,
+	}
+
+	return createEnclaveArgs
+}
+
+func newCreateProductionEnclaveWithDefaultValues(enclaveName string) *kurtosis_engine_rpc_api_bindings.CreateEnclaveArgs {
+
+	defaultApiContainerVersionTag := defaultApiContainerVersionTagStr
+	defaultApiContainerLogLevel := defaultApiContainerLogLevelStr
+	defaultEnclaveMode := kurtosis_engine_rpc_api_bindings.EnclaveMode_PRODUCTION
 
 	createEnclaveArgs := &kurtosis_engine_rpc_api_bindings.CreateEnclaveArgs{
 		EnclaveName:            &enclaveName,


### PR DESCRIPTION
## Description:
Piotr from Nethermind reported that production mode wasn't doing anything. Here's a fix.

Tested using

```
def run(plan):
    plan.add_service(
        name = "test-service",
        config = ServiceConfig(
            image = "alpine:3.17",
            cmd = ["/bin/sh", "-c", "sleep 30 && exit 1"]
        )
    )
```