### PR TITLE
fix: Don't abort build_enclave_manager_webapp with abort_job_if_only_docs_changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -433,8 +433,6 @@ jobs:
     steps:
       - checkout
 
-      - <<: *abort_job_if_only_docs_changes
-
       # Cache our dependencies
       - restore_cache:
           keys:


### PR DESCRIPTION
## Description:
By aborting `build_enclave_manager_webapp` with `abort_job_if_only_docs_changes` the abort will always occur if the build runs on `main` (as the diff there between `main` and `HEAD` will always be empty).

We need `build_enclave_manager_webapp` to run on `main` so that it can be consumed by the `publish_engine_server_image` task.

## Is this change user facing?
NO

## References (if applicable):
- https://github.com/kurtosis-tech/kurtosis/pull/1826
- https://app.circleci.com/pipelines/github/kurtosis-tech/kurtosis/10633/workflows/a50a852d-6570-48ad-9e65-22e9af074a4e
