### PR TITLE
fix: Do not fail if the Traefik config dir path already exists

### DIFF
--- a/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/reverse_proxy_functions/implementations/traefik/traefik_container_config_provider.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/reverse_proxy_functions/implementations/traefik/traefik_container_config_provider.go
@@ -51,7 +51,7 @@ func (traefik *traefikContainerConfigProvider) GetContainerArgs(
 	overrideCmd := []string{
 		shCmdFlag,
 		fmt.Sprintf(
-			"%v '%v' && %v '%v' > %v && %v",
+			"%v -p '%v' && %v '%v' > %v && %v",
 			mkdirCmdName,
 			configDirpath,
 			printfCmdName,


### PR DESCRIPTION
## Description:
There is a race condition between Traefik and us trying to create the config dir.

## Is this change user facing?
NO
