### PR TITLE
docs: remove cloud early access signup form

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Check out an introductory demo video here:
 
 How do I get going?
 ===================
-To see Kurtosis in action, first install it using the instructions [here](https://docs.kurtosis.com/install). _Note that we're working on a cloud-hosted version of Kurtosis that doesn't require any local installation; if this is interesting to you then let us know [here](https://mp2k8nqxxgj.typeform.com/to/U1HcXT1H) and we'll let you know when it's available._
+To see Kurtosis in action, first install it using the instructions [here](https://docs.kurtosis.com/install) or visit [Kurtosis Cloud][https://cloud.kurtosis.com/] to provision a remote host.
 
 Then, run the [Redis voting app Kurtosis package](https://github.com/kurtosis-tech/awesome-kurtosis/tree/main/redis-voting-app):
 

--- a/docs/docs/guides/running-in-k8s.md
+++ b/docs/docs/guides/running-in-k8s.md
@@ -24,7 +24,7 @@ There are many different ways to get a Kubernetes cluster (roughly ordered easie
 - Deploy it on a managed Kuberenetes cluster, managing scaling and configurations yourself (e.g. EKS, AKS, GKE)
 
 :::tip Kurtosis Kloud Early Access
-If you're looking to run a stress-free "Kurtosis on Kubernetes in the cloud", look no further! We're excited to launch an early access offering for [Kurtosis Kloud](https://mp2k8nqxxgj.typeform.com/to/U1HcXT1H). Once you [sign up](https://mp2k8nqxxgj.typeform.com/to/U1HcXT1H), we'll reach out to you with the next steps.
+If you're looking to run a stress-free "Kurtosis on Kubernetes in the cloud", look no further! Check out [Kurtosis Cloud](https://cloud.kurtosis.com/).
 :::
 
 


### PR DESCRIPTION
## Description:
Cloud is real now and works amazingly. This PR replaces mentions of an early sign-up form for Beta access to Cloud with an actual link to cloud.kurtosis.com. 

The old form was made and put in our docs to collect early feedback and design partners in the absence of an actual product for people to try. We now have a real cloud offering for people to try.

## Is this change user facing?
YES

## References (if applicable):
https://kurtosistech.slack.com/archives/C051H93B6DV/p1701435264644419
