### PR TITLE
feat: updated Traefik config rule matcher in order to use a HostRegex matcher instead of Host

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,7 +145,7 @@ version: 2.1
 
 orbs:
   npm-publisher: uraway/npm-publisher@0.2.0
-  kurtosis-docs-checker: kurtosis-tech/docs-checker@0.2.6
+  kurtosis-docs-checker: kurtosis-tech/docs-checker@0.2.7
   slack: circleci/slack@4.10.1
 
 executors:

--- a/container-engine-lib/lib/backend_impls/docker/object_attributes_provider/enclave_object_attributes_provider.go
+++ b/container-engine-lib/lib/backend_impls/docker/object_attributes_provider/enclave_object_attributes_provider.go
@@ -30,6 +30,8 @@ const (
 	logsCollectorFragment                  = "kurtosis-logs-collector"
 	// The collector is per enclave so this is a suffix
 	logsCollectorVolumeFragment = logsCollectorFragment + "-vol"
+
+	anyCharacterPrefixRegexToken = ".*"
 )
 
 type DockerEnclaveObjectAttributesProvider interface {
@@ -524,10 +526,10 @@ func (provider *dockerEnclaveObjectAttributesProviderImpl) getLabelsForEnclaveOb
 // the following labels are returned:
 //
 //	"traefik.enable": "true",
-//	"traefik.http.routers.65d2fb6d6732-3771c85af16a-80.rule": "Host(`80-3771c85af16a-65d2fb6d6732`)",
+//	"traefik.http.routers.65d2fb6d6732-3771c85af16a-80.rule": "HostRegexp(`{name:80-3771c85af16a-65d2fb6d6732.*}`)",
 //	"traefik.http.routers.65d2fb6d6732-3771c85af16a-80.service": "65d2fb6d6732-3771c85af16a-80",
 //	"traefik.http.services.65d2fb6d6732-3771c85af16a-80.loadbalancer.server.port": "80"
-//	"traefik.http.routers.65d2fb6d6732-3771c85af16a-80.rule": "Host(`81-3771c85af16a-65d2fb6d6732`)",
+//	"traefik.http.routers.65d2fb6d6732-3771c85af16a-81.rule": "HostRegexp(`{name:81-3771c85af16a-65d2fb6d6732.*}`)",
 //	"traefik.http.routers.65d2fb6d6732-3771c85af16a-81.service": "65d2fb6d6732-3771c85af16a-81",
 //	"traefik.http.services.65d2fb6d6732-3771c85af16a-81.loadbalancer.server.port": "81"
 func (provider *dockerEnclaveObjectAttributesProviderImpl) getTraefikLabelsForEnclaveObject(serviceUuid string, ports map[string]*port_spec.PortSpec) (map[*docker_label_key.DockerLabelKey]*docker_label_value.DockerLabelValue, error) {
@@ -544,7 +546,7 @@ func (provider *dockerEnclaveObjectAttributesProviderImpl) getTraefikLabelsForEn
 			shortServiceUuid := uuid_generator.ShortenedUUIDString(serviceUuid)
 			servicePortStr := fmt.Sprintf("%s-%s-%d", shortEnclaveUuid, shortServiceUuid, portSpec.GetNumber())
 
-			labelKeyValuePairs[fmt.Sprintf("http.routers.%s.rule", servicePortStr)] = fmt.Sprintf("Host(`%d-%s-%s`)", portSpec.GetNumber(), shortServiceUuid, shortEnclaveUuid)
+			labelKeyValuePairs[fmt.Sprintf("http.routers.%s.rule", servicePortStr)] = fmt.Sprintf("HostRegexp(`{name:%d-%s-%s%s}`)", portSpec.GetNumber(), shortServiceUuid, shortEnclaveUuid, anyCharacterPrefixRegexToken)
 			labelKeyValuePairs[fmt.Sprintf("http.routers.%s.service", servicePortStr)] = servicePortStr
 			labelKeyValuePairs[fmt.Sprintf("http.services.%s.loadbalancer.server.port", servicePortStr)] = strconv.Itoa(int(portSpec.GetNumber()))
 		}

--- a/container-engine-lib/lib/backend_impls/docker/object_attributes_provider/enclave_object_attributes_provider.go
+++ b/container-engine-lib/lib/backend_impls/docker/object_attributes_provider/enclave_object_attributes_provider.go
@@ -526,10 +526,10 @@ func (provider *dockerEnclaveObjectAttributesProviderImpl) getLabelsForEnclaveOb
 // the following labels are returned:
 //
 //	"traefik.enable": "true",
-//	"traefik.http.routers.65d2fb6d6732-3771c85af16a-80.rule": "HostRegexp(`{name:80-3771c85af16a-65d2fb6d6732.*}`)",
+//	"traefik.http.routers.65d2fb6d6732-3771c85af16a-80.rule": "HostRegexp(`{^name:80-3771c85af16a-65d2fb6d6732-?.*$}`)",
 //	"traefik.http.routers.65d2fb6d6732-3771c85af16a-80.service": "65d2fb6d6732-3771c85af16a-80",
 //	"traefik.http.services.65d2fb6d6732-3771c85af16a-80.loadbalancer.server.port": "80"
-//	"traefik.http.routers.65d2fb6d6732-3771c85af16a-81.rule": "HostRegexp(`{name:81-3771c85af16a-65d2fb6d6732.*}`)",
+//	"traefik.http.routers.65d2fb6d6732-3771c85af16a-81.rule": "HostRegexp(`{^name:81-3771c85af16a-65d2fb6d6732-?.*$}`)",
 //	"traefik.http.routers.65d2fb6d6732-3771c85af16a-81.service": "65d2fb6d6732-3771c85af16a-81",
 //	"traefik.http.services.65d2fb6d6732-3771c85af16a-81.loadbalancer.server.port": "81"
 func (provider *dockerEnclaveObjectAttributesProviderImpl) getTraefikLabelsForEnclaveObject(serviceUuid string, ports map[string]*port_spec.PortSpec) (map[*docker_label_key.DockerLabelKey]*docker_label_value.DockerLabelValue, error) {
@@ -546,7 +546,7 @@ func (provider *dockerEnclaveObjectAttributesProviderImpl) getTraefikLabelsForEn
 			shortServiceUuid := uuid_generator.ShortenedUUIDString(serviceUuid)
 			servicePortStr := fmt.Sprintf("%s-%s-%d", shortEnclaveUuid, shortServiceUuid, portSpec.GetNumber())
 
-			labelKeyValuePairs[fmt.Sprintf("http.routers.%s.rule", servicePortStr)] = fmt.Sprintf("HostRegexp(`{name:%d-%s-%s%s}`)", portSpec.GetNumber(), shortServiceUuid, shortEnclaveUuid, anyCharacterPrefixRegexToken)
+			labelKeyValuePairs[fmt.Sprintf("http.routers.%s.rule", servicePortStr)] = fmt.Sprintf("HostRegexp(`{^name:%d-%s-%s-?%s$}`)", portSpec.GetNumber(), shortServiceUuid, shortEnclaveUuid, anyCharacterPrefixRegexToken)
 			labelKeyValuePairs[fmt.Sprintf("http.routers.%s.service", servicePortStr)] = servicePortStr
 			labelKeyValuePairs[fmt.Sprintf("http.services.%s.loadbalancer.server.port", servicePortStr)] = strconv.Itoa(int(portSpec.GetNumber()))
 		}

--- a/container-engine-lib/lib/backend_impls/docker/object_attributes_provider/enclave_object_attributes_provider_test.go
+++ b/container-engine-lib/lib/backend_impls/docker/object_attributes_provider/enclave_object_attributes_provider_test.go
@@ -68,7 +68,7 @@ func TestForUserServiceContainer(t *testing.T) {
 		case "traefik.http.routers.65d2fb6d6732-3771c85af16a-23.rule":
 			require.Fail(t, "A traefik label for port 23 should not be present")
 		case "traefik.http.routers.65d2fb6d6732-3771c85af16a-45.rule":
-			require.Equal(t, labelValue.GetString(), "HostRegexp(`{name:45-3771c85af16a-65d2fb6d6732.*}`)")
+			require.Equal(t, labelValue.GetString(), "HostRegexp(`{^name:45-3771c85af16a-65d2fb6d6732-?.*$}`)")
 		case "traefik.http.routers.65d2fb6d6732-3771c85af16a-45.service":
 			require.Equal(t, labelValue.GetString(), "65d2fb6d6732-3771c85af16a-45")
 		case "traefik.http.services.65d2fb6d6732-3771c85af16a-45.loadbalancer.server.port":

--- a/container-engine-lib/lib/backend_impls/docker/object_attributes_provider/enclave_object_attributes_provider_test.go
+++ b/container-engine-lib/lib/backend_impls/docker/object_attributes_provider/enclave_object_attributes_provider_test.go
@@ -68,7 +68,7 @@ func TestForUserServiceContainer(t *testing.T) {
 		case "traefik.http.routers.65d2fb6d6732-3771c85af16a-23.rule":
 			require.Fail(t, "A traefik label for port 23 should not be present")
 		case "traefik.http.routers.65d2fb6d6732-3771c85af16a-45.rule":
-			require.Equal(t, labelValue.GetString(), "Host(`45-3771c85af16a-65d2fb6d6732`)")
+			require.Equal(t, labelValue.GetString(), "HostRegexp(`{name:45-3771c85af16a-65d2fb6d6732.*}`)")
 		case "traefik.http.routers.65d2fb6d6732-3771c85af16a-45.service":
 			require.Equal(t, labelValue.GetString(), "65d2fb6d6732-3771c85af16a-45")
 		case "traefik.http.services.65d2fb6d6732-3771c85af16a-45.loadbalancer.server.port":

--- a/scripts/set_kt_alias.sh
+++ b/scripts/set_kt_alias.sh
@@ -17,6 +17,10 @@ zsh)  echo "Setting $SHELL_NAME completion"
     source <(ktdev completion zsh)
     compdef __start_kurtosis ktdev
     ;;
+-zsh)  echo "Setting $SHELL_NAME completion"
+    source <(ktdev completion zsh)
+    compdef __start_kurtosis ktdev
+    ;;
 *) echo "Shell $SHELL_NAME is not supported"
    ;;
 esac


### PR DESCRIPTION
## Description:
Created to solve this ticket https://github.com/kurtosis-tech/kurtosis/issues/2268
Still pending a config upgrade in the cloud gateway also

## Is this change user facing?
NO

## References (if applicable):
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
