### PR TITLE
fix: kurtosis run considers every nonexistent path to be a URL and fails with a suspicious error

### DIFF
--- a/cli/cli/commands/run/run.go
+++ b/cli/cli/commands/run/run.go
@@ -12,6 +12,7 @@ import (
 	"os/signal"
 	"path"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/kurtosis-tech/kurtosis/api/golang/core/lib/starlark_run_config"
@@ -104,6 +105,8 @@ const (
 
 	imageDownloadFlagKey = "image-download"
 	defaultImageDownload = "missing"
+
+	httpProtocolRegexStr = "^(http|https)://"
 )
 
 var StarlarkRunCmd = &engine_consuming_kurtosis_command.EngineConsumingKurtosisCommand{
@@ -706,20 +709,8 @@ func validateSerializedArgs(serializedArgs string) error {
 
 func getArgsFromFilepathOrURL(packageArgsFile string) (string, error) {
 	var packageArgsFileBytes []byte
-	isFileURL := true
-	_, err := os.Stat(packageArgsFile)
-	if err == nil {
-		isFileURL = false
-		packageArgsFileBytes, err = os.ReadFile(packageArgsFile)
-		if err != nil {
-			return "", stacktrace.Propagate(err, "attempted to read file provided by flag '%v' with path '%v' but failed", packageArgsFileFlagKey, packageArgsFile)
-		}
-	}
-	if err != nil && !os.IsNotExist(err) {
-		return "", stacktrace.Propagate(err, "An error occurred checking for argument's file existence on '%s'", packageArgsFile)
-	}
 
-	if isFileURL {
+	if isHttpUrl(packageArgsFile) {
 		argsFileURL, parseErr := url.Parse(packageArgsFile)
 		if parseErr != nil {
 			return "", stacktrace.Propagate(parseErr, "An error occurred while parsing file args URL '%s'", argsFileURL)
@@ -734,6 +725,16 @@ func getArgsFromFilepathOrURL(packageArgsFile string) (string, error) {
 			return "", stacktrace.Propagate(readAllErr, "An error occurred reading the args file content")
 		}
 		packageArgsFileBytes = responseBodyBytes
+	} else {
+		_, err := os.Stat(packageArgsFile)
+		if err != nil {
+			return "", stacktrace.Propagate(err, "An error occurred checking for argument's file existence on '%s'", packageArgsFile)
+		}
+
+		packageArgsFileBytes, err = os.ReadFile(packageArgsFile)
+		if err != nil {
+			return "", stacktrace.Propagate(err, "attempted to read file provided by flag '%v' with path '%v' but failed", packageArgsFileFlagKey, packageArgsFile)
+		}
 	}
 
 	packageArgsFileStr := string(packageArgsFileBytes)
@@ -742,4 +743,10 @@ func getArgsFromFilepathOrURL(packageArgsFile string) (string, error) {
 	}
 
 	return packageArgsFileStr, nil
+
+}
+
+func isHttpUrl(maybeHttpUrl string) bool {
+	httpProtocolRegex := regexp.MustCompile(httpProtocolRegexStr)
+	return httpProtocolRegex.MatchString(maybeHttpUrl)
 }

--- a/cli/cli/commands/run/run_test.go
+++ b/cli/cli/commands/run/run_test.go
@@ -42,3 +42,35 @@ func TestValidateArgs_invalid(t *testing.T) {
 	err = validatePackageArgs(testCtx, testParsedFlags, parsedArgs)
 	require.NotNil(t, err)
 }
+
+func TestIsHttpUrl_ValidHTTP(t *testing.T) {
+	fileUrl := "http://www.mysite.com/myfile.json"
+
+	isHttpUrlResult := isHttpUrl(fileUrl)
+
+	require.True(t, isHttpUrlResult)
+}
+
+func TestIsHttpUrl_ValidHTTPS(t *testing.T) {
+	fileUrl := "https://www.mysite.com/myfile.json"
+
+	isHttpUrlResult := isHttpUrl(fileUrl)
+
+	require.True(t, isHttpUrlResult)
+}
+
+func TestIsHttpUrl_NoValidBecauseIsAbsoluteFilepath(t *testing.T) {
+	fileUrl := "/my-folder/myfile.json"
+
+	isHttpUrlResult := isHttpUrl(fileUrl)
+
+	require.False(t, isHttpUrlResult)
+}
+
+func TestIsHttpUrl_NoValidBecauseIsRelativeFilepath(t *testing.T) {
+	fileUrl := "../my-folder/myfile.json"
+
+	isHttpUrlResult := isHttpUrl(fileUrl)
+
+	require.False(t, isHttpUrlResult)
+}


### PR DESCRIPTION
## Description:
kurtosis run considers every nonexistent path to be a URL and fails with a suspicious error

## Is this change user facing?
YES

## References (if applicable):
Fix #1705 
