### PR TITLE
fix: use docker client without timeout for copy files operation

### DIFF
--- a/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/user_services_functions/copy_files_from_user_service.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/user_services_functions/copy_files_from_user_service.go
@@ -26,6 +26,7 @@ func CopyFilesFromUserService(
 	output io.Writer,
 	dockerManager *docker_manager.DockerManager,
 ) error {
+	ctx = context.WithoutCancel(ctx)
 
 	srcPath := srcPathOnContainer
 	srcPathBase := filepath.Base(srcPathOnContainer)

--- a/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/user_services_functions/copy_files_from_user_service.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/user_services_functions/copy_files_from_user_service.go
@@ -26,7 +26,7 @@ func CopyFilesFromUserService(
 	output io.Writer,
 	dockerManager *docker_manager.DockerManager,
 ) error {
-	ctx = context.WithoutCancel(ctx)
+	ctxWithoutCancel := context.WithoutCancel(ctx)
 
 	srcPath := srcPathOnContainer
 	srcPathBase := filepath.Base(srcPathOnContainer)
@@ -36,13 +36,13 @@ func CopyFilesFromUserService(
 	}
 
 	logrus.Debugf("Copying contents from the src path: %v and base %v", srcPath, srcPathBase)
-	_, serviceDockerResources, err := getSingleUserServiceObjAndResourcesNoMutex(ctx, enclaveId, serviceUuid, dockerManager)
+	_, serviceDockerResources, err := getSingleUserServiceObjAndResourcesNoMutex(ctxWithoutCancel, enclaveId, serviceUuid, dockerManager)
 	if err != nil {
 		return stacktrace.Propagate(err, "An error occurred getting user service with UUID '%v' in enclave with ID '%v'", serviceUuid, enclaveId)
 	}
 	container := serviceDockerResources.ServiceContainer
 
-	tarStreamReadCloser, err := dockerManager.CopyFromContainer(ctx, container.GetId(), srcPath)
+	tarStreamReadCloser, err := dockerManager.CopyFromContainer(ctxWithoutCancel, container.GetId(), srcPath)
 	if err != nil {
 		return stacktrace.Propagate(
 			err,

--- a/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/user_services_functions/copy_files_from_user_service.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/user_services_functions/copy_files_from_user_service.go
@@ -26,8 +26,6 @@ func CopyFilesFromUserService(
 	output io.Writer,
 	dockerManager *docker_manager.DockerManager,
 ) error {
-	ctxWithoutCancel := context.WithoutCancel(ctx)
-
 	srcPath := srcPathOnContainer
 	srcPathBase := filepath.Base(srcPathOnContainer)
 	if srcPathBase == doNotIncludeParentDirInArchiveSymbol {
@@ -36,13 +34,13 @@ func CopyFilesFromUserService(
 	}
 
 	logrus.Debugf("Copying contents from the src path: %v and base %v", srcPath, srcPathBase)
-	_, serviceDockerResources, err := getSingleUserServiceObjAndResourcesNoMutex(ctxWithoutCancel, enclaveId, serviceUuid, dockerManager)
+	_, serviceDockerResources, err := getSingleUserServiceObjAndResourcesNoMutex(ctx, enclaveId, serviceUuid, dockerManager)
 	if err != nil {
 		return stacktrace.Propagate(err, "An error occurred getting user service with UUID '%v' in enclave with ID '%v'", serviceUuid, enclaveId)
 	}
 	container := serviceDockerResources.ServiceContainer
 
-	tarStreamReadCloser, err := dockerManager.CopyFromContainer(ctxWithoutCancel, container.GetId(), srcPath)
+	tarStreamReadCloser, err := dockerManager.CopyFromContainer(ctx, container.GetId(), srcPath)
 	if err != nil {
 		return stacktrace.Propagate(
 			err,

--- a/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/user_services_functions/copy_files_from_user_service.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/user_services_functions/copy_files_from_user_service.go
@@ -54,10 +54,11 @@ func CopyFilesFromUserService(
 	}
 	defer tarStreamReadCloser.Close()
 
-	if _, err := io.Copy(output, tarStreamReadCloser); err != nil {
+	if numBytesCopied, err := io.Copy(output, tarStreamReadCloser); err != nil {
 		return stacktrace.Propagate(
 			err,
-			"An error occurred copying the bytes of TAR'd up files at '%v' on service '%v' to the output",
+			"'%v' bytes copied before an error occurred copying the bytes of TAR'd up files at '%v' on service '%v' to the output",
+			numBytesCopied,
 			srcPathOnContainer,
 			serviceUuid,
 		)

--- a/container-engine-lib/lib/backend_impls/docker/docker_manager/docker_manager.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_manager/docker_manager.go
@@ -1553,7 +1553,7 @@ func (manager *DockerManager) CopyFromContainer(ctx context.Context, containerId
 		}
 	}
 
-	tarStreamReadCloser, _, err := manager.dockerClient.CopyFromContainer(
+	tarStreamReadCloser, _, err := manager.dockerClientNoTimeout.CopyFromContainer(
 		ctx,
 		containerId,
 		srcPath)


### PR DESCRIPTION
## Description
If the a user tries to do `store_service_files` on a large directory, they will receive a timeout. To fix this, use the docker client with no timeout when copying files from service container.

## Is this change user facing?
NO

