### PR TITLE
fix: emui remove extra args transformation

### DIFF
--- a/enclave-manager/web/packages/app/src/emui/enclaves/components/configuration/drawer/bodies/EnclaveConfigureBody.tsx
+++ b/enclave-manager/web/packages/app/src/emui/enclaves/components/configuration/drawer/bodies/EnclaveConfigureBody.tsx
@@ -17,7 +17,6 @@ import {
   Tabs,
   Text,
   Tooltip,
-  useToast,
 } from "@chakra-ui/react";
 import { EnclaveMode } from "enclave-manager-sdk/build/engine_service_pb";
 import { ArgumentValueType, KurtosisPackage } from "kurtosis-cloud-indexer-sdk";
@@ -85,7 +84,6 @@ export const EnclaveConfigureBody = forwardRef<EnclaveConfigureBodyAttributes, E
     const [error, setError] = useState<string>();
     const formRef = useRef<EnclaveConfigurationFormImperativeAttributes>(null);
     const yamlRef = useRef<YAMLEditorImperativeAttributes>(null);
-    const toast = useToast();
     const [activeTab, setActiveTab] = useState<(typeof tabs)[number]>("Form");
 
     const handleTabChange = (index: number) => {
@@ -184,20 +182,6 @@ export const EnclaveConfigureBody = forwardRef<EnclaveConfigureBodyAttributes, E
       }
 
       if (formData.args.args) {
-        try {
-          console.debug("formData", formData);
-          formData.args.args = JSON.parse(formData.args.args);
-          console.debug("successfully parsed args as proper JSON", formData.args.args);
-        } catch (err) {
-          toast({
-            title: `An error occurred while preparing data for running package. The package arguments were not proper JSON: ${stringifyError(
-              err,
-            )}`,
-            colorScheme: "red",
-          });
-          return;
-        }
-
         const { args, ...rest } = formData.args;
 
         submissionData = {


### PR DESCRIPTION
## Description:
This fixes an issue reported by @adschwartz and @chunha-park where packages which use the catch all `args` arg, like the ethereum package show the following error:

![image](https://github.com/kurtosis-tech/kurtosis/assets/4419574/15ef556d-3e29-46bf-ad5b-ee0f8fc24694)

This error is occuring because the `args` arg has no 'TopLevelType', so prior to #2052 the `args` field was not parsed as json/yaml when read. However in #2052 the default behaviour was modified to parse fields with an unknown type as json/yaml. This created this new bug, since the `args` field was no parsed twice.

This fix removes the additional parsing in the 'submit' flow.

## Is this change user facing?
YES

## References (if applicable):
- https://sageroomworkspace.slack.com/archives/C060Z6HDYR3/p1705615425847449
