### PR TITLE
fix: treat size value as megabytes

### DIFF
--- a/core/server/api_container/server/startosis_engine/kurtosis_starlark_framework/test_engine/directory_persistent_directory_framework_test.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_starlark_framework/test_engine/directory_persistent_directory_framework_test.go
@@ -38,5 +38,5 @@ func (t *directoryPersistentDirectoryTestCase) Assert(typeValue builtin_argument
 
 	size, err := directoryStarlark.GetSizeOrDefault()
 	require.Nil(t, err)
-	require.Equal(t, testPersistentDirectorySize, size)
+	require.Equal(t, testPersistentDirectorySizeInBytes, size)
 }

--- a/core/server/api_container/server/startosis_engine/kurtosis_starlark_framework/test_engine/static_constants.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_starlark_framework/test_engine/static_constants.go
@@ -48,13 +48,14 @@ var (
 	testPublicPortProtocol        = port_spec.TransportProtocol_TCP
 	testPublicApplicationProtocol = "https"
 
-	testFilesArtifactPath1      = "path/to/file/1"
-	testFilesArtifactName1      = "file_1"
-	testFilesArtifactPath2      = "path/to/file/2"
-	testFilesArtifactName2      = "file_2"
-	testPersistentDirectoryPath = "path/to/persistent/dir"
-	testPersistentDirectoryKey  = "persistent-dir-test"
-	testPersistentDirectorySize = int64(30)
+	testFilesArtifactPath1             = "path/to/file/1"
+	testFilesArtifactName1             = "file_1"
+	testFilesArtifactPath2             = "path/to/file/2"
+	testFilesArtifactName2             = "file_2"
+	testPersistentDirectoryPath        = "path/to/persistent/dir"
+	testPersistentDirectoryKey         = "persistent-dir-test"
+	testPersistentDirectorySize        = int64(30)
+	testPersistentDirectorySizeInBytes = testPersistentDirectorySize * 1024 * 1024
 
 	testEntryPointSlice = []string{
 		"127.0.0.0",

--- a/core/server/api_container/server/startosis_engine/kurtosis_types/directory/directory.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_types/directory/directory.go
@@ -18,7 +18,8 @@ const (
 	PersistentKeyAttr = "persistent_key"
 	SizeKeyAttr       = "size"
 
-	atleastOneMegabyte = 1
+	atleastOneMegabyte       = 1
+	megaByteToByteMultiplier = 1024 * 1024
 )
 
 func NewDirectoryType() *kurtosis_type_constructor.KurtosisTypeConstructor {
@@ -159,5 +160,5 @@ func (directory *Directory) GetSizeOrDefault() (int64, *startosis_errors.Interpr
 	if !ok {
 		return 0, startosis_errors.NewInterpretationError("Couldn't convert size '%v' to int64", size)
 	}
-	return sizeInt64, nil
+	return sizeInt64 * megaByteToByteMultiplier, nil
 }


### PR DESCRIPTION
## Description:
We expect(in DOCS) the user to enter value in megabytes but were never multiplying the value with the megaByteToByte multiplier
