### PR TITLE
fix: correct is_ci value in metrics from APIC

### DIFF
--- a/cli/cli/command_framework/highlevel/engine_consuming_kurtosis_command/engine_consuming_kurtosis_command.go
+++ b/cli/cli/command_framework/highlevel/engine_consuming_kurtosis_command/engine_consuming_kurtosis_command.go
@@ -2,7 +2,6 @@ package engine_consuming_kurtosis_command
 
 import (
 	"context"
-
 	portal_constructors "github.com/kurtosis-tech/kurtosis-portal/api/golang/constructors"
 	"github.com/kurtosis-tech/kurtosis/api/golang/engine/kurtosis_engine_rpc_api_bindings"
 	"github.com/kurtosis-tech/kurtosis/api/golang/engine/lib/kurtosis_context"
@@ -16,7 +15,7 @@ import (
 	"github.com/kurtosis-tech/kurtosis/cli/cli/helpers/portal_manager"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface"
 	"github.com/kurtosis-tech/kurtosis/contexts-config-store/store"
-	metrics_client "github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/client"
+	"github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/metrics_client"
 	"github.com/kurtosis-tech/stacktrace"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"

--- a/cli/cli/commands/clean/clean.go
+++ b/cli/cli/commands/clean/clean.go
@@ -13,7 +13,7 @@ import (
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/container"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/engine"
-	metrics_client "github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/client"
+	"github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/metrics_client"
 	"github.com/kurtosis-tech/stacktrace"
 	"github.com/sirupsen/logrus"
 	"sort"

--- a/cli/cli/commands/dump/dump.go
+++ b/cli/cli/commands/dump/dump.go
@@ -10,7 +10,7 @@ import (
 	"github.com/kurtosis-tech/kurtosis/cli/cli/command_framework/lowlevel/flags"
 	"github.com/kurtosis-tech/kurtosis/cli/cli/command_str_consts"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface"
-	metrics_client "github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/client"
+	"github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/metrics_client"
 	"github.com/kurtosis-tech/stacktrace"
 	"github.com/sirupsen/logrus"
 	"time"

--- a/cli/cli/commands/enclave/add/add.go
+++ b/cli/cli/commands/enclave/add/add.go
@@ -14,7 +14,7 @@ import (
 	"github.com/kurtosis-tech/kurtosis/cli/cli/helpers/logrus_log_levels"
 	"github.com/kurtosis-tech/kurtosis/cli/cli/helpers/output_printers"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface"
-	metrics_client "github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/client"
+	"github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/metrics_client"
 	"github.com/kurtosis-tech/stacktrace"
 	"github.com/sirupsen/logrus"
 	"strings"

--- a/cli/cli/commands/enclave/dump/dump.go
+++ b/cli/cli/commands/enclave/dump/dump.go
@@ -13,7 +13,7 @@ import (
 	"github.com/kurtosis-tech/kurtosis/cli/cli/command_str_consts"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/enclave"
-	metrics_client "github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/client"
+	"github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/metrics_client"
 	"github.com/kurtosis-tech/stacktrace"
 	"github.com/sirupsen/logrus"
 )

--- a/cli/cli/commands/enclave/inspect/inspect.go
+++ b/cli/cli/commands/enclave/inspect/inspect.go
@@ -19,7 +19,7 @@ import (
 	"github.com/kurtosis-tech/kurtosis/cli/cli/helpers/output_printers"
 	"github.com/kurtosis-tech/kurtosis/cli/cli/out"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface"
-	metrics_client "github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/client"
+	"github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/metrics_client"
 	"github.com/kurtosis-tech/stacktrace"
 	"github.com/sirupsen/logrus"
 	"sort"

--- a/cli/cli/commands/enclave/ls/ls.go
+++ b/cli/cli/commands/enclave/ls/ls.go
@@ -16,7 +16,7 @@ import (
 	"github.com/kurtosis-tech/kurtosis/cli/cli/helpers/enclave_status_stringifier"
 	"github.com/kurtosis-tech/kurtosis/cli/cli/helpers/output_printers"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface"
-	metrics_client "github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/client"
+	"github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/metrics_client"
 	"github.com/kurtosis-tech/stacktrace"
 	"sort"
 	"strings"

--- a/cli/cli/commands/enclave/rm/rm.go
+++ b/cli/cli/commands/enclave/rm/rm.go
@@ -12,7 +12,7 @@ import (
 	"github.com/kurtosis-tech/kurtosis/cli/cli/command_framework/lowlevel/flags"
 	"github.com/kurtosis-tech/kurtosis/cli/cli/command_str_consts"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface"
-	metrics_client "github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/client"
+	"github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/metrics_client"
 	"github.com/kurtosis-tech/stacktrace"
 	"github.com/sirupsen/logrus"
 	"sort"

--- a/cli/cli/commands/enclave/stop/stop.go
+++ b/cli/cli/commands/enclave/stop/stop.go
@@ -10,7 +10,7 @@ import (
 	"github.com/kurtosis-tech/kurtosis/cli/cli/command_framework/lowlevel/flags"
 	"github.com/kurtosis-tech/kurtosis/cli/cli/command_str_consts"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface"
-	metrics_client "github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/client"
+	"github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/metrics_client"
 	"github.com/kurtosis-tech/stacktrace"
 	"github.com/sirupsen/logrus"
 	"strings"

--- a/cli/cli/commands/engine/logs/logs.go
+++ b/cli/cli/commands/engine/logs/logs.go
@@ -10,7 +10,7 @@ import (
 	"github.com/kurtosis-tech/kurtosis/cli/cli/command_framework/lowlevel/flags"
 	"github.com/kurtosis-tech/kurtosis/cli/cli/command_str_consts"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface"
-	metrics_client "github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/client"
+	"github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/metrics_client"
 	"github.com/kurtosis-tech/stacktrace"
 	"github.com/sirupsen/logrus"
 	"time"

--- a/cli/cli/commands/files/download/download.go
+++ b/cli/cli/commands/files/download/download.go
@@ -13,7 +13,7 @@ import (
 	"github.com/kurtosis-tech/kurtosis/cli/cli/command_framework/lowlevel/flags"
 	"github.com/kurtosis-tech/kurtosis/cli/cli/command_str_consts"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface"
-	metrics_client "github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/client"
+	"github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/metrics_client"
 	"github.com/kurtosis-tech/stacktrace"
 	"github.com/mholt/archiver"
 	"github.com/sirupsen/logrus"

--- a/cli/cli/commands/files/inspect/inspect.go
+++ b/cli/cli/commands/files/inspect/inspect.go
@@ -15,7 +15,7 @@ import (
 	"github.com/kurtosis-tech/kurtosis/cli/cli/command_framework/lowlevel/flags"
 	"github.com/kurtosis-tech/kurtosis/cli/cli/command_str_consts"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface"
-	metrics_client "github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/client"
+	"github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/metrics_client"
 	"github.com/kurtosis-tech/stacktrace"
 	"github.com/sirupsen/logrus"
 	"github.com/xlab/treeprint"

--- a/cli/cli/commands/files/rendertemplate/rendertemplate.go
+++ b/cli/cli/commands/files/rendertemplate/rendertemplate.go
@@ -18,7 +18,7 @@ import (
 	"github.com/kurtosis-tech/kurtosis/cli/cli/command_framework/lowlevel/flags"
 	"github.com/kurtosis-tech/kurtosis/cli/cli/command_str_consts"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface"
-	metrics_client "github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/client"
+	"github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/metrics_client"
 	"github.com/kurtosis-tech/stacktrace"
 	"github.com/sirupsen/logrus"
 )

--- a/cli/cli/commands/files/storeservice/storeservice.go
+++ b/cli/cli/commands/files/storeservice/storeservice.go
@@ -15,7 +15,7 @@ import (
 	"github.com/kurtosis-tech/kurtosis/cli/cli/command_framework/lowlevel/flags"
 	"github.com/kurtosis-tech/kurtosis/cli/cli/command_str_consts"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface"
-	metrics_client "github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/client"
+	"github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/metrics_client"
 	"github.com/kurtosis-tech/stacktrace"
 	"github.com/sirupsen/logrus"
 )

--- a/cli/cli/commands/files/storeweb/storeweb.go
+++ b/cli/cli/commands/files/storeweb/storeweb.go
@@ -11,7 +11,7 @@ import (
 	"github.com/kurtosis-tech/kurtosis/cli/cli/command_framework/lowlevel/flags"
 	"github.com/kurtosis-tech/kurtosis/cli/cli/command_str_consts"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface"
-	metrics_client "github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/client"
+	"github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/metrics_client"
 	"github.com/kurtosis-tech/stacktrace"
 	"github.com/sirupsen/logrus"
 	"time"

--- a/cli/cli/commands/files/upload/upload.go
+++ b/cli/cli/commands/files/upload/upload.go
@@ -11,7 +11,7 @@ import (
 	"github.com/kurtosis-tech/kurtosis/cli/cli/command_framework/lowlevel/flags"
 	"github.com/kurtosis-tech/kurtosis/cli/cli/command_str_consts"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface"
-	metrics_client "github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/client"
+	"github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/metrics_client"
 	"github.com/kurtosis-tech/stacktrace"
 	"github.com/sirupsen/logrus"
 )

--- a/cli/cli/commands/import/import.go
+++ b/cli/cli/commands/import/import.go
@@ -22,7 +22,7 @@ import (
 	_run "github.com/kurtosis-tech/kurtosis/cli/cli/commands/run"
 	"github.com/kurtosis-tech/kurtosis/cli/cli/commands/service/add"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface"
-	metrics_client "github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/client"
+	"github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/metrics_client"
 	"github.com/kurtosis-tech/kurtosis/name_generator"
 	"github.com/kurtosis-tech/stacktrace"
 	"github.com/sirupsen/logrus"

--- a/cli/cli/commands/port/print/print.go
+++ b/cli/cli/commands/port/print/print.go
@@ -14,7 +14,7 @@ import (
 	"github.com/kurtosis-tech/kurtosis/cli/cli/command_str_consts"
 	"github.com/kurtosis-tech/kurtosis/cli/cli/out"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface"
-	metrics_client "github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/client"
+	"github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/metrics_client"
 	"github.com/kurtosis-tech/stacktrace"
 	"github.com/sirupsen/logrus"
 	"strings"

--- a/cli/cli/commands/run/run.go
+++ b/cli/cli/commands/run/run.go
@@ -34,7 +34,7 @@ import (
 	"github.com/kurtosis-tech/kurtosis/cli/cli/helpers/portal_manager"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface"
 	"github.com/kurtosis-tech/kurtosis/contexts-config-store/store"
-	metrics_client "github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/client"
+	"github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/metrics_client"
 	"github.com/kurtosis-tech/stacktrace"
 	"github.com/sirupsen/logrus"
 )

--- a/cli/cli/commands/service/add/add.go
+++ b/cli/cli/commands/service/add/add.go
@@ -21,7 +21,7 @@ import (
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/uuid_generator"
 	"github.com/kurtosis-tech/kurtosis/contexts-config-store/store"
-	metrics_client "github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/client"
+	"github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/metrics_client"
 	"github.com/kurtosis-tech/stacktrace"
 	"github.com/sirupsen/logrus"
 )

--- a/cli/cli/commands/service/exec/exec.go
+++ b/cli/cli/commands/service/exec/exec.go
@@ -15,7 +15,7 @@ import (
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/enclave"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/service"
-	metrics_client "github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/client"
+	"github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/metrics_client"
 	"github.com/kurtosis-tech/stacktrace"
 )
 

--- a/cli/cli/commands/service/inspect/inspect.go
+++ b/cli/cli/commands/service/inspect/inspect.go
@@ -22,7 +22,7 @@ import (
 	"github.com/kurtosis-tech/kurtosis/cli/cli/helpers/user_services"
 	"github.com/kurtosis-tech/kurtosis/cli/cli/out"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface"
-	metrics_client "github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/client"
+	"github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/metrics_client"
 	"github.com/kurtosis-tech/stacktrace"
 )
 

--- a/cli/cli/commands/service/logs/logs.go
+++ b/cli/cli/commands/service/logs/logs.go
@@ -20,7 +20,7 @@ import (
 	"github.com/kurtosis-tech/kurtosis/cli/cli/out"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/user_support_constants"
-	metrics_client "github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/client"
+	"github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/metrics_client"
 	"github.com/kurtosis-tech/stacktrace"
 	"github.com/sirupsen/logrus"
 	"os"

--- a/cli/cli/commands/service/rm/rm.go
+++ b/cli/cli/commands/service/rm/rm.go
@@ -15,7 +15,7 @@ import (
 	"github.com/kurtosis-tech/kurtosis/cli/cli/command_framework/lowlevel/flags"
 	"github.com/kurtosis-tech/kurtosis/cli/cli/command_str_consts"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface"
-	metrics_client "github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/client"
+	"github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/metrics_client"
 	"github.com/kurtosis-tech/stacktrace"
 )
 

--- a/cli/cli/commands/service/shell/shell.go
+++ b/cli/cli/commands/service/shell/shell.go
@@ -18,7 +18,7 @@ import (
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/enclave"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/service"
-	metrics_client "github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/client"
+	"github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/metrics_client"
 	"github.com/kurtosis-tech/stacktrace"
 )
 

--- a/cli/cli/commands/service/start/start.go
+++ b/cli/cli/commands/service/start/start.go
@@ -17,7 +17,7 @@ import (
 	"github.com/kurtosis-tech/kurtosis/cli/cli/command_framework/lowlevel/flags"
 	"github.com/kurtosis-tech/kurtosis/cli/cli/command_str_consts"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface"
-	metrics_client "github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/client"
+	"github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/metrics_client"
 	"github.com/kurtosis-tech/stacktrace"
 )
 

--- a/cli/cli/commands/service/stop/stop.go
+++ b/cli/cli/commands/service/stop/stop.go
@@ -15,7 +15,7 @@ import (
 	"github.com/kurtosis-tech/kurtosis/cli/cli/command_framework/lowlevel/flags"
 	"github.com/kurtosis-tech/kurtosis/cli/cli/command_str_consts"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface"
-	metrics_client "github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/client"
+	"github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/metrics_client"
 	"github.com/kurtosis-tech/stacktrace"
 	"github.com/sirupsen/logrus"
 )

--- a/cli/cli/helpers/engine_manager/engine_existence_guarantor.go
+++ b/cli/cli/helpers/engine_manager/engine_existence_guarantor.go
@@ -12,7 +12,7 @@ import (
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/user_support_constants"
 	"github.com/kurtosis-tech/kurtosis/engine/launcher/engine_server_launcher"
 	"github.com/kurtosis-tech/kurtosis/kurtosis_version"
-	"github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/client"
+	"github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/metrics_client"
 	"github.com/kurtosis-tech/stacktrace"
 	"github.com/sirupsen/logrus"
 )
@@ -159,7 +159,7 @@ func (guarantor *engineExistenceGuarantor) VisitStopped() error {
 			guarantor.onBastionHost,
 			guarantor.poolSize,
 			guarantor.enclaveEnvVars,
-			client.IsCI(),
+			metrics_client.IsCI(),
 		)
 	} else {
 		_, _, engineLaunchErr = guarantor.engineServerLauncher.LaunchWithCustomVersion(
@@ -173,7 +173,7 @@ func (guarantor *engineExistenceGuarantor) VisitStopped() error {
 			guarantor.onBastionHost,
 			guarantor.poolSize,
 			guarantor.enclaveEnvVars,
-			client.IsCI(),
+			metrics_client.IsCI(),
 		)
 	}
 	if engineLaunchErr != nil {

--- a/cli/cli/helpers/engine_manager/engine_existence_guarantor.go
+++ b/cli/cli/helpers/engine_manager/engine_existence_guarantor.go
@@ -12,6 +12,7 @@ import (
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/user_support_constants"
 	"github.com/kurtosis-tech/kurtosis/engine/launcher/engine_server_launcher"
 	"github.com/kurtosis-tech/kurtosis/kurtosis_version"
+	"github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/client"
 	"github.com/kurtosis-tech/stacktrace"
 	"github.com/sirupsen/logrus"
 )
@@ -158,6 +159,7 @@ func (guarantor *engineExistenceGuarantor) VisitStopped() error {
 			guarantor.onBastionHost,
 			guarantor.poolSize,
 			guarantor.enclaveEnvVars,
+			client.IsCI(),
 		)
 	} else {
 		_, _, engineLaunchErr = guarantor.engineServerLauncher.LaunchWithCustomVersion(
@@ -171,6 +173,7 @@ func (guarantor *engineExistenceGuarantor) VisitStopped() error {
 			guarantor.onBastionHost,
 			guarantor.poolSize,
 			guarantor.enclaveEnvVars,
+			client.IsCI(),
 		)
 	}
 	if engineLaunchErr != nil {

--- a/cli/cli/helpers/metrics_client_factory/metrics_client_factory.go
+++ b/cli/cli/helpers/metrics_client_factory/metrics_client_factory.go
@@ -52,7 +52,8 @@ func GetMetricsClient() (metrics_client.MetricsClient, func() error, error) {
 			sendUserMetrics,
 			shouldFlushMetricsClientQueueOnEachEvent,
 			do_nothing_metrics_client_callback.NewDoNothingMetricsClientCallback(),
-			analytics_logger.ConvertLogrusLoggerToAnalyticsLogger(logger)),
+			analytics_logger.ConvertLogrusLoggerToAnalyticsLogger(logger),
+			metrics_client.IsCI()),
 	)
 
 	if err != nil {
@@ -80,7 +81,8 @@ func GetSegmentClient() (metrics_client.MetricsClient, func() error, error) {
 			sendUserMetrics,
 			shouldFlushMetricsClientQueueOnEachEvent,
 			do_nothing_metrics_client_callback.NewDoNothingMetricsClientCallback(),
-			analytics_logger.ConvertLogrusLoggerToAnalyticsLogger(logger)),
+			analytics_logger.ConvertLogrusLoggerToAnalyticsLogger(logger),
+			metrics_client.IsCI()),
 	)
 
 	if err != nil {

--- a/cli/cli/helpers/metrics_client_factory/metrics_client_factory.go
+++ b/cli/cli/helpers/metrics_client_factory/metrics_client_factory.go
@@ -9,7 +9,7 @@ import (
 	"github.com/kurtosis-tech/kurtosis/cli/cli/kurtosis_config/resolved_config"
 	"github.com/kurtosis-tech/kurtosis/kurtosis_version"
 	"github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/analytics_logger"
-	metrics_client "github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/client"
+	"github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/metrics_client"
 	"github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/source"
 	"github.com/kurtosis-tech/stacktrace"
 	"github.com/sirupsen/logrus"

--- a/cli/cli/helpers/metrics_client_factory/metrics_client_factory.go
+++ b/cli/cli/helpers/metrics_client_factory/metrics_client_factory.go
@@ -44,14 +44,15 @@ func GetMetricsClient() (metrics_client.MetricsClient, func() error, error) {
 
 	logger := logrus.StandardLogger()
 	metricsClient, metricsClientCloseFunc, err := metrics_client.CreateMetricsClient(
-		source.KurtosisCLISource,
-		kurtosis_version.KurtosisVersion,
-		metricsUserId,
-		clusterType,
-		sendUserMetrics,
-		shouldFlushMetricsClientQueueOnEachEvent,
-		do_nothing_metrics_client_callback.NewDoNothingMetricsClientCallback(),
-		analytics_logger.ConvertLogrusLoggerToAnalyticsLogger(logger),
+		metrics_client.NewMetricsClientCreatorOption(
+			source.KurtosisCLISource,
+			kurtosis_version.KurtosisVersion,
+			metricsUserId,
+			clusterType,
+			sendUserMetrics,
+			shouldFlushMetricsClientQueueOnEachEvent,
+			do_nothing_metrics_client_callback.NewDoNothingMetricsClientCallback(),
+			analytics_logger.ConvertLogrusLoggerToAnalyticsLogger(logger)),
 	)
 
 	if err != nil {
@@ -72,14 +73,14 @@ func GetSegmentClient() (metrics_client.MetricsClient, func() error, error) {
 
 	logger := logrus.StandardLogger()
 	metricsClient, metricsClientCloseFunc, err := metrics_client.CreateMetricsClient(
-		source.KurtosisCLISource,
-		kurtosis_version.KurtosisVersion,
-		metricsUserId,
-		clusterType,
-		sendUserMetrics,
-		shouldFlushMetricsClientQueueOnEachEvent,
-		do_nothing_metrics_client_callback.NewDoNothingMetricsClientCallback(),
-		analytics_logger.ConvertLogrusLoggerToAnalyticsLogger(logger),
+		metrics_client.NewMetricsClientCreatorOption(source.KurtosisCLISource,
+			kurtosis_version.KurtosisVersion,
+			metricsUserId,
+			clusterType,
+			sendUserMetrics,
+			shouldFlushMetricsClientQueueOnEachEvent,
+			do_nothing_metrics_client_callback.NewDoNothingMetricsClientCallback(),
+			analytics_logger.ConvertLogrusLoggerToAnalyticsLogger(logger)),
 	)
 
 	if err != nil {

--- a/cli/cli/helpers/user_send_metrics_election/user_send_metrics_election_tracker.go
+++ b/cli/cli/helpers/user_send_metrics_election/user_send_metrics_election_tracker.go
@@ -63,6 +63,7 @@ func SendAnyBackloggedUserMetricsElectionEvent() error {
 				shouldFlushMetricsClientQueueOnEachEvent,
 				metricsClientCallback,
 				analytics_logger.ConvertLogrusLoggerToAnalyticsLogger(logger),
+				metrics_client.IsCI(),
 			),
 		)
 		if err != nil {

--- a/cli/cli/helpers/user_send_metrics_election/user_send_metrics_election_tracker.go
+++ b/cli/cli/helpers/user_send_metrics_election/user_send_metrics_election_tracker.go
@@ -54,14 +54,16 @@ func SendAnyBackloggedUserMetricsElectionEvent() error {
 		logger := logrus.StandardLogger()
 		// This is a special metrics client that, will record their decision about whether to send metrics or not
 		metricsClient, metricsClientCloseFunc, err := metrics_client.CreateMetricsClient(
-			source.KurtosisCLISource,
-			kurtosis_version.KurtosisVersion,
-			metricsUserId,
-			clusterType,
-			didUserAcceptSendingMetricsValueForMetricsClientCreation,
-			shouldFlushMetricsClientQueueOnEachEvent,
-			metricsClientCallback,
-			analytics_logger.ConvertLogrusLoggerToAnalyticsLogger(logger),
+			metrics_client.NewMetricsClientCreatorOption(
+				source.KurtosisCLISource,
+				kurtosis_version.KurtosisVersion,
+				metricsUserId,
+				clusterType,
+				didUserAcceptSendingMetricsValueForMetricsClientCreation,
+				shouldFlushMetricsClientQueueOnEachEvent,
+				metricsClientCallback,
+				analytics_logger.ConvertLogrusLoggerToAnalyticsLogger(logger),
+			),
 		)
 		if err != nil {
 			return stacktrace.Propagate(err, "An error occurred creating the metrics client for recording send-metrics election")

--- a/cli/cli/helpers/user_send_metrics_election/user_send_metrics_election_tracker.go
+++ b/cli/cli/helpers/user_send_metrics_election/user_send_metrics_election_tracker.go
@@ -7,7 +7,7 @@ import (
 	"github.com/kurtosis-tech/kurtosis/cli/cli/kurtosis_config/resolved_config"
 	"github.com/kurtosis-tech/kurtosis/kurtosis_version"
 	"github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/analytics_logger"
-	metrics_client "github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/client"
+	"github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/metrics_client"
 	"github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/source"
 	"github.com/kurtosis-tech/stacktrace"
 	"github.com/sirupsen/logrus"

--- a/cli/cli/kurtosis_config/email_collector/email_collector.go
+++ b/cli/cli/kurtosis_config/email_collector/email_collector.go
@@ -7,7 +7,7 @@ import (
 	"github.com/kurtosis-tech/kurtosis/cli/cli/kurtosis_config/resolved_config"
 	"github.com/kurtosis-tech/kurtosis/kurtosis_version"
 	"github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/analytics_logger"
-	metrics_client "github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/client"
+	"github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/metrics_client"
 	"github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/source"
 	"github.com/sirupsen/logrus"
 )

--- a/cli/cli/kurtosis_config/email_collector/email_collector.go
+++ b/cli/cli/kurtosis_config/email_collector/email_collector.go
@@ -42,16 +42,17 @@ func logUserEmailAddressAsMetric(userEmail string) {
 	logger := logrus.StandardLogger()
 
 	metricsClient, metricsClientCloseFunc, err := metrics_client.CreateMetricsClient(
-		source.KurtosisCLISource,
-		kurtosis_version.KurtosisVersion,
-		metricsUserId,
-		// TODO this isn't relevant for the metric also this only runs at first install;
-		// The user hasn't ever used Kurtosis yet so it has to be the default cluster
-		resolved_config.DefaultDockerClusterName,
-		sendUserMetrics,
-		flushQueueOnEachEvent,
-		do_nothing_metrics_client_callback.NewDoNothingMetricsClientCallback(),
-		analytics_logger.ConvertLogrusLoggerToAnalyticsLogger(logger),
+		metrics_client.NewMetricsClientCreatorOption(
+			source.KurtosisCLISource,
+			kurtosis_version.KurtosisVersion,
+			metricsUserId,
+			// TODO this isn't relevant for the metric also this only runs at first install;
+			// The user hasn't ever used Kurtosis yet so it has to be the default cluster
+			resolved_config.DefaultDockerClusterName,
+			sendUserMetrics,
+			flushQueueOnEachEvent,
+			do_nothing_metrics_client_callback.NewDoNothingMetricsClientCallback(),
+			analytics_logger.ConvertLogrusLoggerToAnalyticsLogger(logger)),
 	)
 	if err != nil {
 		logrus.Debugf("tried creating a metrics client but failed with error:\n%v", err)

--- a/cli/cli/kurtosis_config/email_collector/email_collector.go
+++ b/cli/cli/kurtosis_config/email_collector/email_collector.go
@@ -52,7 +52,8 @@ func logUserEmailAddressAsMetric(userEmail string) {
 			sendUserMetrics,
 			flushQueueOnEachEvent,
 			do_nothing_metrics_client_callback.NewDoNothingMetricsClientCallback(),
-			analytics_logger.ConvertLogrusLoggerToAnalyticsLogger(logger)),
+			analytics_logger.ConvertLogrusLoggerToAnalyticsLogger(logger),
+			metrics_client.IsCI()),
 	)
 	if err != nil {
 		logrus.Debugf("tried creating a metrics client but failed with error:\n%v", err)

--- a/core/launcher/api_container_launcher/api_container_launcher.go
+++ b/core/launcher/api_container_launcher/api_container_launcher.go
@@ -41,6 +41,7 @@ func (launcher ApiContainerLauncher) LaunchWithDefaultVersion(
 	isProductionEnclave bool,
 	metricsUserID string,
 	didUserAcceptSendingMetrics bool,
+	isCI bool,
 ) (
 	resultApiContainer *api_container.APIContainer,
 	resultErr error,
@@ -56,6 +57,7 @@ func (launcher ApiContainerLauncher) LaunchWithDefaultVersion(
 		isProductionEnclave,
 		metricsUserID,
 		didUserAcceptSendingMetrics,
+		isCI,
 	)
 	if err != nil {
 		return nil, stacktrace.Propagate(err, "An error occurred launching the API container with default version tag '%v'", kurtosis_version.KurtosisVersion)
@@ -74,6 +76,7 @@ func (launcher ApiContainerLauncher) LaunchWithCustomVersion(
 	isProductionEnclave bool,
 	metricsUserID string,
 	didUserAcceptSendingMetrics bool,
+	isCI bool,
 ) (
 	resultApiContainer *api_container.APIContainer,
 	resultErr error,
@@ -91,6 +94,7 @@ func (launcher ApiContainerLauncher) LaunchWithCustomVersion(
 		isProductionEnclave,
 		metricsUserID,
 		didUserAcceptSendingMetrics,
+		isCI,
 	)
 	if err != nil {
 		return nil, stacktrace.Propagate(err, "An error occurred creating the API container args")

--- a/core/launcher/args/api_container_args.go
+++ b/core/launcher/args/api_container_args.go
@@ -44,6 +44,9 @@ type APIContainerArgs struct {
 
 	//User consent to send metrics
 	DidUserAcceptSendingMetrics bool `json:"didUserAcceptSendingMetrics"`
+
+	//If its running in a CI environment
+	IsCI bool `json:"is_ci"`
 }
 
 func (args *APIContainerArgs) UnmarshalJSON(data []byte) error {
@@ -92,6 +95,7 @@ func NewAPIContainerArgs(
 	isProductionEnclave bool,
 	metricsUserID string,
 	didUserAcceptSendingMetrics bool,
+	isCI bool,
 ) (*APIContainerArgs, error) {
 	result := &APIContainerArgs{
 		Version:                     version,
@@ -105,6 +109,7 @@ func NewAPIContainerArgs(
 		IsProductionEnclave:         isProductionEnclave,
 		MetricsUserID:               metricsUserID,
 		DidUserAcceptSendingMetrics: didUserAcceptSendingMetrics,
+		IsCI:                        isCI,
 	}
 
 	if err := result.validate(); err != nil {

--- a/core/server/api_container/main.go
+++ b/core/server/api_container/main.go
@@ -186,7 +186,9 @@ func runMain() error {
 			serverArgs.DidUserAcceptSendingMetrics,
 			shouldFlushMetricsClientQueueOnEachEvent,
 			doNothingMetricsClientCallback{},
-			analytics_logger.ConvertLogrusLoggerToAnalyticsLogger(logger)),
+			analytics_logger.ConvertLogrusLoggerToAnalyticsLogger(logger),
+			serverArgs.IsCI,
+		),
 	)
 	if err != nil {
 		return stacktrace.Propagate(err, "An error occurred creating the metrics client")

--- a/core/server/api_container/main.go
+++ b/core/server/api_container/main.go
@@ -178,14 +178,15 @@ func runMain() error {
 
 	logger := logrus.StandardLogger()
 	metricsClient, closeClientFunc, err := metrics_client.CreateMetricsClient(
-		source.KurtosisCoreSource,
-		serverArgs.Version,
-		serverArgs.MetricsUserID,
-		serverArgs.KurtosisBackendType.String(),
-		serverArgs.DidUserAcceptSendingMetrics,
-		shouldFlushMetricsClientQueueOnEachEvent,
-		doNothingMetricsClientCallback{},
-		analytics_logger.ConvertLogrusLoggerToAnalyticsLogger(logger),
+		metrics_client.NewMetricsClientCreatorOption(
+			source.KurtosisCoreSource,
+			serverArgs.Version,
+			serverArgs.MetricsUserID,
+			serverArgs.KurtosisBackendType.String(),
+			serverArgs.DidUserAcceptSendingMetrics,
+			shouldFlushMetricsClientQueueOnEachEvent,
+			doNothingMetricsClientCallback{},
+			analytics_logger.ConvertLogrusLoggerToAnalyticsLogger(logger)),
 	)
 	if err != nil {
 		return stacktrace.Propagate(err, "An error occurred creating the metrics client")

--- a/core/server/api_container/main.go
+++ b/core/server/api_container/main.go
@@ -32,7 +32,7 @@ import (
 	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/runtime_value_store"
 	"github.com/kurtosis-tech/kurtosis/core/server/commons/enclave_data_directory"
 	"github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/analytics_logger"
-	metrics_client "github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/client"
+	"github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/metrics_client"
 	"github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/source"
 	minimal_grpc_server "github.com/kurtosis-tech/minimal-grpc-server/golang/server"
 	"github.com/kurtosis-tech/stacktrace"

--- a/core/server/api_container/server/api_container_service.go
+++ b/core/server/api_container/server/api_container_service.go
@@ -22,7 +22,7 @@ import (
 	"unicode"
 
 	"github.com/kurtosis-tech/kurtosis/core/server/commons/yaml_parser"
-	metrics_client "github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/client"
+	"github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/metrics_client"
 
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/uuid_generator"
 

--- a/engine/launcher/args/args.go
+++ b/engine/launcher/args/args.go
@@ -47,6 +47,9 @@ type EngineServerArgs struct {
 	// Environment variable to pass to all the enclaves the engine is going to create. Those environment variable will
 	// then be accessible in Starlark scripts in the `kurtosis` module
 	EnclaveEnvVars string `json:"enclaveEnvVars"`
+
+	// Whether the Engine is running in a CI  environment
+	IsCI bool `json:"is_ci"`
 }
 
 func (args *EngineServerArgs) UnmarshalJSON(data []byte) error {
@@ -93,6 +96,7 @@ func NewEngineServerArgs(
 	onBastionHost bool,
 	poolSize uint8,
 	enclaveEnvVars string,
+	isCI bool,
 ) (*EngineServerArgs, error) {
 	if enclaveEnvVars == "" {
 		enclaveEnvVars = emptyJsonField
@@ -108,6 +112,7 @@ func NewEngineServerArgs(
 		OnBastionHost:               onBastionHost,
 		PoolSize:                    poolSize,
 		EnclaveEnvVars:              enclaveEnvVars,
+		IsCI:                        isCI,
 	}
 	if err := result.validate(); err != nil {
 		return nil, stacktrace.Propagate(err, "An error occurred validating engine server args")

--- a/engine/launcher/engine_server_launcher/engine_server_launcher.go
+++ b/engine/launcher/engine_server_launcher/engine_server_launcher.go
@@ -39,6 +39,7 @@ func (launcher *EngineServerLauncher) LaunchWithDefaultVersion(
 	onBastionHost bool,
 	poolSize uint8,
 	enclaveEnvVars string,
+	isCI bool,
 ) (
 	resultPublicIpAddr net.IP,
 	resultPublicGrpcPortSpec *port_spec.PortSpec,
@@ -55,6 +56,7 @@ func (launcher *EngineServerLauncher) LaunchWithDefaultVersion(
 		onBastionHost,
 		poolSize,
 		enclaveEnvVars,
+		isCI,
 	)
 	if err != nil {
 		return nil, nil, stacktrace.Propagate(err, "An error occurred launching the engine server container with default version tag '%v'", kurtosis_version.KurtosisVersion)
@@ -73,6 +75,7 @@ func (launcher *EngineServerLauncher) LaunchWithCustomVersion(
 	onBastionHost bool,
 	poolSize uint8,
 	enclaveEnvVars string,
+	isCI bool,
 ) (
 	resultPublicIpAddr net.IP,
 	resultPublicGrpcPortSpec *port_spec.PortSpec,
@@ -90,6 +93,7 @@ func (launcher *EngineServerLauncher) LaunchWithCustomVersion(
 		onBastionHost,
 		poolSize,
 		enclaveEnvVars,
+		isCI,
 	)
 	if err != nil {
 		return nil, nil, stacktrace.Propagate(err, "An error occurred creating the engine server args")

--- a/engine/server/engine/enclave_manager/enclave_creator.go
+++ b/engine/server/engine/enclave_manager/enclave_creator.go
@@ -39,6 +39,7 @@ func (creator *EnclaveCreator) CreateEnclave(
 	isProduction bool,
 	metricsUserID string,
 	didUserAcceptSendingMetrics bool,
+	isCI bool,
 ) (*kurtosis_engine_rpc_api_bindings.EnclaveInfo, error) {
 
 	uuid, err := uuid_generator.GenerateUUIDString()
@@ -80,6 +81,7 @@ func (creator *EnclaveCreator) CreateEnclave(
 		isProduction,
 		metricsUserID,
 		didUserAcceptSendingMetrics,
+		isCI,
 	)
 
 	if err != nil {
@@ -163,6 +165,7 @@ func (creator *EnclaveCreator) launchApiContainer(
 	isProduction bool,
 	metricsUserID string,
 	didUserAcceptSendingMetrics bool,
+	isCI bool,
 ) (
 	resultApiContainer *api_container.APIContainer,
 	resultErr error,
@@ -182,6 +185,7 @@ func (creator *EnclaveCreator) launchApiContainer(
 			isProduction,
 			metricsUserID,
 			didUserAcceptSendingMetrics,
+			isCI,
 		)
 		if err != nil {
 			return nil, stacktrace.Propagate(err, "Expected to be able to launch api container for enclave '%v' with custom version '%v', but an error occurred", enclaveUuid, apiContainerImageVersionTag)
@@ -198,6 +202,7 @@ func (creator *EnclaveCreator) launchApiContainer(
 		isProduction,
 		metricsUserID,
 		didUserAcceptSendingMetrics,
+		isCI,
 	)
 	if err != nil {
 		return nil, stacktrace.Propagate(err, "Expected to be able to launch api container for enclave '%v' with the default version, but an error occurred", enclaveUuid)

--- a/engine/server/engine/enclave_manager/enclave_manager.go
+++ b/engine/server/engine/enclave_manager/enclave_manager.go
@@ -68,6 +68,7 @@ type EnclaveManager struct {
 
 	metricsUserID               string
 	didUserAcceptSendingMetrics bool
+	isCI                        bool
 }
 
 func CreateEnclaveManager(
@@ -80,6 +81,7 @@ func CreateEnclaveManager(
 	enclaveLogFileManager *log_file_manager.LogFileManager,
 	metricsUserID string,
 	didUserAcceptSendingMetrics bool,
+	isCI bool,
 ) (*EnclaveManager, error) {
 	enclaveCreator := newEnclaveCreator(kurtosisBackend, apiContainerKurtosisBackendConfigSupplier)
 
@@ -90,7 +92,7 @@ func CreateEnclaveManager(
 
 	// The enclave pool feature is only available for Kubernetes so far
 	if kurtosisBackendType == args.KurtosisBackendType_Kubernetes {
-		enclavePool, err = CreateEnclavePool(kurtosisBackend, enclaveCreator, poolSize, engineVersion, enclaveEnvVars, metricsUserID, didUserAcceptSendingMetrics)
+		enclavePool, err = CreateEnclavePool(kurtosisBackend, enclaveCreator, poolSize, engineVersion, enclaveEnvVars, metricsUserID, didUserAcceptSendingMetrics, isCI)
 		if err != nil {
 			return nil, stacktrace.Propagate(err, "An error occurred creating enclave pool with pool-size '%v' and engine version '%v'", poolSize, engineVersion)
 		}
@@ -107,6 +109,7 @@ func CreateEnclaveManager(
 		enclaveLogFileManager:                     enclaveLogFileManager,
 		metricsUserID:                             metricsUserID,
 		didUserAcceptSendingMetrics:               didUserAcceptSendingMetrics,
+		isCI:                                      isCI,
 	}
 
 	return enclaveManager, nil
@@ -176,6 +179,7 @@ func (manager *EnclaveManager) CreateEnclave(
 			isProduction,
 			manager.metricsUserID,
 			manager.didUserAcceptSendingMetrics,
+			manager.isCI,
 		)
 		if err != nil {
 			return nil, stacktrace.Propagate(

--- a/engine/server/engine/enclave_manager/enclave_pool.go
+++ b/engine/server/engine/enclave_manager/enclave_pool.go
@@ -32,6 +32,7 @@ type EnclavePool struct {
 	enclaveEnvVars              string
 	metricsUserID               string
 	didUserAcceptSendingMetrics bool
+	isCI                        bool
 }
 
 // CreateEnclavePool will do the following:
@@ -47,6 +48,7 @@ func CreateEnclavePool(
 	enclaveEnvVars string,
 	metricsUserID string,
 	didUserAcceptSendingMetrics bool,
+	isCI bool,
 
 ) (*EnclavePool, error) {
 
@@ -92,6 +94,7 @@ func CreateEnclavePool(
 		enclaveEnvVars:              enclaveEnvVars,
 		metricsUserID:               metricsUserID,
 		didUserAcceptSendingMetrics: didUserAcceptSendingMetrics,
+		isCI:                        isCI,
 	}
 
 	go enclavePool.run(ctxWithCancel)
@@ -276,6 +279,7 @@ func (pool *EnclavePool) createNewIdleEnclave(ctx context.Context) (*kurtosis_en
 		createTestEnclave,
 		pool.metricsUserID,
 		pool.didUserAcceptSendingMetrics,
+		pool.isCI,
 	)
 	if err != nil {
 		return nil, stacktrace.Propagate(

--- a/engine/server/engine/main.go
+++ b/engine/server/engine/main.go
@@ -151,7 +151,7 @@ func runMain() error {
 	logFileManager := log_file_manager.NewLogFileManager(kurtosisBackend, osFs, realTime)
 	logFileManager.StartLogFileManagement(ctx)
 
-	enclaveManager, err := getEnclaveManager(kurtosisBackend, serverArgs.KurtosisBackendType, serverArgs.ImageVersionTag, serverArgs.PoolSize, serverArgs.EnclaveEnvVars, logFileManager, serverArgs.MetricsUserID, serverArgs.DidUserAcceptSendingMetrics)
+	enclaveManager, err := getEnclaveManager(kurtosisBackend, serverArgs.KurtosisBackendType, serverArgs.ImageVersionTag, serverArgs.PoolSize, serverArgs.EnclaveEnvVars, logFileManager, serverArgs.MetricsUserID, serverArgs.DidUserAcceptSendingMetrics, serverArgs.IsCI)
 	if err != nil {
 		return stacktrace.Propagate(err, "Failed to create an enclave manager for backend type '%v' and config '%+v'", serverArgs.KurtosisBackendType, backendConfig)
 	}
@@ -229,6 +229,7 @@ func getEnclaveManager(
 	enclaveLogFileManager *log_file_manager.LogFileManager,
 	metricsUserID string,
 	didUserAcceptSendingMetrics bool,
+	isCI bool,
 ) (*enclave_manager.EnclaveManager, error) {
 	var apiContainerKurtosisBackendConfigSupplier api_container_launcher.KurtosisBackendConfigSupplier
 	switch kurtosisBackendType {
@@ -250,6 +251,7 @@ func getEnclaveManager(
 		enclaveLogFileManager,
 		metricsUserID,
 		didUserAcceptSendingMetrics,
+		isCI,
 	)
 	if err != nil {
 		return nil, stacktrace.Propagate(err, "An error occurred creating enclave manager for backend type '%+v' using pool-size '%v' and engine version '%v'", kurtosisBackendType, poolSize, engineVersion)

--- a/metrics-library/golang/lib/client/is_ci.go
+++ b/metrics-library/golang/lib/client/is_ci.go
@@ -2,11 +2,6 @@ package client
 
 import "os"
 
-const (
-	trueStr  = "true"
-	falseStr = "false"
-)
-
 var ciEnvironmentVariables = []string{
 	// Azure Pipelines
 	"TF_BUILD",
@@ -35,13 +30,13 @@ var ciEnvironmentVariables = []string{
 	"CI",
 }
 
-// isCI Checks environment variables to tell if Kurtosis is running in CI
+// IsCI Checks environment variables to tell if Kurtosis is running in CI
 // This implements this blogpost https://adamj.eu/tech/2020/03/09/detect-if-your-tests-are-running-on-ci/
-func isCI() string {
+func IsCI() bool {
 	for _, environmentVariable := range ciEnvironmentVariables {
 		if _, found := os.LookupEnv(environmentVariable); found {
-			return trueStr
+			return true
 		}
 	}
-	return falseStr
+	return false
 }

--- a/metrics-library/golang/lib/client/is_ci_test.go
+++ b/metrics-library/golang/lib/client/is_ci_test.go
@@ -13,6 +13,6 @@ func TestISCIWhenEnvironmentVariableIsSetSucceeds(t *testing.T) {
 		err := os.Setenv(envVar, envVarValueForTesting)
 		defer os.Unsetenv(envVar)
 		require.Nil(t, err)
-		require.Equal(t, trueStr, isCI())
+		require.True(t, IsCI())
 	}
 }

--- a/metrics-library/golang/lib/client/metrics_client_creator.go
+++ b/metrics-library/golang/lib/client/metrics_client_creator.go
@@ -1,9 +1,7 @@
 package client
 
 import (
-	"github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/source"
 	"github.com/kurtosis-tech/stacktrace"
-	"gopkg.in/segmentio/analytics-go.v3"
 )
 
 const (
@@ -14,24 +12,24 @@ const (
 // the event is enqueued but the queue is flushed suddenly so is pretty close to event traked in sync
 // The argument callbackObject is an object that will be used by the client to notify the
 // application when messages sends to the backend API succeeded or failed.
-func CreateMetricsClient(source source.Source, sourceVersion string, userId string, backendType string, didUserAcceptSendingMetrics bool, shouldFlushQueueOnEachEvent bool, callbackObject Callback, logger analytics.Logger) (MetricsClient, func() error, error) {
+func CreateMetricsClient(options *CreateMetricsClientOption) (MetricsClient, func() error, error) {
 
 	metricsClientType := DoNothing
 
-	if didUserAcceptSendingMetrics {
+	if options.didUserAcceptSendingMetrics {
 		metricsClientType = defaultMetricsType
 	}
 
 	switch metricsClientType {
 	case Segment:
-		segmentCallback := newSegmentCallback(callbackObject.Success, callbackObject.Failure)
-		metricsClient, err := newSegmentClient(source, sourceVersion, userId, backendType, shouldFlushQueueOnEachEvent, segmentCallback, logger)
+		segmentCallback := newSegmentCallback(options.callbackObject.Success, options.callbackObject.Failure)
+		metricsClient, err := newSegmentClient(options.source, options.sourceVersion, options.userId, options.backendType, options.shouldFlushQueueOnEachEvent, segmentCallback, options.logger)
 		if err != nil {
 			return nil, nil, stacktrace.Propagate(err, "An error occurred creating Segment metrics client")
 		}
 		return metricsClient, metricsClient.close, nil
 	case DoNothing:
-		metricsClient := newDoNothingClient(callbackObject)
+		metricsClient := newDoNothingClient(options.callbackObject)
 		return metricsClient, metricsClient.close, nil
 	default:
 		return nil, nil, stacktrace.NewError("Unrecognized metrics client type '%v'", metricsClientType)

--- a/metrics-library/golang/lib/client/metrics_client_creator.go
+++ b/metrics-library/golang/lib/client/metrics_client_creator.go
@@ -23,7 +23,7 @@ func CreateMetricsClient(options *CreateMetricsClientOption) (MetricsClient, fun
 	switch metricsClientType {
 	case Segment:
 		segmentCallback := newSegmentCallback(options.callbackObject.Success, options.callbackObject.Failure)
-		metricsClient, err := newSegmentClient(options.source, options.sourceVersion, options.userId, options.backendType, options.shouldFlushQueueOnEachEvent, segmentCallback, options.logger)
+		metricsClient, err := newSegmentClient(options.source, options.sourceVersion, options.userId, options.backendType, options.shouldFlushQueueOnEachEvent, segmentCallback, options.logger, options.isCI)
 		if err != nil {
 			return nil, nil, stacktrace.Propagate(err, "An error occurred creating Segment metrics client")
 		}

--- a/metrics-library/golang/lib/client/metrics_client_creator_options.go
+++ b/metrics-library/golang/lib/client/metrics_client_creator_options.go
@@ -1,0 +1,37 @@
+package client
+
+import (
+	"github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/source"
+	"gopkg.in/segmentio/analytics-go.v3"
+)
+
+type CreateMetricsClientOption struct {
+	source                      source.Source
+	sourceVersion               string
+	userId                      string
+	backendType                 string
+	didUserAcceptSendingMetrics bool
+	shouldFlushQueueOnEachEvent bool
+	callbackObject              Callback
+	logger                      analytics.Logger
+}
+
+func NewMetricsClientCreatorOption(source source.Source,
+	sourceVersion string,
+	userId string,
+	backendType string,
+	didUserAcceptSendingMetrics bool,
+	shouldFlushQueueOnEachEvent bool,
+	callbackObject Callback,
+	logger analytics.Logger) *CreateMetricsClientOption {
+	return &CreateMetricsClientOption{
+		source:                      source,
+		sourceVersion:               sourceVersion,
+		userId:                      userId,
+		backendType:                 backendType,
+		didUserAcceptSendingMetrics: didUserAcceptSendingMetrics,
+		shouldFlushQueueOnEachEvent: shouldFlushQueueOnEachEvent,
+		callbackObject:              callbackObject,
+		logger:                      logger,
+	}
+}

--- a/metrics-library/golang/lib/client/metrics_client_creator_options.go
+++ b/metrics-library/golang/lib/client/metrics_client_creator_options.go
@@ -14,6 +14,7 @@ type CreateMetricsClientOption struct {
 	shouldFlushQueueOnEachEvent bool
 	callbackObject              Callback
 	logger                      analytics.Logger
+	isCI                        bool
 }
 
 func NewMetricsClientCreatorOption(source source.Source,
@@ -23,7 +24,8 @@ func NewMetricsClientCreatorOption(source source.Source,
 	didUserAcceptSendingMetrics bool,
 	shouldFlushQueueOnEachEvent bool,
 	callbackObject Callback,
-	logger analytics.Logger) *CreateMetricsClientOption {
+	logger analytics.Logger,
+	isCI bool) *CreateMetricsClientOption {
 	return &CreateMetricsClientOption{
 		source:                      source,
 		sourceVersion:               sourceVersion,
@@ -33,5 +35,6 @@ func NewMetricsClientCreatorOption(source source.Source,
 		shouldFlushQueueOnEachEvent: shouldFlushQueueOnEachEvent,
 		callbackObject:              callbackObject,
 		logger:                      logger,
+		isCI:                        isCI,
 	}
 }

--- a/metrics-library/golang/lib/client/segment_client.go
+++ b/metrics-library/golang/lib/client/segment_client.go
@@ -7,6 +7,7 @@ import (
 	"github.com/segmentio/backo-go"
 	"gopkg.in/segmentio/analytics-go.v3"
 	"runtime"
+	"strconv"
 	"time"
 )
 
@@ -44,7 +45,7 @@ type segmentClient struct {
 // the event is enqueued but the queue is flushed suddenly so is pretty close to event traked in sync
 // The argument callbackObject is an object that will be used by the client to notify the
 // application when messages sends to the backend API succeeded or failed.
-func newSegmentClient(source metrics_source.Source, sourceVersion string, userId string, backendType string, shouldFlushQueueOnEachEvent bool, callbackObject analytics.Callback, logger analytics.Logger) (*segmentClient, error) {
+func newSegmentClient(source metrics_source.Source, sourceVersion string, userId string, backendType string, shouldFlushQueueOnEachEvent bool, callbackObject analytics.Callback, logger analytics.Logger, isCI bool) (*segmentClient, error) {
 
 	// nolint: exhaustruct
 	config := analytics.Config{
@@ -86,7 +87,7 @@ func newSegmentClient(source metrics_source.Source, sourceVersion string, userId
 		}
 	}
 
-	return &segmentClient{client: client, analyticsContext: analyticsContext, userID: userId, isCI: isCI(), backendType: backendType}, nil
+	return &segmentClient{client: client, analyticsContext: analyticsContext, userID: userId, isCI: strconv.FormatBool(isCI), backendType: backendType}, nil
 }
 
 func (segment *segmentClient) TrackShouldSendMetricsUserElection(didUserAcceptSendingMetrics bool) error {

--- a/metrics-library/golang/lib/metrics_client/callback.go
+++ b/metrics-library/golang/lib/metrics_client/callback.go
@@ -1,4 +1,4 @@
-package client
+package metrics_client
 
 // Callback methods must return quickly and not cause long blocking operations
 // to avoid interfering with the client's internal work flow.

--- a/metrics-library/golang/lib/metrics_client/do_nothing_client.go
+++ b/metrics-library/golang/lib/metrics_client/do_nothing_client.go
@@ -1,4 +1,4 @@
-package client
+package metrics_client
 
 import "github.com/sirupsen/logrus"
 

--- a/metrics-library/golang/lib/metrics_client/is_ci.go
+++ b/metrics-library/golang/lib/metrics_client/is_ci.go
@@ -1,4 +1,4 @@
-package client
+package metrics_client
 
 import "os"
 

--- a/metrics-library/golang/lib/metrics_client/is_ci_test.go
+++ b/metrics-library/golang/lib/metrics_client/is_ci_test.go
@@ -1,4 +1,4 @@
-package client
+package metrics_client
 
 import (
 	"github.com/stretchr/testify/require"

--- a/metrics-library/golang/lib/metrics_client/metrics_client.go
+++ b/metrics-library/golang/lib/metrics_client/metrics_client.go
@@ -1,4 +1,4 @@
-package client
+package metrics_client
 
 type MetricsClient interface {
 	TrackShouldSendMetricsUserElection(didUserAcceptSendingMetrics bool) error

--- a/metrics-library/golang/lib/metrics_client/metrics_client_creator.go
+++ b/metrics-library/golang/lib/metrics_client/metrics_client_creator.go
@@ -1,4 +1,4 @@
-package client
+package metrics_client
 
 import (
 	"github.com/kurtosis-tech/stacktrace"

--- a/metrics-library/golang/lib/metrics_client/metrics_client_creator_options.go
+++ b/metrics-library/golang/lib/metrics_client/metrics_client_creator_options.go
@@ -1,4 +1,4 @@
-package client
+package metrics_client
 
 import (
 	"github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/source"

--- a/metrics-library/golang/lib/metrics_client/metrics_client_types.go
+++ b/metrics-library/golang/lib/metrics_client/metrics_client_types.go
@@ -1,4 +1,4 @@
-package client
+package metrics_client
 
 const (
 	Segment MetricsClientType = "segment"

--- a/metrics-library/golang/lib/metrics_client/segment_callback.go
+++ b/metrics-library/golang/lib/metrics_client/segment_callback.go
@@ -1,4 +1,4 @@
-package client
+package metrics_client
 
 import (
 	"github.com/sirupsen/logrus"

--- a/metrics-library/golang/lib/metrics_client/segment_client.go
+++ b/metrics-library/golang/lib/metrics_client/segment_client.go
@@ -1,4 +1,4 @@
-package client
+package metrics_client
 
 import (
 	"github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/event"


### PR DESCRIPTION
## Description:
Earlier metrics from the APIC wouldn't get the right value for is_ci as they would look for the CI environment(TF_BUILD, CIRCLE_CI...) variables which our docker container wouldn't contain;

Now

1. CLI figures out if we are running in CI
2. CLI passes the information down to Engine
3. Engine Passes the information down to APIC

So if someone is running in Circle/GitHub actions - wherever the `kurtosis engine restart` happens we get the valid IS_CI value for that CLI