### PR TITLE
chore: upgrade rust to 1.81

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,7 +173,7 @@ parameters:
   # the same version as the server
   rust-version:
     type: string
-    default: 1.70.0
+    default: 1.81.0
   api-node-version:
     type: string
     default: 16.13.0


### PR DESCRIPTION
## Description
`cargo publish` is currently not working in CI due to the following error:
```
error: failed to verify package tarball

Caused by:
  package `home v0.5.11` cannot be built because it requires rustc 1.81 or newer, while the currently active rustc version is 1.70.0
```
CI image was using rust `1.70`. I verified that `cargo publish --dry-run` fails on `1.78.0` locally but when works after updating to version `1.83`

```
   Compiling tokio-io-timeout v1.2.0
   Compiling tokio-stream v0.1.17
   Compiling h2 v0.3.26
   Compiling tower v0.4.13
   Compiling hyper v0.14.32
   Compiling hyper-timeout v0.4.1
   Compiling tonic v0.9.2
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 20.45s
   Uploading kurtosis-sdk v2.0.0 (/Users/tewodrosmitiku/craft/kurtosis/api/rust)
warning: aborting upload due to dry run
```

## Is this change user facing?
NO