### PR TITLE
fix: bust cli build cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -192,7 +192,7 @@ parameters:
   # We can bump the version here if we ever need to bust the cache
   cli-build-cache-key-prefix:
     type: string
-    default: "cli-go-mod-v1"
+    default: "cli-go-mod-v2"
   generate-kurtosis-version-script-path:
     type: string
     default: "scripts/generate-kurtosis-version.sh"


### PR DESCRIPTION
arm64_darwin isn't working; wondering if its got something to do with the cache being dirty