### PR TITLE
docs: add starlark writing tips to more places in the docs

### DIFF
--- a/docs/docs/api-reference/starlark-reference/index.md
+++ b/docs/docs/api-reference/starlark-reference/index.md
@@ -9,6 +9,22 @@ pagination_next: api-reference/starlark-reference/standard-library
 
 This section details the Kurtosis Starlark DSL used to manipulate the contents of enclaves. Feel free to use the [official Kurtosis Starlark VS Code extension][vscode-plugin] when writing Starlark with VSCode for features like syntax highlighting, method signature suggestions, hover preview for functions, and auto-completion for Kurtosis custom types.
 
+Useful tips for using and writing Starlark
+------------------------------------------
+If you're using Visual Studio Code, you may find our [Kurtosis VS Code Extension][vscode-plugin] helpful when writing Starlark.
+
+If you're using Vim, you can add the following to your `.vimrc` to get Starlark syntax highlighting:
+
+```
+" Add syntax highlighting for Starlark files
+autocmd FileType *.star setlocal filetype=python
+```
+
+or if you use Neovim:
+```
+autocmd BufNewFile,BufRead *.star set filetype=python
+```
+
 Parameter Naming Convention
 ---------------------------
 

--- a/docs/docs/best-practices.md
+++ b/docs/docs/best-practices.md
@@ -48,11 +48,26 @@ Kurtosis service names implements [RFC-1035](https://datatracker.ietf.org/doc/ht
 
 Failure to adhere to the above standards will result in errors when running Kurtosis.
 
+Writing and reading Starlark
+----------------------------
 
+If you're using Visual Studio Code, you may find our [Kurtosis VS Code Extension][vscode-plugin] helpful when writing Starlark.
+
+If you're using Vim, you can add the following to your `.vimrc` to get Starlark syntax highlighting:
+
+```
+" Add syntax highlighting for Starlark files
+autocmd FileType *.star setlocal filetype=python
+```
+
+or if you use Neovim:
+```
+autocmd BufNewFile,BufRead *.star set filetype=python
+```
 
 <!---------------------------------------- ONLY LINKS BELOW HERE!!! ----------------------------------->
 [package-parameterization]: ./advanced-concepts/packages.md#parameterization
-
+[vscode-plugin]: https://marketplace.visualstudio.com/items?itemName=Kurtosis.kurtosis-extension
 [service-config-starlark-reference]: ./api-reference/starlark-reference/service-config.md
 [port-spec-starlark-reference]: ./api-reference/starlark-reference/port-spec.md
 [ready-condition-starlark-reference]: ./api-reference/starlark-reference/ready-condition.md

--- a/docs/docs/get-started/get-started.md
+++ b/docs/docs/get-started/get-started.md
@@ -80,24 +80,3 @@ kurtosis run github.com/kurtosis-tech/basic-service-package \
 ![service-c-partying.png](/img/home/service-c-k8s.png)
  
 </details>
-
-Writing and reading Starlark
-----------------------------
-The Starlark programming language is used to manipulate the contents of environments spun up with Kurtosis. Read more about Starlark and why we chose to use it [here](../advanced-concepts/why-kurtosis-starlark.md).
-
-If you're using Visual Studio Code to write and edit Starlark in Kurtosis packages, you may find our [Kurtosis VS Code Extension][vscode-plugin] helpful when writing Starlark.
-
-If you're using Vim, you can add the following to your `.vimrc` to get Starlark syntax highlighting:
-
-```
-" Add syntax highlighting for Starlark files
-autocmd FileType *.star setlocal filetype=python
-```
-
-or if you use Neovim:
-```
-autocmd BufNewFile,BufRead *.star set filetype=python
-```
-
-<!--------------- ONLY LINKS BELOW THIS POINT ---------------------->
-[vscode-plugin]: https://marketplace.visualstudio.com/items?itemName=Kurtosis.kurtosis-extension

--- a/docs/docs/get-started/get-started.md
+++ b/docs/docs/get-started/get-started.md
@@ -80,3 +80,24 @@ kurtosis run github.com/kurtosis-tech/basic-service-package \
 ![service-c-partying.png](/img/home/service-c-k8s.png)
  
 </details>
+
+Writing and reading Starlark
+----------------------------
+The Starlark programming language is used to manipulate the contents of environments spun up with Kurtosis. Read more about Starlark and why we chose to use it [here](../advanced-concepts/why-kurtosis-starlark.md).
+
+If you're using Visual Studio Code to write and edit Starlark in Kurtosis packages, you may find our [Kurtosis VS Code Extension][vscode-plugin] helpful when writing Starlark.
+
+If you're using Vim, you can add the following to your `.vimrc` to get Starlark syntax highlighting:
+
+```
+" Add syntax highlighting for Starlark files
+autocmd FileType *.star setlocal filetype=python
+```
+
+or if you use Neovim:
+```
+autocmd BufNewFile,BufRead *.star set filetype=python
+```
+
+<!--------------- ONLY LINKS BELOW THIS POINT ---------------------->
+[vscode-plugin]: https://marketplace.visualstudio.com/items?itemName=Kurtosis.kurtosis-extension

--- a/docs/docs/get-started/write-your-first-package.md
+++ b/docs/docs/get-started/write-your-first-package.md
@@ -67,6 +67,10 @@ If you're using Vim, you can add the following to your `.vimrc` to get Starlark 
 autocmd FileType *.star setlocal filetype=python
 ```
 
+or if you use Neovim:
+```
+autocmd BufNewFile,BufRead *.star set filetype=python
+```
 :::
 
 Finally, [run][kurtosis-run-reference] the script (we'll explain enclaves in the "Review" section):


### PR DESCRIPTION
## Description:
We have fielded questions from many users about tips and tricks to make writing and reading Starlark easier. This PR adds our top 3 Starlark tips (VSCode plugin, Vim syntax highlighting and Neovim syntax highlighting) to various parts of our docs. Namely:
- Best Practices section
- Get started section
- Expanded the tip box in our "write your own package" quickstart
- Starlark introduction page

## Is this change user facing?
YES

## References (if applicable):
https://discord.com/channels/783719264308953108/1131048810861314169/1180239655376015360
