### PR TITLE
fix: service logs flag exclusivity

### DIFF
--- a/cli/cli/command_framework/lowlevel/flags/parsed_flags.go
+++ b/cli/cli/command_framework/lowlevel/flags/parsed_flags.go
@@ -57,8 +57,3 @@ func (flags *ParsedFlags) GetBool(name string) (bool, error) {
 	}
 	return value, nil
 }
-
-func (flags *ParsedFlags) HasFlag(name string) bool {
-	_, err := flags.cmdFlagsSet.GetString(name)
-	return err != nil
-}

--- a/cli/cli/command_framework/lowlevel/flags/parsed_flags.go
+++ b/cli/cli/command_framework/lowlevel/flags/parsed_flags.go
@@ -57,3 +57,11 @@ func (flags *ParsedFlags) GetBool(name string) (bool, error) {
 	}
 	return value, nil
 }
+
+func (flags *ParsedFlags) HasFlag(name string) bool {
+	_, err := flags.cmdFlagsSet.GetString(name)
+	if err != nil {
+		return true
+	}
+	return false
+}

--- a/cli/cli/command_framework/lowlevel/flags/parsed_flags.go
+++ b/cli/cli/command_framework/lowlevel/flags/parsed_flags.go
@@ -60,8 +60,5 @@ func (flags *ParsedFlags) GetBool(name string) (bool, error) {
 
 func (flags *ParsedFlags) HasFlag(name string) bool {
 	_, err := flags.cmdFlagsSet.GetString(name)
-	if err != nil {
-		return true
-	}
-	return false
+	return err != nil
 }

--- a/cli/cli/commands/service/logs/logs.go
+++ b/cli/cli/commands/service/logs/logs.go
@@ -7,7 +7,12 @@ package logs
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"os"
+	"os/signal"
+	"strconv"
+
 	"github.com/fatih/color"
 	"github.com/kurtosis-tech/kurtosis/api/golang/core/lib/services"
 	"github.com/kurtosis-tech/kurtosis/api/golang/engine/kurtosis_engine_rpc_api_bindings"
@@ -24,9 +29,6 @@ import (
 	"github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/metrics_client"
 	"github.com/kurtosis-tech/stacktrace"
 	"github.com/sirupsen/logrus"
-	"os"
-	"os/signal"
-	"strconv"
 )
 
 const (
@@ -192,6 +194,10 @@ func run(
 	shouldFollowLogs, err := flags.GetBool(shouldFollowLogsFlagKey)
 	if err != nil {
 		return stacktrace.Propagate(err, "An error occurred getting the should-follow-logs flag using key '%v'", shouldFollowLogsFlagKey)
+	}
+
+	if shouldFollowLogs && flags.HasFlag(returnNumLogsFlagKey) {
+		return stacktrace.Propagate(errors.ErrUnsupported, "`%v` flag cannot be used with `%v` flag", shouldFollowLogsFlagKey, returnNumLogsFlagKey)
 	}
 
 	shouldReturnAllLogs, err := flags.GetBool(returnAllLogsFlagKey)

--- a/cli/cli/commands/service/logs/logs.go
+++ b/cli/cli/commands/service/logs/logs.go
@@ -7,7 +7,6 @@ package logs
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -197,7 +196,7 @@ func run(
 	}
 
 	if shouldFollowLogs && flags.HasFlag(returnNumLogsFlagKey) {
-		return stacktrace.Propagate(errors.ErrUnsupported, "`%v` flag cannot be used with `%v` flag", shouldFollowLogsFlagKey, returnNumLogsFlagKey)
+		return stacktrace.Propagate(stacktrace.NewError("Unsupported flags combination"), "`%v` flag cannot be used with `%v` flag", shouldFollowLogsFlagKey, returnNumLogsFlagKey)
 	}
 
 	shouldReturnAllLogs, err := flags.GetBool(returnAllLogsFlagKey)

--- a/cli/cli/commands/service/logs/logs.go
+++ b/cli/cli/commands/service/logs/logs.go
@@ -55,7 +55,7 @@ const (
 
 	interruptChanBufferSize = 5
 
-	defaultNumLogLines            = 200
+	defaultNumLogLines            = 0
 	commonInstructionInMatchFlags = "Important: " + matchTextFilterFlagKey + " and " + matchRegexFilterFlagKey + " flags cannot be used at the same time. You should either use one or the other."
 )
 
@@ -195,10 +195,6 @@ func run(
 		return stacktrace.Propagate(err, "An error occurred getting the should-follow-logs flag using key '%v'", shouldFollowLogsFlagKey)
 	}
 
-	if shouldFollowLogs && flags.HasFlag(returnNumLogsFlagKey) {
-		return stacktrace.Propagate(stacktrace.NewError("Unsupported flags combination"), "`%v` flag cannot be used with `%v` flag", shouldFollowLogsFlagKey, returnNumLogsFlagKey)
-	}
-
 	shouldReturnAllLogs, err := flags.GetBool(returnAllLogsFlagKey)
 	if err != nil {
 		return stacktrace.Propagate(err, "An error occurred getting the 'all' flag using key '%v'", returnAllLogsFlagKey)
@@ -207,6 +203,10 @@ func run(
 	numLogLines, err := flags.GetUint32(returnNumLogsFlagKey)
 	if err != nil {
 		return stacktrace.Propagate(err, "An error occurred getting the 'num' flag using key '%v'", returnNumLogsFlagKey)
+	}
+
+	if shouldFollowLogs && numLogLines > 0 {
+		return stacktrace.Propagate(stacktrace.NewError("Unsupported flags combination"), "`%v` flag cannot be used with `%v` flag", shouldFollowLogsFlagKey, returnNumLogsFlagKey)
 	}
 
 	matchTextStr, err := flags.GetString(matchTextFilterFlagKey)


### PR DESCRIPTION
## Description
This PR changes `service logs` to check exclusivity on `--follow` and `--num`. To do this the default value for `--num` is set to 0. The underlying flag parser does not expose whether the flags exist on the command line 

@tedim52 

## Is this change user facing?

YES
