### PR TITLE
fix: make releases work again without v in tags

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,3 +16,5 @@ jobs:
           # https://github.com/kurtosis-tech/kurtosis/issues/688
           token: "${{ secrets.RELEASER_TOKEN }}"
           release-type: simple
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,11 +1,3 @@
 {
-  "packages": {
-    ".": {
-      "package-name": "kurtosis",
-      "bump-minor-pre-major": false,
-      "bump-path-for-minor-pre-major": false,
-      "include-v-in-tag": false
-    }
-  },
   ".": "1.4.1"
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,10 @@
+{
+  "packages": {
+    ".": {
+      "package-name": "kurtosis",
+      "bump-minor-pre-major": false,
+      "bump-path-for-minor-pre-major": false,
+      "include-v-in-tag": false
+    }
+  }
+}


### PR DESCRIPTION
## Description
<!-- Describe this change, how it works, and the motivation behind it. -->

The release please config was put into the manifest file. That should not be the case. The config file is a separate file. That's why the config wasn't read and we ended up having the `v` prefix in the most recent 1.4.1 release. 

More infos https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md#bootstrap-manually 

## REMINDER: Tag Reviewers, so they get notified to review

## Is this change user facing?
NO
<!-- If yes, please add the "user facing" label to the PR -->
<!-- If yes, don't forget to include docs changes where relevant -->

## References (if applicable)
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
<!-- You can auto-close issues by putting "Fixes #XXXX" here. -->
