### PR TITLE
docs: removing the web3 use case links from docs

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -88,11 +88,6 @@ const config = {
 						activeBasePath: '/sdk'
 					},
 					{
-						href: 'https://web3.kurtosis.com',
-						position: 'left',
-						label: 'Kurtosis for Web3',
-					},
-					{
 						href: 'https://www.kurtosis.com/release-notes',
 						position: 'left',
 						label: 'Release Notes',

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -70,11 +70,6 @@ const sidebars = {
             ]
         },
         'code-examples',
-        {
-            "type": "link",
-            "label": "Kurtosis for Web3",
-            "href": "https://web3.kurtosis.com",
-        },
         'faq',
         'best-practices',
         'roadmap',


### PR DESCRIPTION
## Description:
removing the web3 use case links from the docs

## Is this change user facing?
YES
