### PR TITLE
fix: destroying the current reverse proxy if it can't be used to create a new one during the `CreateReverseProxy` process

### DIFF
--- a/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/reverse_proxy_functions/create_reverse_proxy.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/reverse_proxy_functions/create_reverse_proxy.go
@@ -26,17 +26,22 @@ func CreateReverseProxy(
 	func(),
 	error,
 ) {
-	_, found, err := getReverseProxyContainer(ctx, dockerManager)
+	proxyDockerContainer, found, err := getReverseProxyContainer(ctx, dockerManager)
 	if err != nil {
 		return nil, nil, stacktrace.Propagate(err, "An error occurred getting reverse proxy container.")
 	}
 	if found {
 		logrus.Debugf("Found existing reverse proxy; cannot start a new one.")
-		reverseProxyObj, _, err := getReverseProxyObjectAndContainerId(ctx, dockerManager)
-		if err != nil {
-			return nil, nil, stacktrace.Propagate(err, "An error occurred getting existing reverse proxy.")
+		reverseProxyObj, _, getProxyObjErr := getReverseProxyObjectAndContainerId(ctx, dockerManager)
+		if getProxyObjErr == nil {
+			return reverseProxyObj, nil, nil
 		}
-		return reverseProxyObj, nil, nil
+		logrus.Debugf("Something failed while trying to create the reverse proxy object using container with ID '%s'. Error was:\n%s", proxyDockerContainer.GetId(), getProxyObjErr.Error())
+		logrus.Debugf("Destroying the failing reverse proxy to create a new one...")
+		if destroyProxyContainerErr := destroyReverseProxyWithContainerId(ctx, dockerManager, proxyDockerContainer.GetId()); destroyProxyContainerErr != nil {
+			return nil, nil, stacktrace.Propagate(err, "an error occurred destroying the current reverse proxy that was failing to create a new one")
+		}
+		logrus.Debugf("... current reverse proxy successfully destroyed, starting a new one now.")
 	}
 
 	reverseProxyNetwork, err := shared_helpers.GetEngineAndLogsComponentsNetwork(ctx, dockerManager)

--- a/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/reverse_proxy_functions/destroy_reverse_proxy.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/reverse_proxy_functions/destroy_reverse_proxy.go
@@ -24,13 +24,20 @@ func DestroyReverseProxy(ctx context.Context, dockerManager *docker_manager.Dock
 		return nil
 	}
 
-	if err := dockerManager.StopContainer(ctx, maybeReverseProxyContainerId, stopReverseProxyContainerTimeout); err != nil {
-		return stacktrace.Propagate(err, "An error occurred stopping the reverse proxy container with ID '%v'", maybeReverseProxyContainerId)
+	if err := destroyReverseProxyWithContainerId(ctx, dockerManager, maybeReverseProxyContainerId); err != nil {
+		return stacktrace.Propagate(err, "An error occurred destroying the reverse proxy container with ID '%v'", maybeReverseProxyContainerId)
 	}
 
-	if err := dockerManager.RemoveContainer(ctx, maybeReverseProxyContainerId); err != nil {
-		return stacktrace.Propagate(err, "An error occurred removing the reverse proxy container with ID '%v'", maybeReverseProxyContainerId)
+	return nil
+}
+
+func destroyReverseProxyWithContainerId(ctx context.Context, dockerManager *docker_manager.DockerManager, reverseProxyContainerId string) error {
+	if err := dockerManager.StopContainer(ctx, reverseProxyContainerId, stopReverseProxyContainerTimeout); err != nil {
+		return stacktrace.Propagate(err, "An error occurred stopping the reverse proxy container with ID '%v'", reverseProxyContainerId)
 	}
 
+	if err := dockerManager.RemoveContainer(ctx, reverseProxyContainerId); err != nil {
+		return stacktrace.Propagate(err, "An error occurred removing the reverse proxy container with ID '%v'", reverseProxyContainerId)
+	}
 	return nil
 }


### PR DESCRIPTION
## Description:
destroying the current reverse proxy if it can't be used to create a new one during the `CreateReverseProxy` process

## Is this change user facing?
NO

## References (if applicable):
should fix the error reported by [Barnabas here](https://kurtosistech.slack.com/archives/C032ZB39AHH/p1703066620206599) 
