### PR TITLE
feat: add autocomplete for cluster set command

### DIFF
--- a/cli/cli/commands/cluster/ls/ls.go
+++ b/cli/cli/commands/cluster/ls/ls.go
@@ -32,17 +32,10 @@ var LsCmd = &lowlevel.LowlevelKurtosisCommand{
 }
 
 func run(ctx context.Context, flags *flags.ParsedFlags, args *args.ParsedArgs) error {
-	kurtosisConfigStore := kurtosis_config.GetKurtosisConfigStore()
-	configProvider := kurtosis_config.NewKurtosisConfigProvider(kurtosisConfigStore)
-	kurtosisConfig, err := configProvider.GetOrInitializeConfig()
+	clusterList, err := getClusterList()
 	if err != nil {
-		return stacktrace.Propagate(err, "Failed to get or initialize Kurtosis configuration")
+		return stacktrace.Propagate(err, "Failed to get Kurtosis cluster list")
 	}
-	var clusterList []string
-	for clusterName := range kurtosisConfig.GetKurtosisClusters() {
-		clusterList = append(clusterList, clusterName)
-	}
-	sort.Strings(clusterList)
 
 	tablePrinter := output_printers.NewTablePrinter(clusterCurrentColumnHeader, clusterNameColumnHeader)
 
@@ -58,6 +51,21 @@ func run(ctx context.Context, flags *flags.ParsedFlags, args *args.ParsedArgs) e
 	}
 	tablePrinter.Print()
 	return nil
+}
+
+func GetClusterList() ([]string, error) {
+	kurtosisConfigStore := kurtosis_config.GetKurtosisConfigStore()
+	configProvider := kurtosis_config.NewKurtosisConfigProvider(kurtosisConfigStore)
+	kurtosisConfig, err := configProvider.GetOrInitializeConfig()
+	if err != nil {
+		return []string{}, stacktrace.Propagate(err, "Failed to get or initialize Kurtosis configuration")
+	}
+	var clusterList []string
+	for clusterName := range kurtosisConfig.GetKurtosisClusters() {
+		clusterList = append(clusterList, clusterName)
+	}
+	sort.Strings(clusterList)
+	return clusterList, nil
 }
 
 func isCurrentCluster(clusterName string) bool {

--- a/cli/cli/commands/cluster/ls/ls.go
+++ b/cli/cli/commands/cluster/ls/ls.go
@@ -32,7 +32,7 @@ var LsCmd = &lowlevel.LowlevelKurtosisCommand{
 }
 
 func run(ctx context.Context, flags *flags.ParsedFlags, args *args.ParsedArgs) error {
-	clusterList, err := getClusterList()
+	clusterList, err := GetClusterList()
 	if err != nil {
 		return stacktrace.Propagate(err, "Failed to get Kurtosis cluster list")
 	}

--- a/cli/cli/commands/cluster/set/set.go
+++ b/cli/cli/commands/cluster/set/set.go
@@ -6,6 +6,7 @@ import (
 	"github.com/kurtosis-tech/kurtosis/cli/cli/command_framework/lowlevel/args"
 	"github.com/kurtosis-tech/kurtosis/cli/cli/command_framework/lowlevel/flags"
 	"github.com/kurtosis-tech/kurtosis/cli/cli/command_str_consts"
+	"github.com/kurtosis-tech/kurtosis/cli/cli/commands/cluster/ls"
 	"github.com/kurtosis-tech/kurtosis/cli/cli/defaults"
 	"github.com/kurtosis-tech/kurtosis/cli/cli/helpers/engine_manager"
 	"github.com/kurtosis-tech/kurtosis/cli/cli/helpers/kurtosis_config_getter"
@@ -33,13 +34,21 @@ var SetCmd = &lowlevel.LowlevelKurtosisCommand{
 			IsOptional:            false,
 			DefaultValue:          nil,
 			IsGreedy:              false,
-			ArgCompletionProvider: nil,
+			ArgCompletionProvider: args.NewManualCompletionsProvider(getCompletions),
 			ValidationFunc:        nil,
 		},
 	},
 	PreValidationAndRunFunc:  nil,
 	RunFunc:                  run,
 	PostValidationAndRunFunc: nil,
+}
+
+func getCompletions(ctx context.Context, flags *flags.ParsedFlags, previousArgs *args.ParsedArgs) ([]string, error) {
+	clusterList, err := ls.GetClusterList()
+	if err != nil {
+		return nil, stacktrace.Propagate(err, "Failed to get Kurtosis cluster list")
+	}
+	return clusterList, nil
 }
 
 func run(ctx context.Context, flags *flags.ParsedFlags, args *args.ParsedArgs) error {


### PR DESCRIPTION
## Description:
`kurtosis cluster set` has no autocomplete; had a go at adding this. 

I wasn't 100% sure how to test, but what I did was use the `__complete` command then compare its output to the similar `context set` command:

```
√ kurtosis % ./cli/cli/scripts/launch-cli.sh __complete context set ""
cloud-<hash>
default
:36
Completion ended with directive: ShellCompDirectiveNoFileComp, ShellCompDirectiveKeepOrder
√ kurtosis % ./cli/cli/scripts/launch-cli.sh __complete cluster set ""
docker
k3d-k3s-default
minikube
:36
Completion ended with directive: ShellCompDirectiveNoFileComp, ShellCompDirectiveKeepOrder
```

I'm not sure how to test this for real, i.e. hitting tab in my shell to see autocomplete results.  Maybe some config needed on my side?

## Is this change user facing?
YES

## References (if applicable):
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
