### PR TITLE
fix: make run_python not create additional files artifact

### DIFF
--- a/core/server/api_container/server/startosis_engine/kurtosis_instruction/tasks/run_python.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_instruction/tasks/run_python.go
@@ -37,17 +37,7 @@ const (
 
 	pipInstallCmd = "pip install"
 
-	pythonScriptFileName = "main.py"
-	pythonWorkspace      = "/tmp/python"
-
-	defaultTmpDir                  = ""
-	pythonScriptReadPermission     = 0644
-	enforceMaxSizeLimit            = true
-	temporaryPythonDirectoryPrefix = "run-python-*"
-
 	successfulPipRunExitCode = 0
-
-	scriptArtifactFormat = "%v-python-script"
 )
 
 func NewRunPythonService(serviceNetwork service_network.ServiceNetwork, runtimeValueStore *runtime_value_store.RuntimeValueStore) *kurtosis_plan_instruction.KurtosisPlanInstruction {

--- a/core/server/api_container/server/startosis_engine/kurtosis_instruction/tasks/run_python.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_instruction/tasks/run_python.go
@@ -22,7 +22,6 @@ import (
 	"github.com/kurtosis-tech/stacktrace"
 	"github.com/xtgo/uuid"
 	"go.starlark.net/starlark"
-	"path"
 	"strings"
 )
 
@@ -352,9 +351,8 @@ func getPythonCommandToRun(builtin *RunPythonCapabilities) (string, error) {
 	}
 	argumentsAsString := strings.Join(maybePythonArgumentsWithRuntimeValueReplaced, spaceDelimiter)
 
-	pythonScriptAbsolutePath := path.Join(pythonWorkspace, pythonScriptFileName)
 	if len(argumentsAsString) > 0 {
 		return fmt.Sprintf("python -c '%s' %s", builtin.run, argumentsAsString), nil
 	}
-	return fmt.Sprintf("python %s", pythonScriptAbsolutePath), nil
+	return fmt.Sprintf("python -c '%s'", builtin.run), nil
 }


### PR DESCRIPTION
## Description:
we'd create a files artifact which would

1. make interpret depend on service network - an anti pattern
2. bloat enclave inspect

This fixes both; tested against etheruem-package
