### PR TITLE
docs: add link to release notes from our docs

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -93,6 +93,11 @@ const config = {
 						label: 'Kurtosis for Web3',
 					},
 					{
+						href: 'https://www.kurtosis.com/release-notes',
+						position: 'left',
+						label: 'Release Notes',
+					},
+					{
 						href: 'https://github.com/kurtosis-tech/kurtosis/issues/new?assignees=leeederek&labels=docs&template=docs-issue.yml',
 						position: 'right',
 						label: 'Report Docs Issue',


### PR DESCRIPTION
## Description:
We removed the banner link for our release notes from the website landing page. As a result, this PR adds a link to the [release notes](https://www.kurtosis.com/release-notes) *from our docs*. See screenshot below for what it looks like:

<img width="1136" alt="image" src="https://github.com/kurtosis-tech/kurtosis/assets/103802618/e4cbe49b-4d26-4523-ae9b-399ba523a968">


## Is this change user facing?
YES

## References (if applicable):
https://kurtosistech.slack.com/archives/C051H93B6DV/p1701716258320209
