### PR TITLE
fix: make push cli job use golang 1.20

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -467,6 +467,8 @@ jobs:
             - "<< pipeline.parameters.engine-server-image-filename >>"
 
   build_cli:
+    # we use this docker/tilt-releaser image for cli jobs because starlark-lsp requires it to build
+    # as opposed to running image off cimg/go:<< pipeline.parameters.go-version like every other job
     docker:
       - image: "docker/tilt-releaser@sha256:ff4a71c0d18717cc9c646778cc426a0a4f916885c5fe7eb001f0eaee0d3483a0"
     resource_class: large
@@ -1177,6 +1179,8 @@ jobs:
           scripts/docker-image-builder.sh "${push_to_dockerhub}" "${dockerfile_filepath}" "${image_name_with_version}" "${image_name_to_publish_semver}" "${image_name_to_publish_latest}"
 
   push_cli_artifacts:
+    # we use this docker/tilt-releaser image for cli jobs because starlark-lsp requires it to build
+    # as opposed to running image off cimg/go:<< pipeline.parameters.go-version like every other job
     docker:
       - image: "docker/tilt-releaser@sha256:ff4a71c0d18717cc9c646778cc426a0a4f916885c5fe7eb001f0eaee0d3483a0"
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1178,7 +1178,7 @@ jobs:
 
   push_cli_artifacts:
     docker:
-      - image: "docker/tilt-releaser@sha256:31e51c6441faa5021a20ebe84cf974145d2975f792dd880a5d1c2fa578818458"
+      - image: "docker/tilt-releaser@sha256:ff4a71c0d18717cc9c646778cc426a0a4f916885c5fe7eb001f0eaee0d3483a0"
     steps:
       - slack/notify:
           channel: engineering


### PR DESCRIPTION
## Description:
Updates `push_cli_artifacts` job to use an image based on golang 1.20.

## Is this change user facing?
NO

