### PR TITLE
fix: don't include component name in release please tags

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,6 +4,7 @@
   "bump-minor-pre-major": false,
   "bump-patch-for-minor-pre-major": false,
   "include-v-in-tag": false,
+  "include-component-in-tag": false,
   "packages": {
     ".": {
       "package-name": "kurtosis"


### PR DESCRIPTION
## Description
<!-- Describe this change, how it works, and the motivation behind it. -->
We need to remove the component from the release now. It made a [2.0.0 PR](https://github.com/kurtosis-tech/kurtosis/pull/2589) because it thinks it's a new component named "kurtosis" . We need to remove that component prefix. Then it should be able to pickup previous releases and not create a 2.0.0 .. which it's now creating because it's ignoring all past releases due to it thinking that it's a new component (app)
## REMINDER: Tag Reviewers, so they get notified to review

## Is this change user facing?
NO
<!-- If yes, please add the "user facing" label to the PR -->
<!-- If yes, don't forget to include docs changes where relevant -->

## References (if applicable)
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
<!-- You can auto-close issues by putting "Fixes #XXXX" here. -->
