### PR TITLE
fix: clarify error message for kurtosis portal command

### DIFF
--- a/cli/cli/commands/portal/status/status.go
+++ b/cli/cli/commands/portal/status/status.go
@@ -35,7 +35,7 @@ func run(ctx context.Context, _ *flags.ParsedFlags, args *args.ParsedArgs) error
 		out.PrintOutLn(fmt.Sprintf("Kurtosis Portal is running and healthy on PID %d", pid))
 		return nil
 	} else if process != nil {
-		out.PrintOutLn(fmt.Sprintf("Kurtosis Portal process is on PID %d but it is unreachable", pid))
+		out.PrintOutLn(fmt.Sprintf("Kurtosis Portal process is running on PID %d but the cloud instance was unreachable. Check your network connection, or re-connect to your cloud instance: https://cloud.kurtosis.com/connect", pid))
 		return nil
 	} else if pid != 0 {
 		out.PrintOutLn("Kurtosis Portal PID file exits but process is dead")


### PR DESCRIPTION
## Description
In certain cases, the kurtosis portal may not be able to reach your cloud instance. In this case a `kurtosis run` command may output an error that suggests checking the health of your kurtosis portal

```
[...]
Make sure Kurtosis Portal is running locally with 'kurtosis portal status' and
potentially 'kurtosis portal start'. If it is, make sure the remote server is
running and healthy
```

Running `kurtosis portal status` results in a slightly misleading error message, for example:

```
Kurtosis Portal process is on PID 4615 but it is unreachable
```

`it is unreachable` suggests there is an issue with with `kurtosis portal` process when in reality there is an issue with the cloud instance being unreachable. This PR improves the error message.

## Is this change user facing?
YES

## References (if applicable)
- Slack discussion with @laurentluce 
