### PR TITLE
docs: Add VSCode plugin tip to start of quickstart

### DIFF
--- a/docs/docs/get-started/quickstart.md
+++ b/docs/docs/get-started/quickstart.md
@@ -15,6 +15,10 @@ Before you get started, make sure you have:
 * [Installed Docker](https://docs.docker.com/get-docker/) and ensure the Docker Daemon is running on your machine (e.g. open Docker Desktop). You can quickly check if Docker is running by running: `docker image ls` from your terminal to see all your Docker images.
 * [Installed Kurtosis](https://docs.kurtosis.com/install/#ii-install-the-cli) or [upgrade Kurtosis to the latest version](https://docs.kurtosis.com/upgrade). You can check if Kurtosis is running using the command: `kurtosis version`, which will print your current Kurtosis engine version and CLI version.
 
+:::tip
+This guide will have you writing Kurtosis Starlark. You can optionally install [the VSCode plugin](https://marketplace.visualstudio.com/items?itemName=Kurtosis.kurtosis-extension) to get syntax highlighting, autocomplete, and documentation.
+:::
+
 Run a basic package from Github
 ---------------------------------------
 


### PR DESCRIPTION
## Description:
@Dartoxian gave feedback that having the VSC plugin at the start of the quickstart would have made for a nicer experience. Updating the quickstart to accomplish this

## Is this change user facing?
YES
