### PR TITLE
fix: restart APICs containers when the engine is restarted

### DIFF
--- a/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/engine_functions/create_engine.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/engine_functions/create_engine.go
@@ -29,8 +29,8 @@ const (
 	enclaveManagerUIPort                        = 9711
 	enclaveManagerAPIPort                       = 8081
 	engineDebugServerPort                       = 50102 // in ClI this is 50101 and 50103 for the APIC
-	maxWaitForEngineAvailabilityRetries         = 10
-	timeBetweenWaitForEngineAvailabilityRetries = 1 * time.Second
+	maxWaitForEngineAvailabilityRetries         = 40
+	timeBetweenWaitForEngineAvailabilityRetries = 2 * time.Second
 	logsStorageDirPath                          = "/var/log/kurtosis/"
 )
 

--- a/container-engine-lib/lib/backend_impls/docker/docker_manager/docker_manager.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_manager/docker_manager.go
@@ -1635,7 +1635,7 @@ func (manager *DockerManager) pullImage(context context.Context, imageName strin
 	logrus.Infof("Pulling image '%s'", imageName)
 	err, retryWithLinuxAmd64 := pullImage(manager.dockerClientNoTimeout, imageName, registrySpec, defaultPlatform)
 	if err == nil {
-		return stacktrace.Propagate(err, "An error occurred pulling image '%s'", imageName)
+		return nil
 	}
 	if err != nil && !retryWithLinuxAmd64 {
 		return stacktrace.Propagate(err, "Tried pulling image '%v' but failed", imageName)

--- a/container-engine-lib/lib/backend_impls/docker/docker_manager/docker_manager.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_manager/docker_manager.go
@@ -1635,7 +1635,7 @@ func (manager *DockerManager) pullImage(context context.Context, imageName strin
 	logrus.Infof("Pulling image '%s'", imageName)
 	err, retryWithLinuxAmd64 := pullImage(manager.dockerClientNoTimeout, imageName, registrySpec, defaultPlatform)
 	if err == nil {
-		return nil
+		return stacktrace.Propagate(err, "An error occurred pulling image '%s'", imageName)
 	}
 	if err != nil && !retryWithLinuxAmd64 {
 		return stacktrace.Propagate(err, "Tried pulling image '%v' but failed", imageName)

--- a/engine/server/engine/main.go
+++ b/engine/server/engine/main.go
@@ -261,6 +261,12 @@ func runMain() error {
 		}
 	}()
 
+	if serverArgs.RestartAPIContainers {
+		if err := enclaveManager.RestartAllEnclaveAPIContainers(ctx); err != nil {
+			return stacktrace.Propagate(err, "An error occurred restarting all API containers.")
+		}
+	}
+
 	go func() {
 		err := restApiServer(
 			ctx,
@@ -291,12 +297,6 @@ func runMain() error {
 			logrus.Errorf("We tried to close the engine connect server service but something fails. Err:\n%v", err)
 		}
 	}()
-
-	if serverArgs.RestartAPIContainers {
-		if err := enclaveManager.RestartAllEnclaveAPIContainers(ctx); err != nil {
-			return stacktrace.Propagate(err, "An error occurred restarting all API containers.")
-		}
-	}
 
 	engineHttpServer := connect_server.NewConnectServer(serverArgs.GrpcListenPortNum, grpcServerStopGracePeriod, handler, apiPath)
 	if err := engineHttpServer.RunServerUntilInterruptedWithCors(cors.AllowAll()); err != nil {


### PR DESCRIPTION
## Description
Fixing the issue when running the `kurtosis engine restart --restart-apic-containers`. The issue was happening when the Engine's REST API was trying to reconnect to all the enclaves while the APIC containers were in the restart process.

We are also increasing the engine's readiness check time because the restart process could take more than 1 minutes if there are many APIC containers running


## REMINDER: Tag Reviewers, so they get notified to review

## Is this change user facing?
YES

## References (if applicable)
This is part of the `upgrade kurtosis from the UI` project
