### PR TITLE
chore: Update k8s image pull error message to include a possible platform mismatch

### DIFF
--- a/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_manager/kubernetes_manager.go
+++ b/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_manager/kubernetes_manager.go
@@ -1852,7 +1852,7 @@ func (manager *KubernetesManager) waitForPodAvailability(ctx context.Context, na
 						"Container '%v' using image '%v' in pod '%v' in namespace '%v' is stuck in state '%v'. This likely means:\n"+
 							"1) There's a typo in either the image name or the tag name\n"+
 							"2) The image isn't accessible to Kubernetes (e.g. it's a local image, or it's in a private image registry that Kubernetes can't access)\n"+
-							"3) The image's platform might not match",
+							"3) The image's platform/architecture might not match",
 						containerName,
 						containerStatus.Image,
 						pod.Name,

--- a/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_manager/kubernetes_manager.go
+++ b/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_manager/kubernetes_manager.go
@@ -1851,7 +1851,8 @@ func (manager *KubernetesManager) waitForPodAvailability(ctx context.Context, na
 					return stacktrace.NewError(
 						"Container '%v' using image '%v' in pod '%v' in namespace '%v' is stuck in state '%v'. This likely means:\n"+
 							"1) There's a typo in either the image name or the tag name\n"+
-							"2) The image isn't accessible to Kubernetes (e.g. it's a local image, or it's in a private image registry that Kubernetes can't access)",
+							"2) The image isn't accessible to Kubernetes (e.g. it's a local image, or it's in a private image registry that Kubernetes can't access)\n"+
+							"3) The image's platform might not match",
 						containerName,
 						containerStatus.Image,
 						pod.Name,


### PR DESCRIPTION
## Description:
K8S might not be able to pull the image if there is a typo in the name, if the registry is not accessible but also if the image's platform is not compatible with the one K8S is running on.  We update the error message to indicate that possibility.

## Is this change user facing?
YES

## References (if applicable):
Closes #2097 
