### PR TITLE
chore: bump to release please action to commit with parse commit err log

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'kurtosis-tech/kurtosis'
     steps:
-      - uses: google-github-actions/release-please-action@v4
+      - uses: googleapis/release-please-action@v4
         with:
           # We use the RELEASER_TOKEN so that the GitHub Actions
           # can run on the PR created

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,9 +16,3 @@ jobs:
           # https://github.com/kurtosis-tech/kurtosis/issues/688
           token: "${{ secrets.RELEASER_TOKEN }}"
           release-type: simple
-          package-name: kurtosis
-          bump-minor-pre-major: false
-          bump-patch-for-minor-pre-major: false
-          # Our CI, Docker Images, Kurtosis-SDK bumps all depend on
-          # non v tags
-          include-v-in-tag: false

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'kurtosis-tech/kurtosis'
     steps:
-      - uses: google-github-actions/release-please-action@v3
+      - uses: google-github-actions/release-please-action@v4
         with:
           # We use the RELEASER_TOKEN so that the GitHub Actions
           # can run on the PR created

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'kurtosis-tech/kurtosis'
     steps:
-      - uses: googleapis/release-please-action@v4.1.3
+      - uses: googleapis/release-please-action@d1a8f221d7723166f48a584aebba00ef3f6febec
         with:
           # We use the RELEASER_TOKEN so that the GitHub Actions
           # can run on the PR created

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'kurtosis-tech/kurtosis'
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v4.1.3
         with:
           # We use the RELEASER_TOKEN so that the GitHub Actions
           # can run on the PR created

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,0 +1,10 @@
+{
+  "packages": {
+    ".": {
+      "package-name": "kurtosis",
+      "bump-minor-pre-major": false,
+      "bump-path-for-minor-pre-major": false,
+      "include-v-in-tag": false
+    }
+  }
+}


### PR DESCRIPTION
## Description
Debug log to view err for parsing commits is on 4.1.3 


## Is this change user facing?
NO