### PR TITLE
fix: Use instance `updated at` attribute for uptime calculation

### DIFF
--- a/enclave-manager/web/packages/app/src/emui/enclaves/components/InstanceTermination.tsx
+++ b/enclave-manager/web/packages/app/src/emui/enclaves/components/InstanceTermination.tsx
@@ -20,7 +20,7 @@ export const InstanceTerminationWarning = () => {
   const fetchCloudInstanceCreationTime = async () => {
     try {
       const cloudInstanceConfigResponse = await kurtosisClient.getCloudInstanceConfig();
-      const upTime = Math.floor((Date.now() - new Date(cloudInstanceConfigResponse.created).getTime()) / (3600 * 1000));
+      const upTime = Math.floor((Date.now() - new Date(cloudInstanceConfigResponse.updated).getTime()) / (3600 * 1000));
       const remainingHours = KURTOSIS_CLOUD_INSTANCE_MAX_UPTIME_IN_HOURS - upTime - 1;
       setCloudInstanceRemainingHours(remainingHours);
     } catch (error) {


### PR DESCRIPTION
## Description
An instance `created at` time is the time when it is added to the pool. We need to use the `updated at` time which is the time when the instance is reassigned to the user and set to running.

## Is this change user facing?
YES

## References (if applicable)
https://github.com/kurtosis-tech/kurtosis-cloud-backend/pull/157
