### PR TITLE
fix: handle no docker auth and log only a warning when getting auth credentials fails

### DIFF
--- a/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/engine_functions/docker_config_storage_creator/docker_config_storage_creator.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/engine_functions/docker_config_storage_creator/docker_config_storage_creator.go
@@ -114,10 +114,10 @@ func storeConfigInVolume(
 	for _, registry := range registries {
 		creds, err := docker_manager.GetAuthFromDockerConfig(registry)
 		if err != nil {
-			return stacktrace.NewError("An error occurred getting auth for registry '%v' from Docker config: %v", registry, err)
+			logrus.Warnf("An error occurred getting auth for registry '%v' from Docker config: %v", registry, err)
 		}
 		// creds can be nil if the registry doesn't have auth
-		if creds != nil {
+		if err != nil && creds != nil {
 			cfg.Auths[registry] = *creds
 		}
 	}

--- a/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/engine_functions/docker_config_storage_creator/docker_config_storage_creator.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/engine_functions/docker_config_storage_creator/docker_config_storage_creator.go
@@ -116,7 +116,10 @@ func storeConfigInVolume(
 		if err != nil {
 			return stacktrace.NewError("An error occurred getting auth for registry '%v' from Docker config: %v", registry, err)
 		}
-		cfg.Auths[registry] = *creds
+		// creds can be nil if the registry doesn't have auth
+		if creds != nil {
+			cfg.Auths[registry] = *creds
+		}
 	}
 
 	cfgJsonStr, err := json.Marshal(cfg)

--- a/container-engine-lib/lib/backend_impls/docker/docker_manager/docker_auth_test.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_manager/docker_auth_test.go
@@ -27,6 +27,13 @@ func writeStaticConfig(t *testing.T, configContent string) string {
 	return tmpDir
 }
 
+func TestGetNoAuth(t *testing.T) {
+	os.Setenv(ENV_DOCKER_CONFIG, "/does/not/exist")
+	authConfig, err := GetAuthFromDockerConfig("my-repo/my-image:latest")
+	assert.NoError(t, err)
+	assert.Nil(t, authConfig, "Auth config should be nil")
+}
+
 func TestGetAuthConfigForRepoPlain(t *testing.T) {
 	expectedUser := "user"
 	expectedPassword := "password"

--- a/container-engine-lib/lib/backend_impls/docker/docker_manager/docker_auth_test.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_manager/docker_auth_test.go
@@ -27,8 +27,7 @@ func writeStaticConfig(t *testing.T, configContent string) string {
 	return tmpDir
 }
 
-func TestGetNoAuth(t *testing.T) {
-	os.Setenv(ENV_DOCKER_CONFIG, "/does/not/exist")
+func TestGetAuthWithNoAuthSetReturnsNilAndNoError(t *testing.T) {
 	authConfig, err := GetAuthFromDockerConfig("my-repo/my-image:latest")
 	assert.NoError(t, err)
 	assert.Nil(t, authConfig, "Auth config should be nil")


### PR DESCRIPTION
Fix for : 

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xc0fcb6]

goroutine 1 [running]:
github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/engine_functions/docker_config_storage_creator.storeConfigInVolume({0x2879630, 0xc000062160}, 0xc000062160?, {0xc00017d240, 0x40}, 0x2, 0x7f88a4ef0960?, {0x22d6d69, 0xe})
	/root/project/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/engine_functions/docker_config_storage_creator/docker_config_storage_creator.go:119 +0x756
github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/engine_functions/docker_config_storage_creator.CreateDockerConfigStorage({0x2879630, 0xc000062160}, {0xc00055c240, 0x40}, {0x22fc9c9, 0x1e}, {0x22d6d69, 0xe}, 0xc000093080)
	/root/project/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/engine_functions/docker_config_storage_creator/docker_config_storage_creator.go:79 +0x42f
github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/engine_functions.CreateEngine({0x2879630, 0xc000062160}, {0x22e3b55, 0x13}, {0x22c6bf3, 0x5}, 0x25ee, 0xc00040e6c0, 0x0, {0x0, ...}, ...)
	/root/project/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/engine_functions/create_engine.go:268 +0x1ebe
github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend.(*DockerKurtosisBackend).CreateEngine(0xc0006f3470?, {0x2879630?, 0xc000062160?}, {0x22e3b55?, 0xc0006f34d8?}, {0x22c6bf3?, 0x1f66100?}, 0xe6c0?, 0x22d9c8b?, 0x0, ...)
	/root/project/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/docker_kurtosis_backend.go:121 +0x91
github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_impls/metrics_reporting.(*MetricsReportingKurtosisBackend).CreateEngine(0x0?, {0x2879630?, 0xc000062160?}, {0x22e3b55, 0x13}, {0x22c6bf3, 0x5}, 0x0?, 0x3bafb00?, 0x0, ...)
	/root/project/container-engine-lib/lib/backend_impls/metrics_reporting/metrics_reporting_kurtosis_backend.go:60 +0x8a
github.com/kurtosis-tech/kurtosis/engine/launcher/engine_server_launcher.(*EngineServerLauncher).LaunchWithCustomVersion(0xc000530150, {0x2879630, 0xc000062160}, {0x22c6bf3, 0x5}, 0x6f3698?, 0xc0?, {0xc000056d80, 0x40}, 0x0, ...)
	/root/project/engine/launcher/engine_server_launcher/engine_server_launcher.go:138 +0x275
github.com/kurtosis-tech/kurtosis/engine/launcher/engine_server_launcher.(*EngineServerLauncher).LaunchWithDefaultVersion(0xc00083e8a0?, {0x2879630?, 0xc000062160?}, 0x40e210?, 0xc0?, {0xc000056d80?, 0x[20](https://github.com/ethpandaops/ethereum-package/actions/runs/11596169403/job/32286576485#step:5:21)3000?}, 0x0?, {0x2860ba0, 0x3c9fe38}, ...)
	/root/project/engine/launcher/engine_server_launcher/engine_server_launcher.go:57 +0x165
github.com/kurtosis-tech/kurtosis/cli/cli/helpers/engine_manager.(*engineExistenceGuarantor).VisitStopped(0xc0003ae1c0)
	/root/project/cli/cli/helpers/engine_manager/engine_existence_guarantor.go:220 +0x8b1
github.com/kurtosis-tech/kurtosis/cli/cli/helpers/engine_manager.EngineStatus.Accept({0x22ca44c?, 0x3ca[21](https://github.com/ethpandaops/ethereum-package/actions/runs/11596169403/job/32286576485#step:5:22)a0?}, {0x286b2e0?, 0xc0003ae1c0?})
	/root/project/cli/cli/helpers/engine_manager/engine_status.go:20 +0x75
github.com/kurtosis-tech/kurtosis/cli/cli/helpers/engine_manager.(*EngineManager).startEngineWithGuarantor(0xc0004072c0, {0x2879630, 0xc000062160}, {0x[22](https://github.com/ethpandaops/ethereum-package/actions/runs/11596169403/job/32286576485#step:5:23)ca44c?, 0xc0006f3ab8?}, 0xc0003ae1c0)
	/root/project/cli/cli/helpers/engine_manager/engine_manager.go:400 +0x65
github.com/kurtosis-tech/kurtosis/cli/cli/helpers/engine_manager.(*EngineManager).StartEngineIdempotentlyWithDefaultVersion(0xc0004072c0, {0x2879630?, 0xc000062160}, 0x5, 0x0, {0x0, 0x0}, 0x0, {0x0, 0x0}, ...)
	/root/project/cli/cli/helpers/engine_manager/engine_manager.go:214 +0x436
github.com/kurtosis-tech/kurtosis/cli/cli/command_framework/highlevel/engine_consuming_kurtosis_command.(*EngineConsumingKurtosisCommand).getSetupFunc.func1({0x2879630, 0xc000062160})
	/root/project/cli/cli/command_framework/highlevel/engine_consuming_kurtosis_command/engine_consuming_kurtosis_command.go:190 +0x305
github.com/kurtosis-tech/kurtosis/cli/cli/command_framework/lowlevel.(*LowlevelKurtosisCommand).MustGetCobraCommand.func2(0xc000827800?, {0xc000825[23](https://github.com/ethpandaops/ethereum-package/actions/runs/11596169403/job/32286576485#step:5:24)0, 0x1, 0x3})
	/root/project/cli/cli/command_framework/lowlevel/lowlevel_kurtosis_command.go:280 +0x124
github.com/spf13/cobra.(*Command).execute(0xc000827800, {0xc0008251d0, 0x3, 0x3})
	/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:940 +0x862
github.com/spf13/cobra.(*Command).ExecuteC(0x3b9a580)
	/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:1068 +0x3bd
github.com/spf13/cobra.(*Command).Execute(...)
	/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:992
main.main()
	/root/project/cli/cli/main.go:52 +0x7d
```

And also just logging, instead of throwing a stacktrace error whenever auth credentials failed to be obtained. Fixes:

```
Error:  An error occurred running command 'restart'
  Caused by: An error occurred restarting the Kurtosis engine
  Caused by: An error occurred starting a new engine
  Caused by: An error occurred starting the engine with the engine existence guarantor
  Caused by: An error occurred guaranteeing that a Kurtosis engine is running
  Caused by: An error occurred launching the engine server container
  Caused by: An error occurred launching the engine server container with default version tag '1.4.0'
  Caused by: An error occurred launching the engine server container
  Caused by: An error occurred creating the engine using image 'kurtosistech/engine' with tag '1.4.0' and debug mode 'false'
  Caused by: An error occurred creating Docker config storage.
  Caused by: An error occurred creating  Docker config storage in volume.
  Caused by: An error occurred getting auth for registry 'https://index.docker.io/v1/' from Docker config: error executing credential helper '/usr/bin/docker-credential-desktop get' for 'https://index.docker.io': 
  Caused by: exit status 1
 ```


BEGIN_COMMIT_OVERRIDE
fix: docker auth panic
END_COMMIT_OVERRIDE
