### PR TITLE
fix: enclave name in error message

### DIFF
--- a/engine/server/engine/server/engine_connect_server_service.go
+++ b/engine/server/engine/server/engine_connect_server_service.go
@@ -189,7 +189,7 @@ func (service *EngineConnectServerService) CreateEnclave(ctx context.Context, co
 		isProduction,
 	)
 	if err != nil {
-		return nil, stacktrace.Propagate(err, "An error occurred creating new enclave with name '%v'", args.EnclaveName)
+		return nil, stacktrace.Propagate(err, "An error occurred creating new enclave with name '%v'", args.GetEnclaveName())
 	}
 
 	grpcEnclaveInfo := toGrpcEnclaveInfo(*enclaveInfo)


### PR DESCRIPTION
We were printing a pointer instead of the name