### PR TITLE
fix: Fix the enclave connect button and modal help string in the EM UI

### DIFF
--- a/enclave-manager/web/packages/app/src/emui/enclaves/components/modals/ConnectEnclaveModal.tsx
+++ b/enclave-manager/web/packages/app/src/emui/enclaves/components/modals/ConnectEnclaveModal.tsx
@@ -32,7 +32,7 @@ export const ConnectEnclaveModal = ({ isOpen, onClose, enclave, instanceUUID }: 
           <FileDisplay value={commands} title={"CLI Commands"} filename={`${enclave.name}--connect.sh`} />
         </ModalBody>
         <ModalFooter>
-          The enclave inspect command shows you the ephemeral port to use to connect to your user service.
+          The enclave inspect command shows you the ephemeral ports to use to connect to your user services.
         </ModalFooter>
       </ModalContent>
     </Modal>

--- a/enclave-manager/web/packages/app/src/emui/enclaves/components/widgets/ConnectEnclaveButton.tsx
+++ b/enclave-manager/web/packages/app/src/emui/enclaves/components/widgets/ConnectEnclaveButton.tsx
@@ -1,6 +1,6 @@
 import { Button, ButtonProps, Tooltip } from "@chakra-ui/react";
 import { useState } from "react";
-import { FiTrash2 } from "react-icons/fi";
+import { FiLink2 } from "react-icons/fi";
 import { EnclaveFullInfo } from "../../types";
 import { ConnectEnclaveModal } from "../modals/ConnectEnclaveModal";
 
@@ -17,7 +17,7 @@ export const ConnectEnclaveButton = ({ enclave, instanceUUID, ...buttonProps }: 
       <Tooltip label={`Steps to connect to this enclave from the CLI.`} openDelay={1000}>
         <Button
           colorScheme={"green"}
-          leftIcon={<FiTrash2 />}
+          leftIcon={<FiLink2 />}
           onClick={() => setShowModal(true)}
           size={"sm"}
           variant={"solid"}


### PR DESCRIPTION
## Description:
The enclave connect button was the wrong one in the EM UI.  Updated to one corresponding to the action.

## Is this change user facing?
YES

## References (if applicable):
#2117 
