### PR TITLE
feat: nixify

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,7 @@ lerna-debug.log
 yarn.lock
 package.json
 package-lock.json
+
+# Nix
+# ignores the default result symlink created when building with nix
+result

--- a/enclave-manager/local/go.mod
+++ b/enclave-manager/local/go.mod
@@ -1,0 +1,15 @@
+module github.com/kurtosis-tech/kurtosis/enclave-manager/local
+
+go 1.20
+replace (
+	github.com/kurtosis-tech/kurtosis/enclave-manager => ../server
+	github.com/kurtosis-tech/kurtosis/contexts-config-store => ../../contexts-config-store
+	github.com/kurtosis-tech/kurtosis/kurtosis_version => ../../kurtosis_version
+)
+
+require (
+	github.com/kurtosis-tech/kurtosis/enclave-manager v0.0.0-20230828153722-32770ca96513
+  github.com/sirupsen/logrus v1.9.3
+)
+
+require golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 // indirect

--- a/enclave-manager/local/go.sum
+++ b/enclave-manager/local/go.sum
@@ -1,0 +1,15 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
+github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 h1:0A+M6Uqn+Eje4kHMK80dtF3JCXC4ykBgQG4Fe06QRhQ=
+golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/flake.lock
+++ b/flake.lock
@@ -58,11 +58,11 @@
     },
     "unstable": {
       "locked": {
-        "lastModified": 1706371002,
-        "narHash": "sha256-dwuorKimqSYgyu8Cw6ncKhyQjUDOyuXoxDTVmAXq88s=",
+        "lastModified": 1716509168,
+        "narHash": "sha256-4zSIhSRRIoEBwjbPm3YiGtbd8HDWzFxJjw5DYSDy1n8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c002c6aa977ad22c60398daaa9be52f2203d0006",
+        "rev": "bfb7a882678e518398ce9a31a881538679f6f092",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
     flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { nixpkgs, unstable, flake-utils, ... }:
+  outputs = { self, nixpkgs, unstable, flake-utils, ... }:
     let utils = flake-utils;
     in utils.lib.eachDefaultSystem (system:
       let
@@ -17,8 +17,14 @@
           inherit pkgs system;
           nodejs = pkgs.nodejs_20;
         };
-      in {
+      in
+      {
         formatter = pkgs.nixpkgs-fmt;
+
+        packages = rec {
+          default = kurtosis;
+          kurtosis = unstable_pkgs.callPackage ./package.nix { };
+        };
 
         devShell = pkgs.mkShell {
           nativeBuildInputs = with pkgs;
@@ -27,7 +33,8 @@
                 import ./nix-pkgs/openapi-codegen.nix { inherit pkgs; };
               grpc-tools-node =
                 import ./nix-pkgs/grpc-tools-node.nix { inherit pkgs; };
-            in [
+            in
+            [
               goreleaser
               go_1_20
               gopls

--- a/go.work
+++ b/go.work
@@ -10,6 +10,7 @@ use (
 	./core/launcher
 	./core/server
 	./enclave-manager/api/golang
+	./enclave-manager/local
 	./enclave-manager/server
 	./engine/launcher
 	./engine/server

--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,54 @@
+{ lib
+, buildGoModule
+, writeTextFile
+}:
+
+buildGoModule rec {
+  pname = "kurtosis";
+  version = "0.89.11";
+
+  src = ./.;
+
+  proxyVendor = true;
+  vendorHash = "sha256-GaEIitoRiuYxtS7cDKobFyIlraDNQjcvbRvzG3nUKFU=";
+
+  postPatch =
+    let
+      kurtosisVersion = writeTextFile {
+        name = "kurtosis_verion.go";
+        text = ''
+          package kurtosis_version
+          const (
+            KurtosisVersion = "${version}"
+          )
+        '';
+      };
+    in
+    ''
+      ln -s ${kurtosisVersion} kurtosis_version/kurtosis_version.go
+    '';
+
+  # disable checks temporarily since they connect to the internet
+  # namely user_support_constants_test.go
+  doCheck = false;
+
+  # keep this for future reference
+  preCheck = ''
+    # some tests in commands use XDG home related environment variables
+    export HOME=/tmp
+  '';
+
+  postInstall = ''
+    mv $out/bin/cli $out/bin/kurtosis
+    mv $out/bin/files_artifacts_expander $out/bin/files-artifacts-expander
+    mv $out/bin/api_container $out/bin/api-container
+
+  '';
+
+  meta = with lib; {
+    description = "A platform for launching an ephemeral Ethereum backend";
+    mainProgram = "kurtosis";
+    homepage = "https://github.com/kurtosis-tech/kurtosis";
+    license = licenses.asl20;
+  };
+}


### PR DESCRIPTION
## Description
Packaged kurtosis with nix.

It's worth mentioning that we tested that the resulting binary works/is used in one of our projects https://github.com/cspr-rad/acropolis

To try it out run, checkout the branch and run
```console
$ nix shell .#kurtosis
```
or (without checking out)
```console
$ nix shell github:kurtosis-tech/kurtosis/nixify
```
or (once merged)
```console
$ nix shell github:kurtosis-tech/kurtosis
```

## REMINDER: Tag Reviewers, so they get notified to review
@lostbean 
## Is this change user facing?
It is, but it only adds the capability to add kurtosis as a dependency with nix
