### PR TITLE
feat: EMUI handle loading a package (or subpackage) from github urls

### DIFF
--- a/enclave-manager/web/cypress/e2e/enclaves/packageSearch.cy.ts
+++ b/enclave-manager/web/cypress/e2e/enclaves/packageSearch.cy.ts
@@ -6,4 +6,13 @@ describe("New Enclave package search", () => {
     cy.focused().type("github.com/kurtosis-tech/package-template-repo");
     cy.contains("Package Template Repo");
   });
+
+  it("Can find an enclave with a github url", () => {
+    cy.goToEnclaveList();
+    cy.contains("New Enclave").click().wait(500);
+    cy.contains("Exact Match").should("not.exist");
+    cy.focused().type("https://github.com/kurtosis-tech/awesome-kurtosis/tree/main/redis-voting-app");
+    cy.contains("Exact Match");
+    cy.contains("Redis Voting App");
+  });
 });

--- a/enclave-manager/web/packages/components/src/utils/packageUtils.ts
+++ b/enclave-manager/web/packages/components/src/utils/packageUtils.ts
@@ -1,5 +1,8 @@
 export function parsePackageUrl(packageUrl: string) {
-  const components = packageUrl.replace(/https?:\/\//, "").split("/");
+  const components = packageUrl
+    .replace(/https?:\/\//, "")
+    .replace(/(?<=github\.com\/([^/])+\/([^/])+)\/tree\/main/, "")
+    .split("/");
   if (components.length < 3) {
     throw Error(`Illegal url, invalid number of components: ${packageUrl}`);
   }


### PR DESCRIPTION
## Description:
This PR supports loading subpackages from github urls.

![image](https://github.com/kurtosis-tech/kurtosis/assets/4419574/240b043e-2a18-430f-8734-41037e663e86)

## Is this change user facing?
YES

## References (if applicable):
* https://www.notion.so/kurtosistech/Picasso-Prototype-Refinement-Burndown-5eecbc699d8d41c2b4fe8748f3411f74
