### PR TITLE
chore: update release-please to v4

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'kurtosis-tech/kurtosis'
     steps:
-      - uses: google-github-actions/release-please-action@v4
+      - uses: googleapis/release-please-action@v4
         with:
           # We use the RELEASER_TOKEN so that the GitHub Actions
           # can run on the PR created

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,9 +16,3 @@ jobs:
           # https://github.com/kurtosis-tech/kurtosis/issues/688
           token: "${{ secrets.RELEASER_TOKEN }}"
           release-type: simple
-          package-name: kurtosis
-          bump-minor-pre-major: false
-          bump-patch-for-minor-pre-major: false
-          # Our CI, Docker Images, Kurtosis-SDK bumps all depend on
-          # non v tags
-          include-v-in-tag: false

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'kurtosis-tech/kurtosis'
     steps:
-      - uses: google-github-actions/release-please-action@v3
+      - uses: google-github-actions/release-please-action@v4
         with:
           # We use the RELEASER_TOKEN so that the GitHub Actions
           # can run on the PR created

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,0 +1,10 @@
+{
+  "packages": {
+    ".": {
+      "package-name": "kurtosis",
+      "bump-minor-pre-major": false,
+      "bump-path-for-minor-pre-major": false,
+      "include-v-in-tag": false
+    }
+  }
+}


### PR DESCRIPTION
Should give more verbose info on the current problem with:

> commit could not be parsed: b36ddc9d6c3b2baa8fe03a3f27ec5f3cae68c043 fix: handle no docker auth and log only a warning when getting auth credentials fails (#2579) 

As per https://github.com/googleapis/release-please/issues/2298