### PR TITLE
feat: configured CORS logs in the enclave manager server inside the Kurtosis engine

### DIFF
--- a/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/docker_kurtosis_backend_api_container_functions.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/docker_kurtosis_backend_api_container_functions.go
@@ -43,6 +43,8 @@ func (backend *DockerKurtosisBackend) CreateAPIContainer(
 	ownIpAddressEnvVar string,
 	customEnvVars map[string]string,
 ) (*api_container.APIContainer, error) {
+	logrus.Debugf("Creating the APIC for enclave '%v'", enclaveUuid)
+
 	// Verify no API container already exists in the enclave
 	apiContainersInEnclaveFilters := &api_container.APIContainerFilters{
 		EnclaveIDs: map[enclave.EnclaveUUID]bool{
@@ -203,6 +205,7 @@ func (backend *DockerKurtosisBackend) CreateAPIContainer(
 		return nil, stacktrace.Propagate(err, "An error occurred waiting for the API container's grpc port to become available")
 	}
 
+	logrus.Debugf("Checking for the APIC availability in enclave '%v'...", enclaveUuid)
 	if err := shared_helpers.WaitForPortAvailabilityUsingNetstat(
 		ctx,
 		backend.dockerManager,
@@ -213,6 +216,7 @@ func (backend *DockerKurtosisBackend) CreateAPIContainer(
 	); err != nil {
 		return nil, stacktrace.Propagate(err, "An error occurred waiting for the API container's grpc port to become available")
 	}
+	logrus.Debugf("...APIC is available in enclave '%v'", enclaveUuid)
 
 	bridgeNetworkIpAddress, err := backend.dockerManager.GetContainerIP(ctx, consts.NameOfNetworkToStartEngineAndLogServiceContainersIn, containerId)
 	if err != nil {
@@ -223,6 +227,8 @@ func (backend *DockerKurtosisBackend) CreateAPIContainer(
 	if err != nil {
 		return nil, stacktrace.Propagate(err, "An error occurred creating an API container object from container with ID '%v'", containerId)
 	}
+
+	logrus.Debugf("APIC for enclave '%v' successfully created", enclaveUuid)
 
 	shouldKillContainer = false
 	return result, nil

--- a/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/logs_collector_functions/create_logs_collector.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/logs_collector_functions/create_logs_collector.go
@@ -37,7 +37,7 @@ func CreateLogsCollectorForEnclave(
 	*logs_collector.LogsCollector,
 	error,
 ) {
-
+	logrus.Debugf("Creating logs collector for enclave '%v'", enclaveUuid)
 	preExistingLogsCollectorContainers, err := getLogsCollectorForTheGivenEnclave(ctx, enclaveUuid, dockerManager)
 	if err != nil {
 		return nil, stacktrace.Propagate(err, "An error occurred getting logs collector containers for given enclave '%v'", enclaveUuid)
@@ -118,9 +118,12 @@ func CreateLogsCollectorForEnclave(
 
 	logsCollectorAvailabilityChecker := fluentbit.NewFluentbitAvailabilityChecker(logsCollectorObj.GetBridgeNetworkIpAddress(), logsCollectorObj.GetPrivateHttpPort().GetNumber())
 
+	logrus.Debugf("Checking for logs collector availability in enclave '%v'...", enclaveUuid)
 	if err = logsCollectorAvailabilityChecker.WaitForAvailability(); err != nil {
 		return nil, stacktrace.Propagate(err, "An error occurred while waiting for the log container to become available")
 	}
+	logrus.Debugf("...logs collector is available in enclave '%v'", enclaveUuid)
+	logrus.Debugf("Logs collector successfully created with container ID '%v' for enclave '%v'", containerId, enclaveUuid)
 
 	shouldDisconnectLogsCollectorFromEnclaveNetwork = false
 	shouldRemoveLogsCollectorContainerFunc = false

--- a/enclave-manager/server/server.go
+++ b/enclave-manager/server/server.go
@@ -520,7 +520,11 @@ func RunEnclaveManagerApiServer(enforceAuth bool) error {
 		handler,
 		apiPath,
 	)
-	if err := apiServer.RunServerUntilInterruptedWithCors(cors.AllowAll()); err != nil {
+
+	emCors := cors.AllowAll()
+	emCors.Log = logrus.StandardLogger()
+
+	if err := apiServer.RunServerUntilInterruptedWithCors(emCors); err != nil {
 		logrus.Error("An error occurred running the server", err)
 	}
 	return nil


### PR DESCRIPTION
## Description:
configured CORS logs in the enclave manager server inside the Kurtosis engine

## Is this change user facing?
NO

## References (if applicable):
Related to [this ticket](https://github.com/kurtosis-tech/kurtosis/issues/1768), we need to see the logs
