### PR TITLE
fix: Set the user service K8S ingress labels so it can be found

### DIFF
--- a/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/user_services_functions/start_user_services.go
+++ b/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/user_services_functions/start_user_services.go
@@ -438,6 +438,7 @@ func createStartServiceOperation(
 		if err != nil {
 			return nil, stacktrace.Propagate(err, "An error occurred getting attributes for new ingress for service with UUID '%v'", serviceUuid)
 		}
+		ingressLabelsStrs := shared_helpers.GetStringMapFromLabelMap(ingressAttributes.GetLabels())
 		ingressAnnotationsStrs := shared_helpers.GetStringMapFromAnnotationMap(ingressAttributes.GetAnnotations())
 
 		ingressRules, err := getUserServiceIngressRules(serviceRegistrationObj, privatePorts)
@@ -452,6 +453,7 @@ func createStartServiceOperation(
 				ctx,
 				namespaceName,
 				ingressName,
+				ingressLabelsStrs,
 				ingressAnnotationsStrs,
 				ingressRules,
 			)

--- a/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_manager/kubernetes_manager.go
+++ b/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_manager/kubernetes_manager.go
@@ -1792,7 +1792,7 @@ func (manager *KubernetesManager) HasComputeNodes(ctx context.Context) (bool, er
 
 // ---------------------------Ingresses------------------------------------------------------------------------------
 
-func (manager *KubernetesManager) CreateIngress(ctx context.Context, namespace string, name string, annotations map[string]string, rules []netv1.IngressRule) (*netv1.Ingress, error) {
+func (manager *KubernetesManager) CreateIngress(ctx context.Context, namespace string, name string, labels map[string]string, annotations map[string]string, rules []netv1.IngressRule) (*netv1.Ingress, error) {
 	client := manager.kubernetesClientSet.NetworkingV1().Ingresses(namespace)
 
 	ingress := &netv1.Ingress{
@@ -1813,7 +1813,7 @@ func (manager *KubernetesManager) CreateIngress(ctx context.Context, namespace s
 			},
 			DeletionTimestamp:          nil,
 			DeletionGracePeriodSeconds: nil,
-			Labels:                     nil,
+			Labels:                     labels,
 			Annotations:                annotations,
 			OwnerReferences:            nil,
 			Finalizers:                 nil,

--- a/container-engine-lib/lib/backend_impls/kubernetes/object_attributes_provider/enclave_object_attributes_provider.go
+++ b/container-engine-lib/lib/backend_impls/kubernetes/object_attributes_provider/enclave_object_attributes_provider.go
@@ -258,7 +258,7 @@ func (provider *kubernetesEnclaveObjectAttributesProviderImpl) ForUserServiceIng
 			serviceUUID,
 		)
 	}
-	labels[kubernetes_label_key.KurtosisResourceTypeKubernetesLabelKey] = label_value_consts.UserServiceKurtosisResourceTypeKubernetesLabelValue
+	labels[kubernetes_label_key.KurtosisResourceTypeKubernetesLabelKey] = label_value_consts.UserServiceIngressKurtosisResourceTypeKubernetesLabelValue
 
 	traefikIngressRouterEntrypointsAnnotationValue, err := kubernetes_annotation_value.CreateNewKubernetesAnnotationValue(traefikIngressRouterEntrypointsValue)
 	if err != nil {

--- a/container-engine-lib/lib/backend_impls/kubernetes/object_attributes_provider/enclave_object_attributes_provider.go
+++ b/container-engine-lib/lib/backend_impls/kubernetes/object_attributes_provider/enclave_object_attributes_provider.go
@@ -258,7 +258,7 @@ func (provider *kubernetesEnclaveObjectAttributesProviderImpl) ForUserServiceIng
 			serviceUUID,
 		)
 	}
-	labels[kubernetes_label_key.KurtosisResourceTypeKubernetesLabelKey] = label_value_consts.UserServiceIngressKurtosisResourceTypeKubernetesLabelValue
+	labels[kubernetes_label_key.KurtosisResourceTypeKubernetesLabelKey] = label_value_consts.UserServiceKurtosisResourceTypeKubernetesLabelValue
 
 	traefikIngressRouterEntrypointsAnnotationValue, err := kubernetes_annotation_value.CreateNewKubernetesAnnotationValue(traefikIngressRouterEntrypointsValue)
 	if err != nil {

--- a/container-engine-lib/lib/backend_impls/kubernetes/object_attributes_provider/label_value_consts/label_value_consts.go
+++ b/container-engine-lib/lib/backend_impls/kubernetes/object_attributes_provider/label_value_consts/label_value_consts.go
@@ -15,9 +15,9 @@ const (
 	engineKurtosisResourceTypeLabelValueStr = "kurtosis-engine"
 	// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! DO NOT CHANGE THESE VALUES !!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-	enclaveKurtosisResourceTypeLabelValueStr            = "enclave"
-	apiContainerKurtosisResourceTypeLabelValueStr       = "api-container"
-	userServiceKurtosisResourceTypeLabelValueStr        = "user-service"
+	enclaveKurtosisResourceTypeLabelValueStr      = "enclave"
+	apiContainerKurtosisResourceTypeLabelValueStr = "api-container"
+	userServiceKurtosisResourceTypeLabelValueStr  = "user-service"
 
 	enclaveDataVolumeTypeLabelValueStr             = "enclave-data"
 	filesArtifactsExpansionVolumeTypeLabelValueStr = "files-artifacts-expansion"

--- a/container-engine-lib/lib/backend_impls/kubernetes/object_attributes_provider/label_value_consts/label_value_consts.go
+++ b/container-engine-lib/lib/backend_impls/kubernetes/object_attributes_provider/label_value_consts/label_value_consts.go
@@ -18,7 +18,6 @@ const (
 	enclaveKurtosisResourceTypeLabelValueStr            = "enclave"
 	apiContainerKurtosisResourceTypeLabelValueStr       = "api-container"
 	userServiceKurtosisResourceTypeLabelValueStr        = "user-service"
-	userServiceIngressKurtosisResourceTypeLabelValueStr = "user-service-ingress"
 
 	enclaveDataVolumeTypeLabelValueStr             = "enclave-data"
 	filesArtifactsExpansionVolumeTypeLabelValueStr = "files-artifacts-expansion"
@@ -37,7 +36,5 @@ var EngineKurtosisResourceTypeKubernetesLabelValue = kubernetes_label_value.Must
 var EnclaveKurtosisResourceTypeKubernetesLabelValue = kubernetes_label_value.MustCreateNewKubernetesLabelValue(enclaveKurtosisResourceTypeLabelValueStr)
 var APIContainerKurtosisResourceTypeKubernetesLabelValue = kubernetes_label_value.MustCreateNewKubernetesLabelValue(apiContainerKurtosisResourceTypeLabelValueStr)
 var UserServiceKurtosisResourceTypeKubernetesLabelValue = kubernetes_label_value.MustCreateNewKubernetesLabelValue(userServiceKurtosisResourceTypeLabelValueStr)
-var UserServiceIngressKurtosisResourceTypeKubernetesLabelValue = kubernetes_label_value.MustCreateNewKubernetesLabelValue(userServiceIngressKurtosisResourceTypeLabelValueStr)
-
 var EnclaveDataVolumeTypeKubernetesLabelValue = kubernetes_label_value.MustCreateNewKubernetesLabelValue(enclaveDataVolumeTypeLabelValueStr)
 var FilesArtifactsExpansionVolumeTypeKubernetesLabelValue = kubernetes_label_value.MustCreateNewKubernetesLabelValue(filesArtifactsExpansionVolumeTypeLabelValueStr)


### PR DESCRIPTION
## Description:
The user service K8S ingress labels need to be set properly so the ingress can be found during retrieval and deletion operations.

## Is this change user facing?
NO

## References (if applicable):
#1941 
