### PR TITLE
fix: move log collector creation logic

### DIFF
--- a/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/docker_kurtosis_backend_enclave_functions.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/docker_kurtosis_backend_enclave_functions.go
@@ -23,9 +23,6 @@ const (
 
 	shouldFetchStoppedContainersWhenDumpingEnclave = true
 
-	defaultHttpLogsCollectorPortNum = uint16(9712)
-	defaultTcpLogsCollectorPortNum  = uint16(9713)
-
 	serializedArgs = "SERIALIZED_ARGS"
 )
 
@@ -148,21 +145,7 @@ func (backend *DockerKurtosisBackend) CreateEnclave(ctx context.Context, enclave
 
 	// TODO: return production mode for create enclave request as well
 	newEnclave := enclave.NewEnclave(enclaveUuid, enclaveName, enclave.EnclaveStatus_Empty, &creationTime, false)
-	// TODO the logs collector has a random private ip address in the enclave network that must be tracked
-	if _, err := backend.CreateLogsCollectorForEnclave(ctx, enclaveUuid, defaultTcpLogsCollectorPortNum, defaultHttpLogsCollectorPortNum); err != nil {
-		return nil, stacktrace.Propagate(err, "An error occurred creating the logs collector with TCP port number '%v' and HTTP port number '%v'", defaultTcpLogsCollectorPortNum, defaultHttpLogsCollectorPortNum)
-	}
-	shouldDeleteLogsCollector := true
-	defer func() {
-		if shouldDeleteLogsCollector {
-			err = backend.DestroyLogsCollectorForEnclave(ctx, enclaveUuid)
-			if err != nil {
-				logrus.Errorf("Couldn't cleanup logs collector for enclave '%v' as the following error was thrown:\n%v", enclaveUuid, err)
-			}
-		}
-	}()
 
-	shouldDeleteLogsCollector = false
 	shouldDeleteNetwork = false
 	shouldDeleteVolume = false
 	return newEnclave, nil

--- a/engine/server/engine/enclave_manager/enclave_creator.go
+++ b/engine/server/engine/enclave_manager/enclave_creator.go
@@ -83,13 +83,12 @@ func (creator *EnclaveCreator) CreateEnclave(
 	}()
 
 	// only create log collector for backend as
-	var shouldDeleteLogsCollector bool
+	shouldDeleteLogsCollector := true
 	if kurtosisBackendType == args.KurtosisBackendType_Docker {
 		// TODO the logs collector has a random private ip address in the enclave network that must be tracked
 		if _, err := creator.kurtosisBackend.CreateLogsCollectorForEnclave(setupCtx, enclaveUuid, defaultTcpLogsCollectorPortNum, defaultHttpLogsCollectorPortNum); err != nil {
 			return nil, stacktrace.Propagate(err, "An error occurred creating the logs collector with TCP port number '%v' and HTTP port number '%v'", defaultTcpLogsCollectorPortNum, defaultHttpLogsCollectorPortNum)
 		}
-		shouldDeleteLogsCollector = true
 		defer func() {
 			if shouldDeleteLogsCollector {
 				err = creator.kurtosisBackend.DestroyLogsCollectorForEnclave(teardownCtx, enclaveUuid)
@@ -113,7 +112,6 @@ func (creator *EnclaveCreator) CreateEnclave(
 		cloudUserID,
 		cloudInstanceID,
 	)
-
 	if err != nil {
 		return nil, stacktrace.Propagate(err, "An error occurred launching the API container")
 	}

--- a/engine/server/engine/enclave_manager/enclave_creator.go
+++ b/engine/server/engine/enclave_manager/enclave_creator.go
@@ -13,6 +13,11 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const (
+	defaultHttpLogsCollectorPortNum = uint16(9712)
+	defaultTcpLogsCollectorPortNum  = uint16(9713)
+)
+
 type EnclaveCreator struct {
 	kurtosisBackend                           backend_interface.KurtosisBackend
 	apiContainerKurtosisBackendConfigSupplier api_container_launcher.KurtosisBackendConfigSupplier
@@ -71,6 +76,20 @@ func (creator *EnclaveCreator) CreateEnclave(
 			for enclaveUuid, err := range destroyEnclaveErrs {
 				logrus.Errorf("Expected to be able to cleanup the enclave '%v', but an error was thrown:\n%v", enclaveUuid, err)
 				logrus.Errorf(manualActionRequiredStrFmt, enclaveUuid)
+			}
+		}
+	}()
+
+	// TODO the logs collector has a random private ip address in the enclave network that must be tracked
+	if _, err := creator.kurtosisBackend.CreateLogsCollectorForEnclave(setupCtx, enclaveUuid, defaultTcpLogsCollectorPortNum, defaultHttpLogsCollectorPortNum); err != nil {
+		return nil, stacktrace.Propagate(err, "An error occurred creating the logs collector with TCP port number '%v' and HTTP port number '%v'", defaultTcpLogsCollectorPortNum, defaultHttpLogsCollectorPortNum)
+	}
+	shouldDeleteLogsCollector := true
+	defer func() {
+		if shouldDeleteLogsCollector {
+			err = creator.kurtosisBackend.DestroyLogsCollectorForEnclave(teardownCtx, enclaveUuid)
+			if err != nil {
+				logrus.Errorf("Couldn't cleanup logs collector for enclave '%v' as the following error was thrown:\n%v", enclaveUuid, err)
 			}
 		}
 	}()
@@ -155,8 +174,9 @@ func (creator *EnclaveCreator) CreateEnclave(
 	}
 
 	// Everything started successfully, so the responsibility of deleting the enclave is now transferred to the caller
-	shouldDestroyEnclave = false
 	shouldStopApiContainer = false
+	shouldDeleteLogsCollector = false
+	shouldDestroyEnclave = false
 	return newEnclaveInfo, nil
 }
 

--- a/engine/server/engine/enclave_manager/enclave_creator.go
+++ b/engine/server/engine/enclave_manager/enclave_creator.go
@@ -8,6 +8,7 @@ import (
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/enclave"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/uuid_generator"
 	"github.com/kurtosis-tech/kurtosis/core/launcher/api_container_launcher"
+	"github.com/kurtosis-tech/kurtosis/engine/launcher/args"
 	"github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/metrics_client"
 	"github.com/kurtosis-tech/stacktrace"
 	"github.com/sirupsen/logrus"
@@ -48,6 +49,7 @@ func (creator *EnclaveCreator) CreateEnclave(
 	isCI bool,
 	cloudUserID metrics_client.CloudUserID,
 	cloudInstanceID metrics_client.CloudInstanceID,
+	kurtosisBackendType args.KurtosisBackendType,
 ) (*kurtosis_engine_rpc_api_bindings.EnclaveInfo, error) {
 
 	uuid, err := uuid_generator.GenerateUUIDString()
@@ -80,19 +82,23 @@ func (creator *EnclaveCreator) CreateEnclave(
 		}
 	}()
 
-	// TODO the logs collector has a random private ip address in the enclave network that must be tracked
-	if _, err := creator.kurtosisBackend.CreateLogsCollectorForEnclave(setupCtx, enclaveUuid, defaultTcpLogsCollectorPortNum, defaultHttpLogsCollectorPortNum); err != nil {
-		return nil, stacktrace.Propagate(err, "An error occurred creating the logs collector with TCP port number '%v' and HTTP port number '%v'", defaultTcpLogsCollectorPortNum, defaultHttpLogsCollectorPortNum)
-	}
-	shouldDeleteLogsCollector := true
-	defer func() {
-		if shouldDeleteLogsCollector {
-			err = creator.kurtosisBackend.DestroyLogsCollectorForEnclave(teardownCtx, enclaveUuid)
-			if err != nil {
-				logrus.Errorf("Couldn't cleanup logs collector for enclave '%v' as the following error was thrown:\n%v", enclaveUuid, err)
-			}
+	// only create log collector for backend as
+	var shouldDeleteLogsCollector bool
+	if kurtosisBackendType == args.KurtosisBackendType_Docker {
+		// TODO the logs collector has a random private ip address in the enclave network that must be tracked
+		if _, err := creator.kurtosisBackend.CreateLogsCollectorForEnclave(setupCtx, enclaveUuid, defaultTcpLogsCollectorPortNum, defaultHttpLogsCollectorPortNum); err != nil {
+			return nil, stacktrace.Propagate(err, "An error occurred creating the logs collector with TCP port number '%v' and HTTP port number '%v'", defaultTcpLogsCollectorPortNum, defaultHttpLogsCollectorPortNum)
 		}
-	}()
+		shouldDeleteLogsCollector = true
+		defer func() {
+			if shouldDeleteLogsCollector {
+				err = creator.kurtosisBackend.DestroyLogsCollectorForEnclave(teardownCtx, enclaveUuid)
+				if err != nil {
+					logrus.Errorf("Couldn't cleanup logs collector for enclave '%v' as the following error was thrown:\n%v", enclaveUuid, err)
+				}
+			}
+		}()
+	}
 
 	apiContainer, err := creator.launchApiContainer(setupCtx,
 		apiContainerImageVersionTag,

--- a/engine/server/engine/enclave_manager/enclave_manager.go
+++ b/engine/server/engine/enclave_manager/enclave_manager.go
@@ -55,6 +55,7 @@ type EnclaveManager struct {
 	mutex *sync.Mutex
 
 	kurtosisBackend                           backend_interface.KurtosisBackend
+	kurtosisBackendType                       args.KurtosisBackendType
 	apiContainerKurtosisBackendConfigSupplier api_container_launcher.KurtosisBackendConfigSupplier
 
 	// this is a stop gap solution, this would be stored and retrieved from the DB in the future
@@ -104,8 +105,9 @@ func CreateEnclaveManager(
 	}
 
 	enclaveManager := &EnclaveManager{
-		mutex:           &sync.Mutex{},
-		kurtosisBackend: kurtosisBackend,
+		mutex:               &sync.Mutex{},
+		kurtosisBackend:     kurtosisBackend,
+		kurtosisBackendType: kurtosisBackendType,
 		apiContainerKurtosisBackendConfigSupplier: apiContainerKurtosisBackendConfigSupplier,
 		allExistingAndHistoricalIdentifiers:       []*kurtosis_engine_rpc_api_bindings.EnclaveIdentifiers{},
 		enclaveCreator:                            enclaveCreator,
@@ -189,6 +191,7 @@ func (manager *EnclaveManager) CreateEnclave(
 			manager.isCI,
 			manager.cloudUserID,
 			manager.cloudInstanceID,
+			manager.kurtosisBackendType,
 		)
 		if err != nil {
 			return nil, stacktrace.Propagate(

--- a/engine/server/engine/enclave_manager/enclave_pool.go
+++ b/engine/server/engine/enclave_manager/enclave_pool.go
@@ -6,6 +6,7 @@ import (
 	"github.com/kurtosis-tech/kurtosis/api/golang/engine/kurtosis_engine_rpc_api_bindings"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/enclave"
+	"github.com/kurtosis-tech/kurtosis/engine/launcher/args"
 	"github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/metrics_client"
 	"github.com/kurtosis-tech/stacktrace"
 	"github.com/sirupsen/logrus"
@@ -45,6 +46,7 @@ type EnclavePool struct {
 // 3- Will start a subroutine in charge of filling the pool
 func CreateEnclavePool(
 	kurtosisBackend backend_interface.KurtosisBackend,
+
 	enclaveCreator *EnclaveCreator,
 	poolSize uint8,
 	engineVersion string,
@@ -289,6 +291,7 @@ func (pool *EnclavePool) createNewIdleEnclave(ctx context.Context) (*kurtosis_en
 		pool.isCI,
 		pool.cloudUserID,
 		pool.cloudInstanceID,
+		args.KurtosisBackendType_Kubernetes, // enclave pool only available for k8s
 	)
 	if err != nil {
 		return nil, stacktrace.Propagate(


### PR DESCRIPTION
## Description:
Fixes: https://github.com/kurtosis-tech/kurtosis/issues/1833

The resource leak was being caused by a state where if a failure occurred while creating an enclave (eg. ctrl+C while running `kurtosis enclave add`) at a point where the log collector container was created BEFORE it had been connected to the network AND before the necessary `defer undo`s to clean up the log collector had been queued THEN the network would get cleaned up by the `defer undo` from `CreateNetwork`, but the log collector container would remain.

Any attempt to do a `kurtosis clean -a` would fail to clean log collector container because the network(and thus enclave) the container was created for had already been cleaned up.

After digging - I realized the log collector was being created in `container-engine-lib` as opposed to in the `engine` Moving the logic to the engine AFTER the enclave is created fixes the issue. If there is an error at ANY point in the creation of the log collector container (even if the log collectors `defer undo` hasn't been queued), the `defer undo` from the `CreateEnclave` call will clean the log collector because it has a label with the `enclaveUUID`.

## Is this change user facing?
NO

## References:
https://github.com/kurtosis-tech/kurtosis/issues/1833
