### PR TITLE
chore: pin besu img

### DIFF
--- a/internal_testsuites/golang/testsuite/startlark_user_passing_test/starlark_user_passing_test.go
+++ b/internal_testsuites/golang/testsuite/startlark_user_passing_test/starlark_user_passing_test.go
@@ -14,7 +14,7 @@ const (
 	userOverrideServiceName = "user-override"
 
 	starlarkScriptWithUserIdPassed = `
-IMAGE = "hyperledger/besu:latest"
+IMAGE = "hyperledger/besu:24.3"
 def run(plan, args):
 	no_override = plan.add_service(
 		name = "` + noOverrideServiceName + `",


### PR DESCRIPTION
## Description
Latest besu image runs on root causing our test for `User` override to fail. This PR pins to an older version of besu where user was not root.

## Is this change user facing?
NO
