### PR TITLE
fix: Fix calls to stacktrace in the reverse proxy module

### DIFF
--- a/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/reverse_proxy_functions/create_reverse_proxy.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/reverse_proxy_functions/create_reverse_proxy.go
@@ -49,7 +49,7 @@ func CreateReverseProxy(
 		logrus.Debugf("Something failed while trying to create the reverse proxy object using container with ID '%s'. Error was:\n%s", proxyDockerContainer.GetId(), getProxyObjErr.Error())
 		logrus.Debugf("Destroying the failing reverse proxy to create a new one...")
 		if destroyProxyContainerErr := destroyReverseProxyWithContainerId(ctx, dockerManager, proxyDockerContainer.GetId()); destroyProxyContainerErr != nil {
-			return nil, nil, stacktrace.Propagate(err, "an error occurred destroying the current reverse proxy that was failing to create a new one")
+			return nil, nil, stacktrace.Propagate(destroyProxyContainerErr, "an error occurred destroying the current reverse proxy that was failing to create a new one")
 		}
 		logrus.Debugf("... current reverse proxy successfully destroyed, starting a new one now.")
 	}

--- a/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/reverse_proxy_functions/network_reverse_proxy.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/reverse_proxy_functions/network_reverse_proxy.go
@@ -25,7 +25,7 @@ func ConnectReverseProxyToNetwork(ctx context.Context, dockerManager *docker_man
 	}
 
 	if maybeReverseProxyObject == nil {
-		return stacktrace.Propagate(err, "An error occurred while connecting the reverse proxy to the enclave network '%v' because no reverse proxy was found", networkId)
+		return stacktrace.NewError("An error occurred while connecting the reverse proxy to the enclave network '%v' because no reverse proxy was found", networkId)
 	}
 
 	_, found := maybeReverseProxyObject.GetEnclaveNetworksIpAddress()[networkId]
@@ -48,7 +48,7 @@ func DisconnectReverseProxyFromNetwork(ctx context.Context, dockerManager *docke
 	}
 
 	if maybeReverseProxyObject == nil {
-		return stacktrace.Propagate(err, "An error occurred while disconnecting the reverse proxy from the enclave network '%v' because no reverse proxy was found", networkId)
+		return stacktrace.NewError("An error occurred while disconnecting the reverse proxy from the enclave network '%v' because no reverse proxy was found", networkId)
 	}
 
 	_, found := maybeReverseProxyObject.GetEnclaveNetworksIpAddress()[networkId]


### PR DESCRIPTION
## Description:
A user reported a Go panic in the reverse proxy module when the reverse proxy container is missing.  The reverse proxy is missing because of the lack of support for podman.

## Is this change user facing?
NO

## References (if applicable):
https://discord.com/channels/783719264308953108/1139207537959391232/1201943594714542171
