### PR TITLE
fix: Fix the connect to enclave CLI commands in the EM UI

### DIFF
--- a/enclave-manager/web/packages/app/src/emui/enclaves/components/modals/ConnectEnclaveModal.tsx
+++ b/enclave-manager/web/packages/app/src/emui/enclaves/components/modals/ConnectEnclaveModal.tsx
@@ -13,12 +13,14 @@ import { EnclaveFullInfo } from "../../types";
 export type ConnectEnclaveModalProps = {
   enclave: EnclaveFullInfo;
   instanceUUID: string;
+  apiKey: string;
   isOpen: boolean;
   onClose: () => void;
 };
 
-export const ConnectEnclaveModal = ({ isOpen, onClose, enclave, instanceUUID }: ConnectEnclaveModalProps) => {
+export const ConnectEnclaveModal = ({ isOpen, onClose, enclave, instanceUUID, apiKey }: ConnectEnclaveModalProps) => {
   const commands = `
+  export KURTOSIS_CLOUD_API_KEY="${apiKey}"
   kurtosis cloud load ${instanceUUID}
   kurtosis enclave connect ${enclave.name}
   kurtosis enclave inspect ${enclave.name}`;

--- a/enclave-manager/web/packages/app/src/emui/enclaves/components/widgets/ConnectEnclaveButton.tsx
+++ b/enclave-manager/web/packages/app/src/emui/enclaves/components/widgets/ConnectEnclaveButton.tsx
@@ -7,9 +7,10 @@ import { ConnectEnclaveModal } from "../modals/ConnectEnclaveModal";
 type ConnectEnclaveButtonProps = ButtonProps & {
   enclave: EnclaveFullInfo;
   instanceUUID: string;
+  apiKey: string;
 };
 
-export const ConnectEnclaveButton = ({ enclave, instanceUUID, ...buttonProps }: ConnectEnclaveButtonProps) => {
+export const ConnectEnclaveButton = ({ enclave, instanceUUID, apiKey, ...buttonProps }: ConnectEnclaveButtonProps) => {
   const [showModal, setShowModal] = useState(false);
 
   return (
@@ -29,6 +30,7 @@ export const ConnectEnclaveButton = ({ enclave, instanceUUID, ...buttonProps }: 
       <ConnectEnclaveModal
         enclave={enclave}
         instanceUUID={instanceUUID}
+        apiKey={apiKey}
         isOpen={showModal}
         onClose={() => setShowModal(false)}
       />

--- a/enclave-manager/web/packages/app/src/emui/enclaves/enclave/Enclave.tsx
+++ b/enclave-manager/web/packages/app/src/emui/enclaves/enclave/Enclave.tsx
@@ -46,6 +46,7 @@ const EnclaveImpl = ({ enclave }: EnclaveImplProps) => {
   };
 
   const instanceUUID = Cookies.get("_kurtosis_instance_id") || "";
+  const apiKey = Cookies.get("_kurtosis_api_key") || "";
 
   return (
     <Tabs isManual isLazy index={activeIndex} onChange={handleTabChange} variant={"kurtosisHeaderLine"}>
@@ -58,7 +59,7 @@ const EnclaveImpl = ({ enclave }: EnclaveImplProps) => {
           <Flex gap={"8px"} alignItems={"center"} pb={"16px"}>
             <DeleteEnclavesButton enclaves={[enclave]} />
             <EditEnclaveButton enclave={enclave} />
-            <ConnectEnclaveButton enclave={enclave} instanceUUID={instanceUUID} />
+            <ConnectEnclaveButton enclave={enclave} instanceUUID={instanceUUID} apiKey={apiKey} />
           </Flex>
         </Flex>
         <TabPanels>


### PR DESCRIPTION
Add api key environment variable set command to the list of connect to enclave CLI commands in the EM UI.

## Is this change user facing?
YES

## References (if applicable):
https://github.com/kurtosis-tech/kurtosis-cloud-frontend/pull/84
