### PR TITLE
chore: make sure that the webapp is available for the engine in the engine publish step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1103,6 +1103,10 @@ jobs:
           version="$(cat version.txt)"
           "<<pipeline.parameters.generate-kurtosis-version-script-path>>" $version
 
+      - attach_workspace:
+          at: "<< pipeline.parameters.workspace-with-cli-binary-and-images-mountpoint >>"
+
+      - run: cp -R << pipeline.parameters.workspace-with-cli-binary-and-images-mountpoint >>/webapp engine/server/webapp
 
       - setup_remote_docker:
           version: "<< pipeline.parameters.docker-engine-version>>"
@@ -1429,6 +1433,8 @@ workflows:
           context:
             - docker-user
             - slack-secrets
+          requires:
+            - build_enclave_manager_webapp
           filters:
             branches:
               ignore: /.*/


### PR DESCRIPTION
## Description
This PR makes the enclave manager web ui available during the engine build step - this should fix the issue seen here https://app.circleci.com/pipelines/github/kurtosis-tech/kurtosis/9327/workflows/48587b79-2de3-4f3f-9b2f-3d0a6bf184b2/jobs/129862

## Is this change user facing?
YES/NO
No

## References (if applicable):
* https://app.circleci.com/pipelines/github/kurtosis-tech/kurtosis/9327/workflows/48587b79-2de3-4f3f-9b2f-3d0a6bf184b2/jobs/129862
