### PR TITLE
fix: deprecate ConnectServices, remove calls to it

### DIFF
--- a/api/golang/core/lib/enclaves/enclave_context.go
+++ b/api/golang/core/lib/enclaves/enclave_context.go
@@ -429,6 +429,7 @@ func (enclaveCtx *EnclaveContext) GetAllFilesArtifactNamesAndUuids(ctx context.C
 }
 
 // Docs available at https://docs.kurtosis.com/sdk#connectservices
+// Deprecated: currently a no-op that we're removing
 func (enclaveCtx *EnclaveContext) ConnectServices(ctx context.Context, connect kurtosis_core_rpc_api_bindings.Connect) error {
 	args := binding_constructors.NewConnectServicesArgs(connect)
 	_, err := enclaveCtx.client.ConnectServices(ctx, args)

--- a/cli/cli/commands/run/run.go
+++ b/cli/cli/commands/run/run.go
@@ -355,11 +355,6 @@ func run(
 	var cancelFunc context.CancelFunc
 	var errRunningKurtosis error
 
-	connect := kurtosis_core_rpc_api_bindings.Connect_CONNECT
-	if noConnect {
-		connect = kurtosis_core_rpc_api_bindings.Connect_NO_CONNECT
-	}
-
 	isRemotePackage := strings.HasPrefix(starlarkScriptOrPackagePath, githubDomainPrefix)
 	if isRemotePackage {
 		responseLineChan, cancelFunc, errRunningKurtosis = executeRemotePackage(ctx, enclaveCtx, starlarkScriptOrPackagePath, starlarkRunConfig)
@@ -393,10 +388,6 @@ func run(
 
 	errRunningKurtosis = ReadAndPrintResponseLinesUntilClosed(responseLineChan, cancelFunc, verbosity, dryRun)
 
-	if err = enclaveCtx.ConnectServices(ctx, connect); err != nil {
-		logrus.Warnf("An error occurred configuring the user services port forwarding\nError was: %v", err)
-	}
-
 	servicesInEnclavePostRun, servicesInEnclaveError := enclaveCtx.GetServices()
 	if servicesInEnclaveError != nil {
 		logrus.Warn("Tried getting number of services in the enclave to log metrics but failed")
@@ -426,7 +417,7 @@ func run(
 		return nil
 	}
 
-	if connect == kurtosis_core_rpc_api_bindings.Connect_NO_CONNECT {
+	if noConnect {
 		logrus.Info("Not forwarding user service ports locally as requested")
 		return nil
 	}


### PR DESCRIPTION
## Description:
We won't end up using `ConnectServices` so I'm removing the call to it first of all.

Once this calling code is no longer running out there, we can drop the protobuf definition and linked code.  Doing it all at once will probably break things post-upgrade, where people have pre-existing APICs running. 

## Is this change user facing?
NO
<!-- If yes, please add the "user facing" label to the PR -->
<!-- If yes, don't forget to include docs changes where relevant -->

## References (if applicable):
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
