### PR TITLE
fix: emui log line overflow

### DIFF
--- a/enclave-manager/web/src/components/enclaves/logs/LogLine.tsx
+++ b/enclave-manager/web/src/components/enclaves/logs/LogLine.tsx
@@ -56,6 +56,7 @@ export const LogLine = ({ timestamp, message, status }: LogLineProps) => {
       <Box
         as={"pre"}
         whiteSpace={"pre-wrap"}
+        overflowWrap={"anywhere"}
         fontSize={"xs"}
         lineHeight="2"
         fontWeight={400}


### PR DESCRIPTION
## Description:
Log lines in the emui were previously overflowing on the x axis causing lower scroll bars to appear on the log viewer. This meant that the auto scroll behaviour would be disengaged whenever a very long line appeared. This PR fixes that issue

### demo with ethereum package

https://github.com/kurtosis-tech/kurtosis/assets/4419574/67ea042e-466b-429c-bead-9fa9d49e1180

## Is this change user facing?
YES
