### PR TITLE
docs: fix formatting bug in our quickstart

### DIFF
--- a/docs/docs/get-started/quickstart.md
+++ b/docs/docs/get-started/quickstart.md
@@ -34,11 +34,7 @@ Click on the "New Workspace" button! You don't have to worry about the Context U
  
 </details>
 
-<<<<<<< HEAD
 If you ever get stuck, every Kurtosis command accepts a `-h` flag to print helptext. If that doesn't help, feel free to post your question in our [Github Discussions Forum][github-discussions] or ask us in our [Discord server](https://discord.gg/jJFG7XBqcY).
-=======
-If you ever get stuck, every Kurtosis command accepts a `-h` flag to print helptext. If that doesn't help, you can get in touch with us in our [Discord server](https://discord.gg/6Jjp9c89z9) or on [Github](https://github.com/kurtosis-tech/kurtosis/issues/new/choose)!
->>>>>>> main
 
 Install dependencies
 --------------------


### PR DESCRIPTION
## Description:
We messed up something in our quickstart's formatting: 
<img width="993" alt="image" src="https://github.com/kurtosis-tech/kurtosis/assets/103802618/d79ac5b2-7451-4df9-bac3-3f40044f7e77">

This PR fixes this

## Is this change user facing?
YES

## References (if applicable):
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
