### PR TITLE
chore: fix clean yarn start in emui

### DIFF
--- a/enclave-manager/web/package.json
+++ b/enclave-manager/web/package.json
@@ -37,9 +37,9 @@
     "build:cloudDev": "dotenv -e packages/app/.env.cloudDevelopment -- lerna run --stream build",
     "prettier": "prettier . --check",
     "prettier:fix": "prettier . --write",
-    "start": "REACT_APP_VERSION=$(git fetch origin --tags -q && git describe --dirty --match '[0-9]*' --tags)-development lerna run --stream --scope @kurtosis/emui-app start",
-    "start:cloud": "REACT_APP_VERSION=$(git fetch origin --tags -q && git describe --dirty --match '[0-9]*' --tags)-cloudDevelopment lerna run --stream --scope @kurtosis/emui-app start:cloud",
-    "start:prod": "lerna run --stream --scope @kurtosis/emui-app start:prod",
+    "start": "REACT_APP_VERSION=$(git fetch origin --tags -q && git describe --dirty --match '[0-9]*' --tags)-development lerna run --stream --parallel start",
+    "start:cloud": "REACT_APP_VERSION=$(git fetch origin --tags -q && git describe --dirty --match '[0-9]*' --tags)-cloudDevelopment lerna run --stream --parallel start:cloud",
+    "start:prod": "lerna run --stream --parallel start:prod",
     "test": "lerna run test"
   },
   "workspaces": {

--- a/enclave-manager/web/packages/app/package.json
+++ b/enclave-manager/web/packages/app/package.json
@@ -23,8 +23,9 @@
   "scripts": {
     "analyze": "source-map-explorer 'build/static/js/*.js'",
     "clean": "rm -rf build",
-    "start": "PORT=4000 craco start",
-    "start:cloud": "BROWSER=none PUBLIC_URL=http://localhost:3000/emui-dev PORT=4000 dotenv -e ./.env.cloudDevelopment -- craco start",
+    "waitForComponentsBuild": "scripts/wait-until-file-exists.sh ../components/build/index.js",
+    "start": "yarn waitForComponentsBuild && PORT=4000 craco start",
+    "start:cloud": "yarn waitForComponentsBuild && BROWSER=none PUBLIC_URL=http://localhost:3000/emui-dev PORT=4000 dotenv -e ./.env.cloudDevelopment -- craco start",
     "start:prod": "serve -p 4000 -s build",
     "build": "craco build",
     "test": "craco test",

--- a/enclave-manager/web/packages/app/scripts/wait-until-file-exists.sh
+++ b/enclave-manager/web/packages/app/scripts/wait-until-file-exists.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# 2021-07-08 WATERMARK, DO NOT REMOVE - This script was generated from the Kurtosis Bash script template
+
+set -euo pipefail   # Bash "strict mode"
+
+# ==================================================================================================
+#                                       Arg Parsing & Validation
+# ==================================================================================================
+show_helptext_and_exit() {
+    echo "Usage: $(basename "${0}") file_name"
+    echo ""
+    echo "  file_name         The file to wait to exist"
+    echo ""
+    exit 1  # Exit with an error so that if this is accidentally called by CI, the script will fail
+}
+
+file_name="${1:-}"
+
+if [ -z "${file_name}" ]; then
+    echo "Error: No file to wait for provided" >&2
+    show_helptext_and_exit
+fi
+
+# ==================================================================================================
+#                                             Main Logic
+# ==================================================================================================
+# Block until the given file appears or the given timeout is reached.
+# Exit status is 0 iff the file exists.
+wait_file() {
+  local file="$1"; shift
+  local wait_seconds="${1:-30}"; shift # 30 seconds as default timeout
+  test $wait_seconds -lt 1 && echo 'At least 1 second is required' && return 1
+
+  until test $((wait_seconds--)) -eq 0 -o -e "$file" ; do sleep 1; done
+
+  test $wait_seconds -ge 0 # equivalent: let ++wait_seconds
+}
+
+wait_file "$file_name" 30
+exit 0

--- a/enclave-manager/web/packages/components/package.json
+++ b/enclave-manager/web/packages/components/package.json
@@ -20,6 +20,7 @@
   },
   "homepage": "https://github.com/kurtosis-tech/kurtosis",
   "scripts": {
+    "start": "tsc --watch --preserveWatchOutput",
     "build": "rm -rf build/; tsc"
   },
   "eslintConfig": {


### PR DESCRIPTION
## Description:
After the EMUI refactor to a multipackage build running `yarn start` on a clean checkout failed with `Can't resolve: 'kurtosis-ui-components'`.

This failure was because the `build/` output is not present on a clean checkout. Additionally, by referencing components `build` directory, rather than `src`, hot reloading changes to the components in the emui was also not working.

![image](https://github.com/kurtosis-tech/kurtosis/assets/4419574/46242777-5fbb-4cba-979b-f9a7dba073bf)

This PR fixes this issue by:
* Adding a `start` script to the components package, which hot rebuilds on changes (via ` tsc --watch`). This enables the app to reload on changes to the `components` source.
* Waits for the `components/build` directory to be populated before running the development server of the `app` - this enables it to initially load correctly.

## Is this change user facing?
NO

## References (if applicable):
https://sageroomworkspace.slack.com/archives/C05DZ4UABDZ/p1702590613774869?thread_ts=1702549439.774119&cid=C05DZ4UABDZ
