### PR TITLE
fix: Rust version upgraded to v1.70.0 for fixing the publish Rust SDK CI job,

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,7 +166,7 @@ parameters:
   # the same version as the server
   rust-version:
     type: string
-    default: 1.68.2
+    default: 1.70.0
   api-node-version:
     type: string
     default: 16.13.0


### PR DESCRIPTION
## Description:
<!-- Describe this change, how it works, and the motivation behind it. -->

## Is this change user facing?
YES

## References (if applicable):
The publish Rust SDK job was failing because one of the dependencies needs this new version, error here> https://app.circleci.com/pipelines/github/kurtosis-tech/kurtosis/10302/workflows/68049b61-fa4f-44da-8e3b-d36b49c93974/jobs/146354
