### PR TITLE
fix: import package with same prefix name as the root package

### DIFF
--- a/core/server/api_container/server/startosis_engine/startosis_packages/git_package_content_provider/git_package_content_provider_test.go
+++ b/core/server/api_container/server/startosis_engine/startosis_packages/git_package_content_provider/git_package_content_provider_test.go
@@ -612,17 +612,32 @@ func TestGetAbsoluteLocator_RepositoriesWithSamePrefixNameShouldNotBeBlocked(t *
 }
 
 func Test_isSamePackageLocalAbsoluteLocator_TestDetectionInSubpath(t *testing.T) {
+	// Without root package id trailing slash.
 	result := shouldBlockAbsoluteLocatorBecauseIsInTheSameSourceModuleLocatorPackage("github.com/author/package/bang/lib.star", "github.com/author/package/main.star", "github.com/author/package")
+	require.True(t, result)
+
+	// With root package id trailing slash.
+	result = shouldBlockAbsoluteLocatorBecauseIsInTheSameSourceModuleLocatorPackage("github.com/author/package/bang/lib.star", "github.com/author/package/main.star", "github.com/author/package/")
 	require.True(t, result)
 }
 
 func Test_isSamePackageLocalAbsoluteLocator_TestDetectionInDifferentSubdirectories(t *testing.T) {
+	// Without root package id trailing slash.
 	result := shouldBlockAbsoluteLocatorBecauseIsInTheSameSourceModuleLocatorPackage("github.com/author/package/subdir1/file1.star", "github.com/author/package/subdir2/file2.star", "github.com/author/package")
+	require.True(t, result)
+
+	// With root package id trailing slash.
+	result = shouldBlockAbsoluteLocatorBecauseIsInTheSameSourceModuleLocatorPackage("github.com/author/package/subdir1/file1.star", "github.com/author/package/subdir2/file2.star", "github.com/author/package/")
 	require.True(t, result)
 }
 
 func Test_isNotSamePackageLocalAbsoluteLocator_TestRepositoriesWithSamePrefixNames(t *testing.T) {
+	// Without root package id trailing slash.
 	result := shouldBlockAbsoluteLocatorBecauseIsInTheSameSourceModuleLocatorPackage("github.com/author/package2/main.star", "github.com/author/package/main.star", "github.com/author/package")
+	require.False(t, result)
+
+	// With root package id trailing slash.
+	result = shouldBlockAbsoluteLocatorBecauseIsInTheSameSourceModuleLocatorPackage("github.com/author/package2/main.star", "github.com/author/package/main.star", "github.com/author/package/")
 	require.False(t, result)
 }
 

--- a/core/server/api_container/server/startosis_engine/startosis_packages/git_package_content_provider/git_package_content_provider_test.go
+++ b/core/server/api_container/server/startosis_engine/startosis_packages/git_package_content_provider/git_package_content_provider_test.go
@@ -600,6 +600,17 @@ func TestGetAbsoluteLocator_AbsoluteLocatorIsInRootPackageButSourceIsNotShouldNo
 	require.Nil(t, err)
 }
 
