### PR TITLE
fix: nil pointer error found in the `kurtosis clean -a` cmd, adding remove reverse proxy container function when it already exists

### DIFF
--- a/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/reverse_proxy_functions/destroy_reverse_proxy.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/reverse_proxy_functions/destroy_reverse_proxy.go
@@ -16,7 +16,7 @@ const (
 func DestroyReverseProxy(ctx context.Context, dockerManager *docker_manager.DockerManager) error {
 	_, maybeReverseProxyContainerId, err := getReverseProxyObjectAndContainerId(ctx, dockerManager)
 	if err != nil {
-		logrus.Warnf("Attempted to destroy reverse proxy but no reverse proxy container was found.")
+		logrus.Warnf("Attempted to destroy reverse proxy but no reverse proxy container was found. Error was:\n%s", err.Error())
 		return nil
 	}
 


### PR DESCRIPTION
## Description:
fix: nil pointer error found in the `kurtosis clean -a` cmd, adding remove reverse proxy container function when it already exists

## Is this change user-facing?
YES

## References (if applicable):
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
