### PR TITLE
fix: adding the `core script build call`, which was removed by accident, in the main build script

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -33,6 +33,7 @@ BUILD_SCRIPT_RELATIVE_FILEPATHS=(
     "metrics-library/scripts/build.sh"
     "enclave-manager/scripts/build.sh"
     "engine/scripts/build.sh"
+    "core/scripts/build.sh"
 )
 
 # projects with debug mode enabled


### PR DESCRIPTION
## Description:
adding the `core script build call`, which was removed by accident, in the main build script

## Is this change user facing?
NO

## References (if applicable):
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
