### PR TITLE
fix: log streaming resource leaks

### DIFF
--- a/engine/server/engine/centralized_logs/client_implementations/persistent_volume/stream_logs_strategy/per_week_stream_logs_strategy.go
+++ b/engine/server/engine/centralized_logs/client_implementations/persistent_volume/stream_logs_strategy/per_week_stream_logs_strategy.go
@@ -376,6 +376,10 @@ func (strategy *PerWeekStreamLogsStrategy) followLogs(
 	if err != nil {
 		return stacktrace.Propagate(err, "An error occurred while attempting to tail the log file.")
 	}
+	defer func() {
+		logTail.Stop()
+		logTail.Cleanup()
+	}()
 
 	for {
 		select {

--- a/engine/server/engine/centralized_logs/client_implementations/persistent_volume/stream_logs_strategy/per_week_stream_logs_strategy.go
+++ b/engine/server/engine/centralized_logs/client_implementations/persistent_volume/stream_logs_strategy/per_week_stream_logs_strategy.go
@@ -6,6 +6,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
 	"github.com/hpcloud/tail"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/enclave"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/service"
@@ -16,11 +22,6 @@ import (
 	"github.com/kurtosis-tech/stacktrace"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/exp/slices"
-	"io"
-	"os"
-	"strconv"
-	"strings"
-	"time"
 )
 
 const (
@@ -99,7 +100,7 @@ func (strategy *PerWeekStreamLogsStrategy) StreamLogs(
 
 	if shouldFollowLogs {
 		latestLogFile := paths[len(paths)-1]
-		if err := strategy.followLogs(latestLogFile, logsByKurtosisUserServiceUuidChan, serviceUuid, conjunctiveLogLinesFiltersWithRegex); err != nil {
+		if err := strategy.followLogs(ctx, latestLogFile, logsByKurtosisUserServiceUuidChan, serviceUuid, conjunctiveLogLinesFiltersWithRegex); err != nil {
 			streamErrChan <- stacktrace.Propagate(err, "An error occurred creating following logs for service '%v' in enclave '%v'", serviceUuid, enclaveUuid)
 			return
 		}
@@ -353,6 +354,7 @@ func (strategy *PerWeekStreamLogsStrategy) isWithinRetentionPeriod(logLine *logl
 
 // Continue streaming log lines as they are written to log file (tail -f [filepath])
 func (strategy *PerWeekStreamLogsStrategy) followLogs(
+	ctx context.Context,
 	filepath string,
 	logsByKurtosisUserServiceUuidChan chan map[service.ServiceUUID][]logline.LogLine,
 	serviceUuid service.ServiceUUID,
@@ -375,21 +377,26 @@ func (strategy *PerWeekStreamLogsStrategy) followLogs(
 		return stacktrace.Propagate(err, "An error occurred while attempting to tail the log file.")
 	}
 
-	for logLine := range logTail.Lines {
-		if logLine.Err != nil {
-			return stacktrace.Propagate(logLine.Err, "hpcloud/tail encountered an error with the following log line: %v", logLine.Text)
-		}
-		jsonLog, err := convertStringToJson(logLine.Text)
-		if err != nil {
-			// if tail package fails to parse a valid new line, fail fast
-			return stacktrace.NewError("hpcloud/tail returned the following line: '%v' that was not valid json.\nThis is potentially a bug in tailing package.", logLine.Text)
-		}
-		err = strategy.sendJsonLogLine(jsonLog, logsByKurtosisUserServiceUuidChan, serviceUuid, conjunctiveLogLinesFiltersWithRegex)
-		if err != nil {
-			return stacktrace.Propagate(err, "An error occurred sending json log line '%v'.", logLine.Text)
+	for {
+		select {
+		case <-ctx.Done():
+			logrus.Debugf("Context was canceled, stopping streaming service logs for service '%v'", serviceUuid)
+			return nil
+		case logLine := <-logTail.Lines:
+			if logLine.Err != nil {
+				return stacktrace.Propagate(logLine.Err, "hpcloud/tail encountered an error with the following log line: %v", logLine.Text)
+			}
+			jsonLog, err := convertStringToJson(logLine.Text)
+			if err != nil {
+				// if tail package fails to parse a valid new line, fail fast
+				return stacktrace.NewError("hpcloud/tail returned the following line: '%v' that was not valid json.\nThis is potentially a bug in tailing package.", logLine.Text)
+			}
+			err = strategy.sendJsonLogLine(jsonLog, logsByKurtosisUserServiceUuidChan, serviceUuid, conjunctiveLogLinesFiltersWithRegex)
+			if err != nil {
+				return stacktrace.Propagate(err, "An error occurred sending json log line '%v'.", logLine.Text)
+			}
 		}
 	}
-	return nil
 }
 
 func convertStringToJson(line string) (JsonLog, error) {

--- a/engine/server/engine/centralized_logs/client_implementations/persistent_volume/stream_logs_strategy/per_week_stream_logs_strategy.go
+++ b/engine/server/engine/centralized_logs/client_implementations/persistent_volume/stream_logs_strategy/per_week_stream_logs_strategy.go
@@ -377,7 +377,9 @@ func (strategy *PerWeekStreamLogsStrategy) followLogs(
 		return stacktrace.Propagate(err, "An error occurred while attempting to tail the log file.")
 	}
 	defer func() {
-		logTail.Stop()
+		if err := logTail.Stop(); err != nil {
+			logrus.WithError(err).WithFields(logrus.Fields{filepath: filepath}).Error("Failed to stop reading log file")
+		}
 		logTail.Cleanup()
 	}()
 

--- a/engine/server/engine/server/engine_rest_api_handler.go
+++ b/engine/server/engine/server/engine_rest_api_handler.go
@@ -31,7 +31,8 @@ type EngineRuntime struct {
 // Delete Enclaves
 // (DELETE /enclaves)
 func (engine EngineRuntime) DeleteEnclaves(ctx context.Context, request api.DeleteEnclavesRequestObject) (api.DeleteEnclavesResponseObject, error) {
-	removedEnclaveUuidsAndNames, err := engine.EnclaveManager.Clean(ctx, *request.Params.RemoveAll)
+	removeAll := utils.DerefWith(request.Params.RemoveAll, false)
+	removedEnclaveUuidsAndNames, err := engine.EnclaveManager.Clean(ctx, removeAll)
 	if err != nil {
 		response := internalErrorResponseInfof(err, "An error occurred while cleaning enclaves")
 		return api.DeleteEnclavesdefaultJSONResponse{
@@ -39,7 +40,7 @@ func (engine EngineRuntime) DeleteEnclaves(ctx context.Context, request api.Dele
 			StatusCode: int(response.Code),
 		}, nil
 	}
-	if *request.Params.RemoveAll {
+	if removeAll {
 		if err = engine.LogFileManager.RemoveAllLogs(); err != nil {
 			response := internalErrorResponseInfof(err, "An error occurred removing all logs")
 			return api.DeleteEnclavesdefaultJSONResponse{

--- a/engine/server/engine/server/websocket_api_handler.go
+++ b/engine/server/engine/server/websocket_api_handler.go
@@ -198,7 +198,7 @@ func streamStarlarkLogsWithWebsocket[T any](ctx echo.Context, cors cors.Cors, st
 	if err != nil {
 		logrus.WithError(err).WithFields(logrus.Fields{
 			"streamerUUID": streamerUUID,
-		}).Error("Failed to stream all data")
+		}).Warn("Failed to stream all data")
 	}
 }
 
@@ -271,7 +271,7 @@ func streamServiceLogsWithWebsocket(ctx echo.Context, cors cors.Cors, streamer s
 	if err != nil {
 		logrus.WithError(err).WithFields(logrus.Fields{
 			"services": streamer.GetRequestedServiceUuids(),
-		}).Error("Failed to stream all data")
+		}).Warn("Failed to stream all data")
 	}
 }
 

--- a/engine/server/engine/server/websocket_api_handler.go
+++ b/engine/server/engine/server/websocket_api_handler.go
@@ -263,6 +263,7 @@ func streamServiceLogsWithWebsocket(ctx echo.Context, cors cors.Cors, streamer s
 		return
 	}
 	defer wsPump.Close()
+	wsPump.OnClose(func() { streamer.Close() })
 
 	err = streamer.Consume(func(logline *api_type.ServiceLogs) error {
 		return wsPump.PumpMessage(logline)


### PR DESCRIPTION
## Description:
This PR fixes resources leaks during reading and streaming of service log files. Two goroutines (one in the central logs and one in the websocket processing) were not being closed after the streaming connection would be closed. Also the file reader used to taif -f the log file wasn't being close, leading the multiple processes reading the same file piling-up when the reconnections happened.  

## Is this change user facing?
NO