+func TestGetAbsoluteLocator_RepositoriesWithSamePrefixNameShouldNotBeBlocked(t *testing.T) {
+	provider := NewGitPackageContentProvider("", "", NewGitHubPackageAuthProvider(""), nil)
+
+	packageId := "github.com/main-package"
+	locatorOfModuleInWhichThisBuiltInIsBeingCalled := "github.com/main-package-xyz/main.star" // same package prefix
+	maybeRelativeLocator := "github.com/main-package/file.star"
+
+	_, err := provider.GetAbsoluteLocator(packageId, locatorOfModuleInWhichThisBuiltInIsBeingCalled, maybeRelativeLocator, noPackageReplaceOptions)
+	require.Nil(t, err)
+}
+
 func Test_isSamePackageLocalAbsoluteLocator_TestDetectionInSubpath(t *testing.T) {
 	result := shouldBlockAbsoluteLocatorBecauseIsInTheSameSourceModuleLocatorPackage("github.com/author/package/bang/lib.star", "github.com/author/package/main.star", "github.com/author/package/")
 	require.True(t, result)

--- a/core/server/api_container/server/startosis_engine/startosis_packages/git_package_content_provider/git_package_content_provider_test.go
+++ b/core/server/api_container/server/startosis_engine/startosis_packages/git_package_content_provider/git_package_content_provider_test.go
@@ -2,6 +2,10 @@ package git_package_content_provider
 
 import (
 	"fmt"
+	"os"
+	"path"
+	"testing"
+
 	"github.com/kurtosis-tech/kurtosis/api/golang/core/lib/shared_utils"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/database_accessors/enclave_db"
 	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/docker_compose_transpiler"
@@ -12,9 +16,6 @@ import (
 	"github.com/kurtosis-tech/stacktrace"
 	"github.com/stretchr/testify/require"
 	bolt "go.etcd.io/bbolt"
-	"os"
-	"path"
-	"testing"
 )
 
 const (
@@ -600,7 +601,7 @@ func TestGetAbsoluteLocator_AbsoluteLocatorIsInRootPackageButSourceIsNotShouldNo
 	require.Nil(t, err)
 }
 
-func TestGetAbsoluteLocator_RepositoriesWithSamePrefixNameShouldNotBeBlocked(t *testing.T) {
+func TestGetAbsoluteLocator_ImportPackageWithSamePrefixNameAsRootPackageShouldNotBeBlocked(t *testing.T) {
 	provider := NewGitPackageContentProvider("", "", NewGitHubPackageAuthProvider(""), nil)
 
 	packageId := "github.com/main-package"
@@ -631,7 +632,7 @@ func Test_isSamePackageLocalAbsoluteLocator_TestDetectionInDifferentSubdirectori
 	require.True(t, result)
 }
 
-func Test_isNotSamePackageLocalAbsoluteLocator_TestRepositoriesWithSamePrefixNames(t *testing.T) {
+func Test_isNotSamePackageLocalAbsoluteLocator_TestImportPackageWithSamePrefixNameAsRootPackages(t *testing.T) {
 	// Without root package id trailing slash.
 	result := shouldBlockAbsoluteLocatorBecauseIsInTheSameSourceModuleLocatorPackage("github.com/author/package2/main.star", "github.com/author/package/main.star", "github.com/author/package")
 	require.False(t, result)

--- a/core/server/api_container/server/startosis_engine/startosis_packages/git_package_content_provider/git_package_content_provider_test.go
+++ b/core/server/api_container/server/startosis_engine/startosis_packages/git_package_content_provider/git_package_content_provider_test.go
@@ -612,17 +612,17 @@ func TestGetAbsoluteLocator_RepositoriesWithSamePrefixNameShouldNotBeBlocked(t *
 }
 
 func Test_isSamePackageLocalAbsoluteLocator_TestDetectionInSubpath(t *testing.T) {
-	result := shouldBlockAbsoluteLocatorBecauseIsInTheSameSourceModuleLocatorPackage("github.com/author/package/bang/lib.star", "github.com/author/package/main.star", "github.com/author/package/")
+	result := shouldBlockAbsoluteLocatorBecauseIsInTheSameSourceModuleLocatorPackage("github.com/author/package/bang/lib.star", "github.com/author/package/main.star", "github.com/author/package")
 	require.True(t, result)
 }
 
 func Test_isSamePackageLocalAbsoluteLocator_TestDetectionInDifferentSubdirectories(t *testing.T) {
-	result := shouldBlockAbsoluteLocatorBecauseIsInTheSameSourceModuleLocatorPackage("github.com/author/package/subdir1/file1.star", "github.com/author/package/subdir2/file2.star", "github.com/author/package/")
+	result := shouldBlockAbsoluteLocatorBecauseIsInTheSameSourceModuleLocatorPackage("github.com/author/package/subdir1/file1.star", "github.com/author/package/subdir2/file2.star", "github.com/author/package")
 	require.True(t, result)
 }
 
 func Test_isNotSamePackageLocalAbsoluteLocator_TestRepositoriesWithSamePrefixNames(t *testing.T) {
-	result := shouldBlockAbsoluteLocatorBecauseIsInTheSameSourceModuleLocatorPackage("github.com/author/package2/main.star", "github.com/author/package/main.star", "github.com/author/package/")
+	result := shouldBlockAbsoluteLocatorBecauseIsInTheSameSourceModuleLocatorPackage("github.com/author/package2/main.star", "github.com/author/package/main.star", "github.com/author/package")
 	require.False(t, result)
 }
 

--- a/core/server/api_container/server/startosis_engine/startosis_packages/git_package_content_provider/git_package_content_provider_test.go
+++ b/core/server/api_container/server/startosis_engine/startosis_packages/git_package_content_provider/git_package_content_provider_test.go
@@ -610,6 +610,11 @@ func Test_isSamePackageLocalAbsoluteLocator_TestDetectionInDifferentSubdirectori
 	require.True(t, result)
 }
 
+func Test_isNotSamePackageLocalAbsoluteLocator_TestRepositoriesWithSamePrefixNames(t *testing.T) {
+	result := shouldBlockAbsoluteLocatorBecauseIsInTheSameSourceModuleLocatorPackage("github.com/author/package2/main.star", "github.com/author/package/main.star", "github.com/author/package/")
+	require.False(t, result)
+}
+
 func Test_getPathToPackageRoot(t *testing.T) {
 	githubUrlWithKurtosisPackageInSubfolder := "github.com/sample/sample-package/folder/subpackage"
 	parsedGitUrl, err := shared_utils.ParseGitURL(githubUrlWithKurtosisPackageInSubfolder)

--- a/core/server/api_container/server/startosis_engine/startosis_packages/git_package_content_provider/locators.go
+++ b/core/server/api_container/server/startosis_engine/startosis_packages/git_package_content_provider/locators.go
@@ -21,7 +21,7 @@ func isLocalLocator(locator string) bool {
 
 func shouldBlockAbsoluteLocatorBecauseIsInTheSameSourceModuleLocatorPackage(relativeOrAbsoluteLocator string, sourceModuleLocator string, rootPackageId string) bool {
 	// Make sure the root package id ends with a trailing slash.
-	rootPackageId = strings.TrimPrefix(rootPackageId, "/") + "/"
+	rootPackageId = strings.TrimSuffix(rootPackageId, "/") + "/"
 	isSourceModuleInRootPackage := strings.HasPrefix(sourceModuleLocator, rootPackageId)
 	isAbsoluteLocatorInRootPackage := strings.HasPrefix(relativeOrAbsoluteLocator, rootPackageId)
 	return isSourceModuleInRootPackage && isAbsoluteLocatorInRootPackage

--- a/core/server/api_container/server/startosis_engine/startosis_packages/git_package_content_provider/locators.go
+++ b/core/server/api_container/server/startosis_engine/startosis_packages/git_package_content_provider/locators.go
@@ -20,6 +20,8 @@ func isLocalLocator(locator string) bool {
 }
 
 func shouldBlockAbsoluteLocatorBecauseIsInTheSameSourceModuleLocatorPackage(relativeOrAbsoluteLocator string, sourceModuleLocator string, rootPackageId string) bool {
+	// Make sure the root package id ends with a trailing slash.
+	rootPackageId = strings.TrimPrefix(rootPackageId, "/") + "/"
 	isSourceModuleInRootPackage := strings.HasPrefix(sourceModuleLocator, rootPackageId)
 	isAbsoluteLocatorInRootPackage := strings.HasPrefix(relativeOrAbsoluteLocator, rootPackageId)
 	return isSourceModuleInRootPackage && isAbsoluteLocatorInRootPackage

--- a/core/server/api_container/server/startosis_engine/startosis_packages/git_package_content_provider/locators.go
+++ b/core/server/api_container/server/startosis_engine/startosis_packages/git_package_content_provider/locators.go
@@ -20,10 +20,8 @@ func isLocalLocator(locator string) bool {
 }
 
 func shouldBlockAbsoluteLocatorBecauseIsInTheSameSourceModuleLocatorPackage(relativeOrAbsoluteLocator string, sourceModuleLocator string, rootPackageId string) bool {
-
 	isSourceModuleInRootPackage := strings.HasPrefix(sourceModuleLocator, rootPackageId)
 	isAbsoluteLocatorInRootPackage := strings.HasPrefix(relativeOrAbsoluteLocator, rootPackageId)
-
 	return isSourceModuleInRootPackage && isAbsoluteLocatorInRootPackage
 }
 


### PR DESCRIPTION
## Description
<!-- Describe this change, how it works, and the motivation behind it. -->

An attempt to fix the issue when importing a package with the same prefix name as the root package (e.g. importing `kurtosis-test-xyz` inside `kurtosis-test`)

I added two new test cases to show it's not working properly:

```go
func TestGetAbsoluteLocator_RepositoriesWithSamePrefixNameShouldNotBeBlocked(t *testing.T) {
	provider := NewGitPackageContentProvider("", "", NewGitHubPackageAuthProvider(""), nil)

	packageId := "github.com/main-package"
	locatorOfModuleInWhichThisBuiltInIsBeingCalled := "github.com/main-package-xyz/main.star" // same package prefix
	maybeRelativeLocator := "github.com/main-package/file.star"

	_, err := provider.GetAbsoluteLocator(packageId, locatorOfModuleInWhichThisBuiltInIsBeingCalled, maybeRelativeLocator, noPackageReplaceOptions)
	require.Nil(t, err)
}

func Test_isNotSamePackageLocalAbsoluteLocator_TestRepositoriesWithSamePrefixNames(t *testing.T) {
	result := shouldBlockAbsoluteLocatorBecauseIsInTheSameSourceModuleLocatorPackage("github.com/author/package2/main.star", "github.com/author/package/main.star", "github.com/author/package")
	require.False(t, result)
}
```

```bash
--- FAIL: TestGetAbsoluteLocator_RepositoriesWithSamePrefixNameShouldNotBeBlocked (0.00s)
    git_package_content_provider_test.go:611: 
                Error Trace:    /home/circleci/project/core/server/api_container/server/startosis_engine/startosis_packages/git_package_content_provider/git_package_content_provider_test.go:611
                Error:          Expected nil, but got: &startosis_errors.InterpretationError{msg:"Locator 'github.com/main-package/file.star' is referencing a file within the same package using absolute import syntax, but only relative import syntax (path starting with '/' or '.') is allowed for within-package imports", cause:error(nil), stacktrace:[]startosis_errors.CallFrame(nil)}
                Test:           TestGetAbsoluteLocator_RepositoriesWithSamePrefixNameShouldNotBeBlocked
FAIL
FAIL    github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/startosis_packages/git_package_content_provider     5.120s

--- FAIL: Test_isNotSamePackageLocalAbsoluteLocator_TestRepositoriesWithSamePrefixNames (0.00s)
    git_package_content_provider_test.go:626: 
                Error Trace:    /home/circleci/project/core/server/api_container/server/startosis_engine/startosis_packages/git_package_content_provider/git_package_content_provider_test.go:626
                Error:          Should be false
                Test:           Test_isNotSamePackageLocalAbsoluteLocator_TestRepositoriesWithSamePrefixNames
```

The problem comes from the fact that the function only checks if the locator contains the package id (prefix check) instead of carrying out a more rigorous check:

```go
func shouldBlockAbsoluteLocatorBecauseIsInTheSameSourceModuleLocatorPackage(relativeOrAbsoluteLocator string, sourceModuleLocator string, rootPackageId string) bool {
	isSourceModuleInRootPackage := strings.HasPrefix(sourceModuleLocator, rootPackageId)
	isAbsoluteLocatorInRootPackage := strings.HasPrefix(relativeOrAbsoluteLocator, rootPackageId)
	return isSourceModuleInRootPackage && isAbsoluteLocatorInRootPackage
}
```

To fix this I made sure the `rootPackageId` ends with a trailing slash. This way it should not complain when checking absolute locators with the same prefix.

```go
func shouldBlockAbsoluteLocatorBecauseIsInTheSameSourceModuleLocatorPackage(relativeOrAbsoluteLocator string, sourceModuleLocator string, rootPackageId string) bool {
	// Make sure the root package id ends with a trailing slash.
	rootPackageId = strings.TrimSuffix(rootPackageId, "/") + "/"
	isSourceModuleInRootPackage := strings.HasPrefix(sourceModuleLocator, rootPackageId)
	isAbsoluteLocatorInRootPackage := strings.HasPrefix(relativeOrAbsoluteLocator, rootPackageId)
	return isSourceModuleInRootPackage && isAbsoluteLocatorInRootPackage
}
```

## REMINDER: Tag Reviewers, so they get notified to review

## Is this change user facing?
YES
<!-- If yes, please add the "user facing" label to the PR -->
<!-- If yes, don't forget to include docs changes where relevant -->

## References (if applicable)
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
<!-- You can auto-close issues by putting "Fixes #XXXX" here. -->
