### PR TITLE
feat: new emui service logs

### DIFF
--- a/enclave-manager/web/src/client/enclaveManager/KurtosisClient.ts
+++ b/enclave-manager/web/src/client/enclaveManager/KurtosisClient.ts
@@ -6,6 +6,7 @@ import {
   EnclaveAPIContainerInfo,
   EnclaveInfo,
   EnclaveMode,
+  GetServiceLogsArgs,
 } from "enclave-manager-sdk/build/engine_service_pb";
 import { KurtosisEnclaveManagerServer } from "enclave-manager-sdk/build/kurtosis_enclave_manager_api_connect";
 import {
@@ -16,6 +17,7 @@ import {
 } from "enclave-manager-sdk/build/kurtosis_enclave_manager_api_pb";
 import { assertDefined, asyncResult } from "../../utils";
 import { RemoveFunctions } from "../../utils/types";
+import { EnclaveFullInfo } from "../../emui/enclaves/types";
 
 export abstract class KurtosisClient {
   protected readonly client: PromiseClient<typeof KurtosisEnclaveManagerServer>;
@@ -77,6 +79,24 @@ export abstract class KurtosisClient {
       });
       return this.client.getServices(request, this.getHeaderOptions());
     }, "KurtosisClient could not getServices");
+  }
+
+  async getServiceLogs(
+    enclave: RemoveFunctions<EnclaveFullInfo>
+    packageId: string,
+    args: Record<string, any>,
+  ) {
+    // Not currently using asyncResult as the return type here is an asyncIterable
+    const request = new GetServiceLogsArgs({
+      apicIpAddress: apicInfo.bridgeIpAddress,
+      apicPort: apicInfo.grpcPortInsideEnclave,
+      RunStarlarkPackageArgs: new RunStarlarkPackageArgs({
+        dryRun: false,
+        packageId: packageId,
+        serializedParams: JSON.stringify(args),
+      }),
+    });
+    return this.client.getServiceLogs(request, this.getHeaderOptions());
   }
 
   async getStarlarkRun(enclave: RemoveFunctions<EnclaveInfo>) {

--- a/enclave-manager/web/src/client/enclaveManager/LocalKurtosisClient.ts
+++ b/enclave-manager/web/src/client/enclaveManager/LocalKurtosisClient.ts
@@ -6,7 +6,7 @@ import { KurtosisClient } from "./KurtosisClient";
 
 export class LocalKurtosisClient extends KurtosisClient {
   constructor() {
-    const defaultUrl = new URL(window.location.href);
+    const defaultUrl = new URL(`${window.location.protocol}//${window.location.host}`);
     super(
       createPromiseClient(
         KurtosisEnclaveManagerServer,

--- a/enclave-manager/web/src/components/KurtosisBreadcrumbs.tsx
+++ b/enclave-manager/web/src/components/KurtosisBreadcrumbs.tsx
@@ -12,18 +12,27 @@ export type KurtosisBreadcrumb = {
 export const KurtosisBreadcrumbs = () => {
   const matches = useMatches() as UIMatch<
     object,
-    { crumb?: (data: object, params: Params<string>) => KurtosisBreadcrumb | Promise<KurtosisBreadcrumb> }
+    {
+      crumb?: (
+        data: Record<string, object>,
+        params: Params<string>,
+      ) => KurtosisBreadcrumb | Promise<KurtosisBreadcrumb>;
+    }
   >[];
 
   const [matchCrumbs, setMatchCrumbs] = useState<KurtosisBreadcrumb[]>([]);
 
   useEffect(() => {
     (async () => {
+      const allLoaderData = matches
+        .filter((match) => isDefined(match.data))
+        .reduce((acc, match) => ({ ...acc, [match.id]: match.data }), {});
+
       setMatchCrumbs(
         await Promise.all(
           matches
             .map((match) =>
-              isDefined(match.handle?.crumb) ? Promise.resolve(match.handle.crumb(match.data, match.params)) : null,
+              isDefined(match.handle?.crumb) ? Promise.resolve(match.handle.crumb(allLoaderData, match.params)) : null,
             )
             .filter(isDefined),
         ),

--- a/enclave-manager/web/src/components/enclaves/logs/LogLine.tsx
+++ b/enclave-manager/web/src/components/enclaves/logs/LogLine.tsx
@@ -1,13 +1,16 @@
-import { Box } from "@chakra-ui/react";
+import { Box, Flex } from "@chakra-ui/react";
+import { DateTime } from "luxon";
+import { isDefined } from "../../../utils";
 
 export type LogStatus = "info" | "error";
 
 export type LogLineProps = {
+  timestamp?: DateTime;
   message?: string;
   status?: LogStatus;
 };
 
-export const LogLine = ({ message, status }: LogLineProps) => {
+export const LogLine = ({ timestamp, message, status }: LogLineProps) => {
   const statusToColor = (status?: LogStatus) => {
     switch (status) {
       case "error":
@@ -20,19 +23,31 @@ export const LogLine = ({ message, status }: LogLineProps) => {
   };
 
   return (
-    <Box
-      as={"pre"}
-      whiteSpace={"pre-wrap"}
-      borderBottom={"1px solid #444444"}
-      p={"14px 0"}
-      m={"0 16px"}
-      fontSize={"xs"}
-      lineHeight="2"
-      fontWeight={400}
-      fontFamily="Ubuntu Mono"
-      color={statusToColor(status)}
-    >
-      {message || <i>No message</i>}
-    </Box>
+    <Flex borderBottom={"1px solid #444444"} p={"14px 0"} m={"0 16px"} gap={"8px"} alignItems={"center"}>
+      {isDefined(timestamp) && (
+        <Box
+          as={"pre"}
+          whiteSpace={"pre-wrap"}
+          fontSize={"xs"}
+          lineHeight="2"
+          fontWeight={700}
+          fontFamily="Ubuntu Mono"
+          color={"white"}
+        >
+          {timestamp.toLocal().toFormat("yyyy-MM-dd hh:mm:ss.SSS ZZZZ")}
+        </Box>
+      )}
+      <Box
+        as={"pre"}
+        whiteSpace={"pre-wrap"}
+        fontSize={"xs"}
+        lineHeight="2"
+        fontWeight={400}
+        fontFamily="Ubuntu Mono"
+        color={statusToColor(status)}
+      >
+        {message || <i>No message</i>}
+      </Box>
+    </Flex>
   );
 };

--- a/enclave-manager/web/src/components/enclaves/logs/LogViewer.tsx
+++ b/enclave-manager/web/src/components/enclaves/logs/LogViewer.tsx
@@ -22,6 +22,7 @@ export const LogViewer = ({
 }: LogViewerProps) => {
   const virtuosoRef = useRef<VirtuosoHandle>(null);
   const [logLines, setLogLines] = useState(propsLogLines);
+  const [userIsScrolling, setUserIsScrolling] = useState(false);
   const [automaticScroll, setAutomaticScroll] = useState(true);
 
   const throttledSetLogLines = useMemo(() => throttle(setLogLines, 500), []);
@@ -34,6 +35,14 @@ export const LogViewer = ({
     setAutomaticScroll(e.target.checked);
     if (virtuosoRef.current && e.target.checked) {
       virtuosoRef.current.scrollToIndex({ index: "LAST" });
+    }
+  };
+
+  const handleBottomStateChange = (atBottom: boolean) => {
+    if (userIsScrolling) {
+      setAutomaticScroll(atBottom);
+    } else if (automaticScroll && !atBottom) {
+      virtuosoRef.current?.scrollToIndex({ index: "LAST" });
     }
   };
 
@@ -71,7 +80,8 @@ export const LogViewer = ({
         <Virtuoso
           ref={virtuosoRef}
           followOutput={automaticScroll}
-          atBottomStateChange={(atBottom) => setAutomaticScroll(atBottom)}
+          atBottomStateChange={handleBottomStateChange}
+          isScrolling={setUserIsScrolling}
           style={{ height: "660px" }}
           data={logLines.filter(({ message }) => isDefined(message))}
           itemContent={(index, line) => <LogLine {...line} />}

--- a/enclave-manager/web/src/components/enclaves/tables/ServicesTable.tsx
+++ b/enclave-manager/web/src/components/enclaves/tables/ServicesTable.tsx
@@ -25,7 +25,7 @@ type ServicesTableRow = {
 
 const serviceToRow = (service: ServiceInfo): ServicesTableRow => {
   return {
-    serviceUUID: service.serviceUuid,
+    serviceUUID: service.shortenedUuid,
     name: service.name,
     status: service.serviceStatus,
     image: service.container?.imageName,

--- a/enclave-manager/web/src/emui/enclaves/EnclaveRoutes.tsx
+++ b/enclave-manager/web/src/emui/enclaves/EnclaveRoutes.tsx
@@ -4,6 +4,7 @@ import { enclavesAction } from "./action";
 import { Enclave, enclaveLoader, enclaveTabLoader } from "./enclave";
 import { runStarlarkAction } from "./enclave/action";
 import { EnclaveLoaderDeferred } from "./enclave/loader";
+import { Service } from "./enclave/service/Service";
 import { EnclaveList } from "./EnclaveList";
 import { enclavesLoader } from "./loader";
 
@@ -35,7 +36,8 @@ export const enclaveRoutes = (kurtosisClient: KurtosisClient): RouteObject[] => 
         },
         children: [
           {
-            path: "service/:serviceUUID",
+            path: "service/:serviceUUID/:activeTab?",
+            element: <Service />,
           },
           {
             path: "file/:fileUUID",

--- a/enclave-manager/web/src/emui/enclaves/enclave/service/Service.tsx
+++ b/enclave-manager/web/src/emui/enclaves/enclave/service/Service.tsx
@@ -1,0 +1,107 @@
+import { Flex, Spinner, Tab, TabList, TabPanel, TabPanels, Tabs } from "@chakra-ui/react";
+import { ServiceInfo } from "enclave-manager-sdk/build/api_container_service_pb";
+import { FunctionComponent, Suspense } from "react";
+import { Await, useNavigate, useParams, useRouteLoaderData } from "react-router-dom";
+import { EditEnclaveButton } from "../../../../components/enclaves/EditEnclaveButton";
+import { DeleteEnclavesButton } from "../../../../components/enclaves/widgets/DeleteEnclavesButton";
+import { KurtosisAlert } from "../../../../components/KurtosisAlert";
+import { isDefined } from "../../../../utils";
+import { EnclaveFullInfo } from "../../types";
+import { EnclaveLoaderResolved } from "../loader";
+import { ServiceLogs } from "./logs/ServiceLogs";
+import { ServiceOverview } from "./overview/ServiceOverview";
+
+const tabs: { path: string; element: FunctionComponent<{ enclave: EnclaveFullInfo; service: ServiceInfo }> }[] = [
+  { path: "overview", element: ServiceOverview },
+  { path: "logs", element: ServiceLogs },
+];
+
+export const Service = () => {
+  const { data } = useRouteLoaderData("enclave") as EnclaveLoaderResolved;
+
+  return (
+    <Suspense
+      fallback={
+        <Flex justifyContent={"center"} p={"20px"}>
+          <Spinner size={"xl"} />
+        </Flex>
+      }
+    >
+      <Await resolve={data} children={(data) => <MaybeServiceImpl enclave={data.enclave} />} />
+    </Suspense>
+  );
+};
+
+type MaybeServiceImplProps = {
+  enclave: EnclaveLoaderResolved["data"]["enclave"];
+};
+
+const MaybeServiceImpl = ({ enclave: enclaveResult }: MaybeServiceImplProps) => {
+  const { enclaveUUID, serviceUUID } = useParams();
+
+  if (!isDefined(enclaveResult)) {
+    return <KurtosisAlert message={`Could not find enclave ${enclaveUUID}`} />;
+  }
+
+  if (enclaveResult.isErr) {
+    return <KurtosisAlert message={"Enclave could not load"} />;
+  }
+
+  if (enclaveResult.value.services.isErr) {
+    return <KurtosisAlert message={"Services for enclave could not load"} />;
+  }
+
+  const service = Object.values(enclaveResult.value.services.value.serviceInfo).find(
+    (service) => service.shortenedUuid === serviceUUID,
+  );
+  if (!isDefined(service)) {
+    return <KurtosisAlert message={`Could not find service ${serviceUUID}`} />;
+  }
+
+  return <ServiceImpl enclave={enclaveResult.value} service={service} />;
+};
+
+type ServiceImplProps = {
+  enclave: EnclaveFullInfo;
+  service: ServiceInfo;
+};
+
+const ServiceImpl = ({ enclave, service }: ServiceImplProps) => {
+  const navigator = useNavigate();
+  const params = useParams();
+  console.log(params);
+  const activeTab = params.activeTab || "overview";
+  const activeIndex = tabs.findIndex((tab) => tab.path === activeTab);
+
+  const handleTabChange = (newTabIndex: number) => {
+    const tab = tabs[newTabIndex];
+    navigator(`/enclave/${enclave.shortenedUuid}/service/${service.shortenedUuid}/${tab.path}`);
+  };
+
+  return (
+    <Flex direction="column" width={"100%"}>
+      <Tabs isManual isLazy index={activeIndex} onChange={handleTabChange}>
+        <TabList>
+          <Flex justifyContent={"space-between"} width={"100%"}>
+            <TabList>
+              {tabs.map((tab) => (
+                <Tab key={tab.path}>{tab.path}</Tab>
+              ))}
+            </TabList>
+            <Flex gap={"8px"} alignItems={"center"}>
+              <DeleteEnclavesButton enclaves={[enclave]} />
+              <EditEnclaveButton enclave={enclave} />
+            </Flex>
+          </Flex>
+        </TabList>
+        <TabPanels>
+          {tabs.map((tab) => (
+            <TabPanel key={tab.path}>
+              <tab.element enclave={enclave} service={service} />
+            </TabPanel>
+          ))}
+        </TabPanels>
+      </Tabs>
+    </Flex>
+  );
+};

--- a/enclave-manager/web/src/emui/enclaves/enclave/service/Service.tsx
+++ b/enclave-manager/web/src/emui/enclaves/enclave/service/Service.tsx
@@ -69,7 +69,6 @@ type ServiceImplProps = {
 const ServiceImpl = ({ enclave, service }: ServiceImplProps) => {
   const navigator = useNavigate();
   const params = useParams();
-  console.log(params);
   const activeTab = params.activeTab || "overview";
   const activeIndex = tabs.findIndex((tab) => tab.path === activeTab);
 

--- a/enclave-manager/web/src/emui/enclaves/enclave/service/logs/ServiceLogs.tsx
+++ b/enclave-manager/web/src/emui/enclaves/enclave/service/logs/ServiceLogs.tsx
@@ -1,0 +1,11 @@
+import { ServiceInfo } from "enclave-manager-sdk/build/api_container_service_pb";
+import { EnclaveFullInfo } from "../../../types";
+
+type ServiceLogsProps = {
+  enclave: EnclaveFullInfo;
+  service: ServiceInfo;
+};
+
+export const ServiceLogs = ({ enclave, service }: ServiceLogsProps) => {
+  return <div>Hello world</div>;
+};

--- a/enclave-manager/web/src/emui/enclaves/enclave/service/logs/ServiceLogs.tsx
+++ b/enclave-manager/web/src/emui/enclaves/enclave/service/logs/ServiceLogs.tsx
@@ -1,5 +1,19 @@
 import { ServiceInfo } from "enclave-manager-sdk/build/api_container_service_pb";
 import { EnclaveFullInfo } from "../../../types";
+import { useEffect, useState } from "react";
+import { LogLineProps } from "../../../../../components/enclaves/logs/LogLine";
+import { isDefined, stringifyError } from "../../../../../utils";
+import { useKurtosisClient } from "../../../../../client/enclaveManager/KurtosisClientContext";
+import { Timestamp } from "@bufbuild/protobuf";
+import { LogViewer } from "../../../../../components/enclaves/logs/LogViewer";
+import { DateTime } from "luxon";
+
+const serviceLogLineToLogLineProps = (lines: string[], timestamp?: Timestamp): LogLineProps[] => {
+  return lines.map((line) => ({
+    message: line,
+    timestamp: isDefined(timestamp) ? DateTime.fromJSDate(timestamp?.toDate()) : undefined,
+  }));
+};
 
 type ServiceLogsProps = {
   enclave: EnclaveFullInfo;
@@ -7,5 +21,38 @@ type ServiceLogsProps = {
 };
 
 export const ServiceLogs = ({ enclave, service }: ServiceLogsProps) => {
-  return <div>Hello world</div>;
+  const kurtosisClient = useKurtosisClient();
+  const [logLines, setLogLines] = useState<LogLineProps[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    const abortController = new AbortController();
+    (async () => {
+      setLogLines([]);
+      try {
+        for await (const lineGroup of await kurtosisClient.getServiceLogs(abortController, enclave, [service])) {
+          if (cancelled) {
+            return;
+          }
+          const lineGroupForService = lineGroup.serviceLogsByServiceUuid[service.serviceUuid];
+          if (!isDefined(lineGroupForService)) {
+            continue;
+          }
+          const parsedLines = serviceLogLineToLogLineProps(lineGroupForService.line, lineGroupForService.timestamp);
+          setLogLines((logLines) => [...logLines, ...parsedLines]);
+        }
+      } catch (error: any) {
+        if (cancelled) {
+          return;
+        }
+        setLogLines((logLines) => [...logLines, { message: `Error: ${stringifyError(error)}`, status: "error" }]);
+      }
+    })();
+    return () => {
+      cancelled = true;
+      abortController.abort();
+    };
+  }, [enclave, service]);
+
+  return <LogViewer logLines={logLines} />;
 };

--- a/enclave-manager/web/src/emui/enclaves/enclave/service/overview/ServiceOverview.tsx
+++ b/enclave-manager/web/src/emui/enclaves/enclave/service/overview/ServiceOverview.tsx
@@ -1,0 +1,39 @@
+import { Flex, Grid, GridItem, Icon, Text } from "@chakra-ui/react";
+import { ServiceInfo } from "enclave-manager-sdk/build/api_container_service_pb";
+import { IoLogoDocker } from "react-icons/io5";
+import { ServiceStatusTag } from "../../../../../components/enclaves/widgets/ServiceStatus";
+import { FLEX_STANDARD_GAP } from "../../../../../components/theme/constants";
+import { ValueCard } from "../../../../../components/ValueCard";
+
+type ServiceOverviewProps = {
+  service: ServiceInfo;
+};
+
+export const ServiceOverview = ({ service }: ServiceOverviewProps) => {
+  return (
+    <Flex flexDirection={"column"} gap={FLEX_STANDARD_GAP}>
+      <Grid templateColumns={"repeat(4, 1fr)"} gap={FLEX_STANDARD_GAP}>
+        <GridItem>
+          <ValueCard title={"Name"} value={service.name} copyEnabled />
+        </GridItem>
+        <GridItem>
+          <ValueCard title={"UUID"} value={service.shortenedUuid} copyEnabled />
+        </GridItem>
+        <GridItem>
+          <ValueCard title={"Status"} value={<ServiceStatusTag status={service.serviceStatus} variant={"asText"} />} />
+        </GridItem>
+        <GridItem>
+          <ValueCard
+            title={"Image"}
+            value={
+              <Flex>
+                <Icon as={IoLogoDocker} />
+                <Text>{service.container?.imageName || "unknown"}</Text>
+              </Flex>
+            }
+          />
+        </GridItem>
+      </Grid>
+    </Flex>
+  );
+};

--- a/enclave-manager/web/src/emui/enclaves/enclave/service/tabLoader.ts
+++ b/enclave-manager/web/src/emui/enclaves/enclave/service/tabLoader.ts
@@ -1,0 +1,14 @@
+import { LoaderFunctionArgs } from "react-router-dom";
+
+export const serviceTabLoader = async ({ params }: LoaderFunctionArgs): Promise<{ routeName: string }> => {
+  const activeTab = params.activeTab;
+
+  switch (activeTab?.toLowerCase()) {
+    case "overview":
+      return { routeName: "Overview" };
+    case "logs":
+      return { routeName: "Logs" };
+    default:
+      return { routeName: "Overview" };
+  }
+};


### PR DESCRIPTION
## Description:
This change adds support for showing enclave service logs in the new enclave manager ui.

Additionally, this pr contains a partial implementation of the service view ui - full implementation to follow.

### Demo:

In this demo `github.com/kurtosis-tech/log-load-package` is used to demonstrate large quantities of logs don't seem to break following. Additionally, my browser has it's locale set to san francisco - so that browser locale dependent timestamps can be demonstrated.

https://github.com/kurtosis-tech/kurtosis/assets/4419574/533b5f5a-7fdf-40b1-a6c5-e0b67970811c

## Is this change user facing?
YES
