### PR TITLE
fix: Fix doc checker CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,7 +123,7 @@ version: 2.1
 
 orbs:
   npm-publisher: uraway/npm-publisher@0.2.0
-  kurtosis-docs-checker: kurtosis-tech/docs-checker@0.2.4
+  kurtosis-docs-checker: kurtosis-tech/docs-checker@0.2.6
   slack: circleci/slack@4.10.1
 
 executors:
@@ -1143,7 +1143,7 @@ workflows:
     jobs:
       # -- build jobs ------------------------------------------
       - kurtosis-docs-checker/check-docs:
-          dir-to-exclude: '"./docs/*"'
+          dir-to-exclude: '^(./docs/*|./CHANGELOG.md)'
           should-check-changelog: false
           markdown-link-check-config-json: |
             {


### PR DESCRIPTION
## Description:
This PR fixes the doc check Ci job that is failing to check all the links in the CHANGELOG file. The link in this file are auto generated and they grow unbounded on each merge. Therefore we decided to exclude it from the doc checker job.

## Is this change user facing?
NO

## References (if applicable):
- also need this: https://github.com/kurtosis-tech/kurtosis-docs-checker-orb/pull/20