### PR TITLE
fix: only print image banner if image arch is non empty string and different

### DIFF
--- a/core/server/api_container/server/startosis_engine/startosis_validator.go
+++ b/core/server/api_container/server/startosis_engine/startosis_validator.go
@@ -32,6 +32,8 @@ const (
 	containerImageArchitectureMsgLineFormat = "> %s - %s"
 
 	linebreak = "\n"
+
+	emptyImageArchitecture = ""
 )
 
 type StartosisValidator struct {
@@ -221,15 +223,17 @@ func sendContainerImageSummaryInfoMsg(
 			pulledFromStr = containerDownloadedImagesMsgFromRemote
 		}
 
+		imageLine := fmt.Sprintf(containerDownloadedImagesMsgLineFormat, image, pulledFromStr)
+		imageLines = append(imageLines, imageLine)
+
 		architecture := validatedImage.GetArchitecture()
 
-		if architecture != runtime.GOARCH {
+		if architecture == emptyImageArchitecture {
+			logrus.Debugf("Couldn't fetch image architecture for '%v'; this is expected on k8s backend but not docker", image)
+		} else if architecture != runtime.GOARCH {
 			imageWithIncorrectArchLine := fmt.Sprintf(containerImageArchitectureMsgLineFormat, image, architecture)
 			imagesWithIncorrectArchLines = append(imagesWithIncorrectArchLines, imageWithIncorrectArchLine)
 		}
-
-		imageLine := fmt.Sprintf(containerDownloadedImagesMsgLineFormat, image, pulledFromStr)
-		imageLines = append(imageLines, imageLine)
 	}
 
 	msgLines := []string{containerDownloadedImagesMsgHeader}


### PR DESCRIPTION
Closes #1780 

we'd print the image arch banner incorrectly on k8s as the k8s backend would return ""