### PR TITLE
fix: in api/golang go.mod use a fixed version of the new utils sub package

### DIFF
--- a/api/golang/go.mod
+++ b/api/golang/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/kurtosis-tech/kurtosis/cloud/api/golang v0.0.0-20230803130419-099ee7a4e3dc
 	github.com/kurtosis-tech/kurtosis/contexts-config-store v0.0.0-20230818184218-f4e3e773463b
 	github.com/kurtosis-tech/kurtosis/grpc-file-transfer/golang v0.0.0-20230803130419-099ee7a4e3dc
-	github.com/kurtosis-tech/kurtosis/utils v0.0.0-00010101000000-000000000000
+	github.com/kurtosis-tech/kurtosis/utils v0.0.0-20240104153602-385833de9d76  // this version needs to be fixed for outside people to import api/golang
 	github.com/kurtosis-tech/stacktrace v0.0.0-20211028211901-1c67a77b5409
 	github.com/labstack/echo/v4 v4.11.3
 	github.com/oapi-codegen/runtime v1.1.0

--- a/cli/cli/go.mod
+++ b/cli/cli/go.mod
@@ -111,7 +111,7 @@ require (
 	github.com/klauspost/compress v1.17.2 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.5 // indirect
 	github.com/kurtosis-tech/kurtosis/grpc-file-transfer/golang v0.0.0 // indirect
-	github.com/kurtosis-tech/kurtosis/utils v0.0.0-00010101000000-000000000000 // indirect
+	github.com/kurtosis-tech/kurtosis/utils v0.0.0-20240104153602-385833de9d76 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-shellwords v1.0.12 // indirect


### PR DESCRIPTION
Using 0.0.0 doesn't really work for people who are trying to import us from the outside world