### PR TITLE
fix: user/instance id values were flipped

### DIFF
--- a/cli/cli/commands/kurtosis_context/add/add.go
+++ b/cli/cli/commands/kurtosis_context/add/add.go
@@ -76,8 +76,8 @@ func AddContext(newContextToAdd *generated.KurtosisContext, envVars *string, clo
 			newContextToAdd.GetRemoteContextV0().GetTunnelPort(),
 			newContextToAdd.GetRemoteContextV0().GetTlsConfig(),
 			envVars,
-			cloudInstanceIdCopy,
 			cloudUserIdCopy,
+			cloudInstanceIdCopy,
 		)
 	} else {
 		enrichedContextData = newContextToAdd


### PR DESCRIPTION
Earlier the value of user and instance id were flipped in `kurtosis context add`