### PR TITLE
fix: node selector validation

### DIFF
--- a/core/server/api_container/server/startosis_engine/kurtosis_starlark_framework/builtin_argument/validators.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_starlark_framework/builtin_argument/validators.go
@@ -148,31 +148,46 @@ func DurationOrNone(value starlark.Value, attributeName string) *startosis_error
 }
 
 func StringMappingToString(value starlark.Value, attributeName string) *startosis_errors.InterpretationError {
-	labelsMap := map[string]string{}
-	labelsDict, ok := value.(*starlark.Dict)
-	if !ok {
-		return startosis_errors.NewInterpretationError("Attribute '%s' is expected to be a dictionary of strings, got '%s'", attributeName, reflect.TypeOf(value))
+	if _, err := parseMapStringString(value, attributeName); err != nil {
+		return err
 	}
-	for _, labelKey := range labelsDict.Keys() {
-		labelValue, found, err := labelsDict.Get(labelKey)
-		if err != nil {
-			return startosis_errors.WrapWithInterpretationError(err, "Unexpected error iterating on dictionary. Value associated to key '%v' could not be found", labelKey)
-		} else if !found {
-			return startosis_errors.NewInterpretationError("Unexpected error iterating on dictionary. Value associated to key '%v' could not be found", labelKey)
-		}
+	return nil
+}
 
-		labelKeyStr, ok := labelKey.(starlark.String)
-		if !ok {
-			return startosis_errors.NewInterpretationError("Key in '%s' dictionary was expected to be a string, got '%s'", attributeName, reflect.TypeOf(labelKey))
-		}
-		labelValueStr, ok := labelValue.(starlark.String)
-		if !ok {
-			return startosis_errors.NewInterpretationError("Value associated to key '%s' in dictionary '%s' was expected to be a string, got '%s'", labelKeyStr, attributeName, reflect.TypeOf(value))
-		}
-		labelsMap[labelKeyStr.GoString()] = labelValueStr.GoString()
+func ServiceLabelsValidator(value starlark.Value, attributeName string) *startosis_errors.InterpretationError {
+	labelsMap, interpretationErr := parseMapStringString(value, attributeName)
+	if interpretationErr != nil {
+		return interpretationErr
 	}
 	if err := service.ValidateServiceConfigLabels(labelsMap); err != nil {
 		return startosis_errors.WrapWithInterpretationError(err, "An error occurred validating service config labels '%+v'", labelsMap)
 	}
 	return nil
+}
+
+func parseMapStringString(value starlark.Value, attributeName string) (map[string]string, *startosis_errors.InterpretationError) {
+	stringMap := map[string]string{}
+	stringDict, ok := value.(*starlark.Dict)
+	if !ok {
+		return nil, startosis_errors.NewInterpretationError("Attribute '%s' is expected to be a dictionary of strings, got '%s'", attributeName, reflect.TypeOf(value))
+	}
+	for _, mapKey := range stringDict.Keys() {
+		mapValue, found, err := stringDict.Get(mapKey)
+		if err != nil {
+			return nil, startosis_errors.WrapWithInterpretationError(err, "Unexpected error iterating on dictionary. Value associated to key '%v' could not be found", mapKey)
+		} else if !found {
+			return nil, startosis_errors.NewInterpretationError("Unexpected error iterating on dictionary. Value associated to key '%v' could not be found", mapKey)
+		}
+
+		mapKeyStr, ok := mapKey.(starlark.String)
+		if !ok {
+			return nil, startosis_errors.NewInterpretationError("Key in '%s' dictionary was expected to be a string, got '%s'", attributeName, reflect.TypeOf(mapKey))
+		}
+		mapValueStr, ok := mapValue.(starlark.String)
+		if !ok {
+			return nil, startosis_errors.NewInterpretationError("Value associated to key '%s' in dictionary '%s' was expected to be a string, got '%s'", mapKeyStr, attributeName, reflect.TypeOf(value))
+		}
+		stringMap[mapKeyStr.GoString()] = mapValueStr.GoString()
+	}
+	return stringMap, nil
 }

--- a/core/server/api_container/server/startosis_engine/kurtosis_starlark_framework/test_engine/static_constants.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_starlark_framework/test_engine/static_constants.go
@@ -118,8 +118,8 @@ var (
 		testServiceConfigLabelsKey2: testServiceConfigLabelsValue2,
 	}
 
-	testNodeSelectorKey1   = "disktype"
-	testNodeSelectorValue1 = "ssd"
+	testNodeSelectorKey1   = "k3s.io/hostname"
+	testNodeSelectorValue1 = "asrock-berlin-03"
 	testNodeSelectors      = map[string]string{
 		testNodeSelectorKey1: testNodeSelectorValue1,
 	}

--- a/core/server/api_container/server/startosis_engine/kurtosis_types/service_config/service_config.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_types/service_config/service_config.go
@@ -183,7 +183,8 @@ func NewServiceConfigType() *kurtosis_type_constructor.KurtosisTypeConstructor {
 					IsOptional:        true,
 					ZeroValueProvider: builtin_argument.ZeroValueProvider[*starlark.Dict],
 					Validator: func(value starlark.Value) *startosis_errors.InterpretationError {
-						return builtin_argument.StringMappingToString(value, LabelsAttr)
+
+						return builtin_argument.ServiceLabelsValidator(value, LabelsAttr)
 					},
 				},
 				{


### PR DESCRIPTION
We were enforcing label validation on node selectors; but the node selectors just need to be a string map