### PR TITLE
fix: make releases work again by removing the v prefix on tags

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -4,7 +4,7 @@
       "package-name": "kurtosis",
       "bump-minor-pre-major": false,
       "bump-path-for-minor-pre-major": false,
-      "include-v-in-tag": false
+      "include-v-in-tags": false
     }
   },
   ".": "1.4.1"


### PR DESCRIPTION
## Description
<!-- Describe this change, how it works, and the motivation behind it. -->

## REMINDER: Tag Reviewers, so they get notified to review

## Is this change user facing?
NO
<!-- If yes, please add the "user facing" label to the PR -->
<!-- If yes, don't forget to include docs changes where relevant -->

## References (if applicable)
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
<!-- You can auto-close issues by putting "Fixes #XXXX" here. -->
