### PR TITLE
feat: adding enclave production mode value in the APIC primitive

### DIFF
--- a/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/kubernetes_kurtosis_backend_api_container_functions.go
+++ b/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/kubernetes_kurtosis_backend_api_container_functions.go
@@ -1043,6 +1043,7 @@ func getApiContainerObjectsFromKubernetesResources(
 			publicIpAddr,
 			publicGrpcPortSpec,
 			nil,
+			false,
 		)
 
 		result[enclaveId] = apiContainerObj

--- a/container-engine-lib/lib/backend_interface/objects/api_container/api_container.go
+++ b/container-engine-lib/lib/backend_interface/objects/api_container/api_container.go
@@ -26,6 +26,9 @@ type APIContainer struct {
 	publicGrpcPort *port_spec.PortSpec
 
 	bridgeNetworkIpAddress net.IP
+
+	// Identifies if this API container is running in a production mode enclave
+	isProductionEnclave bool
 }
 
 func NewAPIContainer(
@@ -36,6 +39,7 @@ func NewAPIContainer(
 	publicIpAddr net.IP,
 	publicGrpcPort *port_spec.PortSpec,
 	bridgeNetworkIpAddress net.IP,
+	isProductionEnclave bool,
 ) *APIContainer {
 	return &APIContainer{
 		enclaveId:              enclaveId,
@@ -45,6 +49,7 @@ func NewAPIContainer(
 		publicIpAddr:           publicIpAddr,
 		publicGrpcPort:         publicGrpcPort,
 		bridgeNetworkIpAddress: bridgeNetworkIpAddress,
+		isProductionEnclave:    isProductionEnclave,
 	}
 }
 

--- a/container-engine-lib/lib/backend_interface/objects/api_container/api_container.go
+++ b/container-engine-lib/lib/backend_interface/objects/api_container/api_container.go
@@ -80,3 +80,7 @@ func (apiContainer *APIContainer) GetPublicIPAddress() net.IP {
 func (apiContainer *APIContainer) GetPublicGRPCPort() *port_spec.PortSpec {
 	return apiContainer.publicGrpcPort
 }
+
+func (apiContainer *APIContainer) IsProductionEnclave() bool {
+	return apiContainer.isProductionEnclave
+}


### PR DESCRIPTION
## Description
The `production mode` value is already in the `enclave` primitive but we also want to add it in the `APIC` primitive this way we will be able to get this data just by calling the `kurtosisBackend.GetAPIContainers()` instead of having to call the `kurtosisBackend.GetEnclaves()`which will demand more internal backend calls, and also because this data is stored in the APIC´s env vars.

Adding it only in the Docker backend because production mode is not implemented in Kubernetes yet.

## REMINDER: Tag Reviewers, so they get notified to review

## Is this change user facing?
NO

## References (if applicable)
This is part of the "Upgrade Kurtosis from the Cloud UI project"
