### PR TITLE
chore: only run `build_enclave_manager_webapp` on non docs changes and tagged commits

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -433,6 +433,11 @@ jobs:
     steps:
       - checkout
 
+      - run: |
+          if git --no-pager diff --exit-code origin/main...HEAD -- . ':!docs' ':!*.md'; then
+            circleci-agent step halt
+          fi 
+
       # Cache our dependencies
       - restore_cache:
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -436,7 +436,7 @@ jobs:
       - run: |
           # If the current commit is not a tag and if there is no change (compared to main) of anything but docs, then skip this
           if (! git describe --exact-match) && git --no-pager diff --exit-code origin/main...HEAD -- . ':!docs' ':!*.md' ; then
-            echo Hello #circleci-agent step halt
+            circleci-agent step halt
           fi
 
       # Cache our dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -434,9 +434,10 @@ jobs:
       - checkout
 
       - run: |
-          if git --no-pager diff --exit-code origin/main...HEAD -- . ':!docs' ':!*.md'; then
-            circleci-agent step halt
-          fi 
+          # If the current commit is not a tag and if there is no change (compared to main) of anything but docs, then skip this
+          if (! git describe --exact-match) && git --no-pager diff --exit-code origin/main...HEAD -- . ':!docs' ':!*.md' ; then
+            echo Hello #circleci-agent step halt
+          fi
 
       # Cache our dependencies
       - restore_cache:


### PR DESCRIPTION
## Description:
Yesterday we [removed](https://github.com/kurtosis-tech/kurtosis/pull/2038) the logic which skips `build_enclave_manager_webapp` if the build commit diff against `main` has only docs changes. We did this because we want `build_enclave_manager_webapp` to run on `main` during publish - so that commit would always have no diff from `main` (as it would be the same commit.

This change means that we skip `build_enclave_manager_webapp` only if the current commit is not tagged and the diff against main has no changes other than docs changes.

This restores the previous behaviour, with the exception that `build_enclave_manager_webapp` runs on tagged commits - ie it can run during publish jobs.

## Is this change user facing?
NO

## References (if applicable):
* https://github.com/kurtosis-tech/kurtosis/pull/2038
