### PR TITLE
feat: increase max upload size

### DIFF
--- a/path-compression/path_compresssion.go
+++ b/path-compression/path_compresssion.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	kurtosisDataTransferLimit = 2000 * 1024 * 1024 // 2 GB
+	kurtosisDataTransferLimit = 2000 * 1024 * 1024 // ~2 GB
 	tempCompressionDirPattern = "upload-compression-cache-"
 	compressionExtension      = ".tgz"
 	defaultTmpDir             = ""

--- a/path-compression/path_compresssion.go
+++ b/path-compression/path_compresssion.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	kurtosisDataTransferLimit = 100 * 1024 * 1024 // 100 MB
+	kurtosisDataTransferLimit = 2000 * 1024 * 1024 // 2 GB
 	tempCompressionDirPattern = "upload-compression-cache-"
 	compressionExtension      = ".tgz"
 	defaultTmpDir             = ""
@@ -94,8 +94,8 @@ func CompressPathToFile(pathToCompress string, enforceMaxFileSizeLimit bool) (st
 
 	if enforceMaxFileSizeLimit && compressedFileSize >= kurtosisDataTransferLimit {
 		return "", 0, nil, stacktrace.NewError(
-			"The files you are trying to upload, which are now compressed, exceed or reach 100mb. " +
-				"Manipulation (i.e. uploads or downloads) of files larger than 100mb is currently disallowed in Kurtosis.")
+			"The files you are trying to upload, which are now compressed, exceed or reach 2 GB. " +
+				"Manipulation (i.e. uploads or downloads) of files larger than 2 GB is currently disallowed in Kurtosis.")
 	}
 
 	return compressedFilePath, compressedFileSize, compressedFileContentMd5.Sum(nil), nil


### PR DESCRIPTION
## Description
Users trying to use `ImageBuildSpec` to build images inside their packages have repositories greater than 100MB. Image building in Kurtosis requires that the entire build context is within the package, and thus gets uploaded into the APIContainer where the validation step that builds images is done.

This PR increases the upload limit of the compression / upload library to account for larger repositorie (2GB)

## Is this change user facing?
YES

## References (if applicable)
https://github.com/ethpandaops/optimism-package/issues/72
