### PR TITLE
chore: remove the env vars from the error stack

### DIFF
--- a/engine/launcher/engine_server_launcher/engine_server_launcher.go
+++ b/engine/launcher/engine_server_launcher/engine_server_launcher.go
@@ -137,7 +137,7 @@ func (launcher *EngineServerLauncher) LaunchWithCustomVersion(
 		githubAuthToken,
 	)
 	if err != nil {
-		return nil, nil, stacktrace.Propagate(err, "An error occurred launching the engine server container with environment variables '%+v'", envVars)
+		return nil, nil, stacktrace.Propagate(err, "An error occurred launching the engine server container")
 	}
 	return engine.GetPublicIPAddress(), engine.GetPublicGRPCPort(), nil
 }


### PR DESCRIPTION
## Description
remove the env vars from the error stack

## REMINDER: Tag Reviewers, so they get notified to review

## Is this change user facing?
NO

## References (if applicable)
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
<!-- You can auto-close issues by putting "Fixes #XXXX" here. -->
