### PR TITLE
fix: emui yaml editor populating with values

### DIFF
--- a/enclave-manager/web/packages/app/src/emui/enclaves/components/configuration/utils.ts
+++ b/enclave-manager/web/packages/app/src/emui/enclaves/components/configuration/utils.ts
@@ -57,7 +57,7 @@ export function transformFormArgsToKurtosisArgs(data: Record<string, any>, kurto
       case ArgumentValueType.LIST:
         return value.map((v: any) => transformValue(innerValuetype, v));
       case ArgumentValueType.BOOL:
-        return isDefined(value) ? isStringTrue(value) : null;
+        return isDefined(value) && value !== "" ? isStringTrue(value) : null;
       case ArgumentValueType.INTEGER:
         return isNaN(value) || isNaN(parseFloat(value)) ? null : parseFloat(value);
       case ArgumentValueType.STRING:


### PR DESCRIPTION
## Description:
@mieubrisse performed the following:
* open the postgres package for a new enclave
* Click YAML (sees `{}`)
* Click Form
* Click YAML (sees
```
persistent: false
launch_adminer: false
```

This is unexpected as the user has not specified values for these args. This PR fixes an issue specifically in boolean input that caused this problem - when we convert from 'kurtosis args' to 'form args' (YAML -> Form) we set the value for the boolean input to `""` (rather than undefined - I don't think we can set values on the form to the undefined value). Then when we convert 'form args' to 'kurtosis args' (Form -> YAML) we need to treat the empty string as if no value were set, rather than a falsey value.

## Is this change user facing?
YES

## References (if applicable):
* Direct message on slack.
