### PR TITLE
fix: new emui correct handling of Bool input type

### DIFF
--- a/enclave-manager/web/src/components/enclaves/configuration/KurtosisPackageArgumentInput.tsx
+++ b/enclave-manager/web/src/components/enclaves/configuration/KurtosisPackageArgumentInput.tsx
@@ -31,7 +31,7 @@ export const KurtosisPackageArgumentInput = ({ argument, disabled }: KurtosisPac
       helperText={argument.description}
     >
       <KurtosisArgumentTypeInput
-        type={argument.typeV2?.topLevelType || ArgumentValueType.JSON}
+        type={argument.typeV2?.topLevelType || ArgumentValueType.BOOL}
         subType1={argument.typeV2?.innerType1}
         subType2={argument.typeV2?.innerType2}
         name={fieldName}

--- a/enclave-manager/web/src/components/enclaves/configuration/KurtosisPackageArgumentInput.tsx
+++ b/enclave-manager/web/src/components/enclaves/configuration/KurtosisPackageArgumentInput.tsx
@@ -31,7 +31,7 @@ export const KurtosisPackageArgumentInput = ({ argument, disabled }: KurtosisPac
       helperText={argument.description}
     >
       <KurtosisArgumentTypeInput
-        type={argument.typeV2?.topLevelType || ArgumentValueType.BOOL}
+        type={argument.typeV2?.topLevelType}
         subType1={argument.typeV2?.innerType1}
         subType2={argument.typeV2?.innerType2}
         name={fieldName}

--- a/enclave-manager/web/src/components/enclaves/configuration/inputs/KurtosisArgumentTypeInput.tsx
+++ b/enclave-manager/web/src/components/enclaves/configuration/inputs/KurtosisArgumentTypeInput.tsx
@@ -10,7 +10,7 @@ import { ListArgumentInput } from "./ListArgumentInput";
 import { StringArgumentInput } from "./StringArgumentInput";
 
 export type KurtosisArgumentTypeInputProps = {
-  type: ArgumentValueType;
+  type?: ArgumentValueType;
   subType1?: ArgumentValueType;
   subType2?: ArgumentValueType;
   name: FieldPath<ConfigureEnclaveForm>;

--- a/enclave-manager/web/src/components/enclaves/configuration/utils.ts
+++ b/enclave-manager/web/src/components/enclaves/configuration/utils.ts
@@ -15,7 +15,7 @@ export function argTypeToString(argType?: ArgumentValueType) {
     case ArgumentValueType.STRING:
       return "string";
     default:
-      return "unknown";
+      return "json";
   }
 }
 
@@ -31,6 +31,6 @@ export function argToTypeString(arg: PackageArg) {
     case ArgumentValueType.LIST:
       return `${argTypeToString(arg.typeV2.innerType1)}[]`;
     default:
-      return "unknown";
+      return "json";
   }
 }


### PR DESCRIPTION
## Description:
This PR corrects the enclave configuration form input to use boolean if a package argument type is boolean - which is enum value 0 and was previously treated as falsy.

### Screenshot of fix
![image](https://github.com/kurtosis-tech/kurtosis/assets/4419574/a14f2ac8-f35b-4454-b6cc-cd06d66ca0c0)



## Is this change user facing?
YES
