### PR TITLE
fix: replace nix installer

### DIFF
--- a/core/server/Dockerfile
+++ b/core/server/Dockerfile
@@ -4,9 +4,10 @@ FROM alpine:3.17
 RUN apk update && apk add --no-cache bash protobuf-dev sudo shadow curl xz
 
 # Install Nix
-# We need to set filter-syscalls to false to allow Nix to work properly inside a container: https://github.com/NixOS/nix/issues/5258
-ENV NIX_INSTALL_ARGS="--extra-conf 'filter-syscalls = false'"
-RUN sh <(curl -L https://nixos.org/nix/install) --daemon --yes
+# We need to set filter-syscalls to false to allow Nix install to work properly inside a container with cross platform emulation
+# via QEMU: https://github.com/NixOS/nix/issues/5258 and use a more flexible installer https://github.com/DeterminateSystems/nix-installer
+# with a workaround on the same issue: https://github.com/DeterminateSystems/nix-installer/issues/324)
+RUN curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install linux --no-confirm --init none --extra-conf "filter-syscalls = false"
 
 ARG TARGETARCH
 

--- a/core/server/Dockerfile.debug
+++ b/core/server/Dockerfile.debug
@@ -4,9 +4,10 @@ FROM alpine:3.19
 RUN apk update && apk add --no-cache bash protobuf-dev sudo shadow curl xz
 
 # Install Nix
-# We need to set filter-syscalls to false to allow Nix to work properly inside a container: https://github.com/NixOS/nix/issues/5258
-ENV NIX_INSTALL_ARGS="--extra-conf 'filter-syscalls = false'"
-RUN sh <(curl -L https://nixos.org/nix/install) --daemon --yes
+# We need to set filter-syscalls to false to allow Nix install to work properly inside a container with cross platform emulation
+# via QEMU: https://github.com/NixOS/nix/issues/5258 and use a more flexible installer https://github.com/DeterminateSystems/nix-installer
+# with a workaround on the same issue: https://github.com/DeterminateSystems/nix-installer/issues/324)
+RUN curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install linux --no-confirm --init none --extra-conf "filter-syscalls = false"
 
 # Make sure that you changed the port inside the APIC's code before changing it here
 EXPOSE 50103


### PR DESCRIPTION
## Description:
Fix the cross platform docker images that are trying to install nix by replacing the installer and passing extra config params.

## Is this change user facing?
NO

## References (if applicable):
- https://github.com/DeterminateSystems/nix-installer/issues/324
- https://github.com/NixOS/nix/issues/5258