### PR TITLE
fix: Remove Derek and Karla as default assignees for docs issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/docs-issue.yml
+++ b/.github/ISSUE_TEMPLATE/docs-issue.yml
@@ -1,9 +1,7 @@
 name: "Docs Issue"
 description: Report an issue in our documentation
 labels: ["docs"]
-assignees:
-  - leeederek
-  - thylocine33
+assignees: []
 body:
   - type: input
     id: url-link


### PR DESCRIPTION
## Description:
Derek and Karla are the default assignees for docs issues; this fixes that

## Is this change user facing?
NO