### PR TITLE
feat: clean k8s logging checkpoints and buffers on -a

### DIFF
--- a/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/engine_functions/create_engine.go
+++ b/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/engine_functions/create_engine.go
@@ -530,21 +530,7 @@ func createEnginePod(
 	engineInitContainers := []apiv1.Container{}
 
 	// Create pods with engine containers and volumes in kubernetes
-	pod, err := kubernetesManager.CreatePod(
-		ctx,
-		namespace,
-		enginePodName,
-		enginePodLabelStrs,
-		enginePodAnnotationStrs,
-		engineInitContainers,
-		engineContainers,
-		engineVolumes,
-		serviceAccountName,
-		// Engine doesn't auto restart
-		apiv1.RestartPolicyNever,
-		noToleration,
-		noSelectors,
-	)
+	pod, err := kubernetesManager.CreatePod(ctx, namespace, enginePodName, enginePodLabelStrs, enginePodAnnotationStrs, engineInitContainers, engineContainers, engineVolumes, serviceAccountName, apiv1.RestartPolicyNever, noToleration, noSelectors, false, false)
 	if err != nil {
 		return nil, nil, stacktrace.Propagate(err, "An error occurred while creating the pod with name '%s' in namespace '%s' with image '%s'", enginePodName, namespace, containerImageAndTag)
 	}

--- a/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/engine_functions/create_engine.go
+++ b/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/engine_functions/create_engine.go
@@ -397,6 +397,7 @@ func createEngineClusterRole(
 				kubernetes_manager_consts.ConfigMapsKubernetesResource,
 				kubernetes_manager_consts.DaemonSetsKubernetesResource,
 				kubernetes_manager_consts.DeploymentsKubernetesResource,
+				kubernetes_manager_consts.DeploymentsScaleKubernetesResource,
 			},
 		},
 		{

--- a/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/kubernetes_kurtosis_backend_api_container_functions.go
+++ b/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/kubernetes_kurtosis_backend_api_container_functions.go
@@ -481,20 +481,7 @@ func (backend *KubernetesKurtosisBackend) CreateAPIContainer(
 	apiContainerRestartPolicy := apiv1.RestartPolicyOnFailure
 
 	// Create pods with api container containers and volumes in Kubernetes
-	apiContainerPod, err := backend.kubernetesManager.CreatePod(
-		ctx,
-		enclaveNamespaceName,
-		apiContainerPodName,
-		apiContainerPodLabels,
-		apiContainerPodAnnotations,
-		apiContainerInitContainers,
-		apiContainerContainers,
-		apiContainerVolumes,
-		apiContainerServiceAccountName,
-		apiContainerRestartPolicy,
-		noTolerations,
-		noSelectors,
-	)
+	apiContainerPod, err := backend.kubernetesManager.CreatePod(ctx, enclaveNamespaceName, apiContainerPodName, apiContainerPodLabels, apiContainerPodAnnotations, apiContainerInitContainers, apiContainerContainers, apiContainerVolumes, apiContainerServiceAccountName, apiContainerRestartPolicy, noTolerations, noSelectors, false, false)
 	if err != nil {
 		errMsg := fmt.Sprintf("An error occurred while creating the pod with name '%s' in namespace '%s' with image '%s'", apiContainerPodName, enclaveNamespaceName, image)
 		logrus.Errorf("%s. Error was:\n%s", errMsg, err)

--- a/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/kubernetes_kurtosis_backend_enclave_functions.go
+++ b/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/kubernetes_kurtosis_backend_enclave_functions.go
@@ -3,7 +3,9 @@ package kubernetes_kurtosis_backend
 import (
 	"context"
 	"fmt"
+	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_aggregator_functions"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_aggregator_functions/implementations/vector"
+	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_collector_functions"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_collector_functions/implementations/fluentbit"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_impls/kubernetes/object_attributes_provider/kubernetes_label_key"
 	"strings"
@@ -333,14 +335,12 @@ func (backend *KubernetesKurtosisBackend) DestroyEnclaves(
 
 	// if destroy is deleting ALL enclaves, now's a good time to clean up log stuff
 	if filters.Statuses[enclave.EnclaveStatus_Running] {
-		logsCollectorDaemonSet := fluentbit.NewFluentbitLogsCollector()
-		if err := logsCollectorDaemonSet.Clean(ctx, backend.kubernetesManager); err != nil {
+		if err := logs_collector_functions.CleanLogsCollector(ctx, fluentbit.NewFluentbitLogsCollector(), backend.kubernetesManager); err != nil {
 			return nil, nil, stacktrace.Propagate(err, "An error cleaning logs collector daemon set.")
 		}
 
-		logsAggregatorDeployment := vector.NewVectorLogsAggregatorDeployment()
-		if err := logsAggregatorDeployment.Clean(ctx, backend.kubernetesManager); err != nil {
-			return nil, nil, stacktrace.Propagate(err, "An error cleaning logs aggregator daemon set.")
+		if err := logs_aggregator_functions.CleanLogsAggregator(ctx, vector.NewVectorLogsAggregatorDeployment(), backend.kubernetesManager); err != nil {
+			return nil, nil, stacktrace.Propagate(err, "An error cleaning logs aggregator deployment.")
 		}
 	}
 

--- a/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_aggregator_functions/clean_logs_aggregator.go
+++ b/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_aggregator_functions/clean_logs_aggregator.go
@@ -1,0 +1,23 @@
+package logs_aggregator_functions
+
+import (
+	"context"
+	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_manager"
+	"github.com/kurtosis-tech/stacktrace"
+)
+
+func CleanLogsAggregator(
+	ctx context.Context,
+	logsAggregatorDeployment LogsAggregatorDeployment,
+	kubernetesManager *kubernetes_manager.KubernetesManager) error {
+	_, k8sResources, err := getLogsAggregatorObjAndResourcesForCluster(ctx, kubernetesManager)
+	if err != nil {
+		return stacktrace.Propagate(err, "An error occurred getting logs aggregator object and resources for cluster.")
+	}
+
+	if err := logsAggregatorDeployment.Clean(ctx, k8sResources.deployment, kubernetesManager); err != nil {
+		return stacktrace.Propagate(err, "An error occurred cleaning logs aggregator deployment '%v'", k8sResources.deployment.Name)
+	}
+
+	return nil
+}

--- a/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_aggregator_functions/create_logs_aggregator.go
+++ b/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_aggregator_functions/create_logs_aggregator.go
@@ -28,7 +28,7 @@ func CreateLogsAggregator(
 	}
 
 	if logsAggregatorObj != nil {
-		removeLogsAggregatorFunc = func() {} // can't create remove in this situation so jus make it a no op
+		removeLogsAggregatorFunc = func() { return } // can't create remove in this situation so jus make it a no op
 		logrus.Debug("Found existing logs aggregator deployment.")
 	} else {
 		logrus.Debug("Did not find existing logs aggregator, creating one...")

--- a/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_aggregator_functions/create_logs_aggregator.go
+++ b/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_aggregator_functions/create_logs_aggregator.go
@@ -24,11 +24,11 @@ func CreateLogsAggregator(
 
 	logsAggregatorObj, kubernetesResources, err = getLogsAggregatorObjAndResourcesForCluster(ctx, kubernetesManager)
 	if err != nil {
-		return nil, nil, stacktrace.Propagate(err, "An error occurred getting logs aggregator object and resources for cluster.")
+		return nil, removeLogsAggregatorFunc, stacktrace.Propagate(err, "An error occurred getting logs aggregator object and resources for cluster.")
 	}
 
 	if logsAggregatorObj != nil {
-		removeLogsAggregatorFunc = func() { return } // can't create remove in this situation so jus make it a no op
+		removeLogsAggregatorFunc = func() {} // can't create remove in this situation so jus make it a no op
 		logrus.Debug("Found existing logs aggregator deployment.")
 	} else {
 		logrus.Debug("Did not find existing logs aggregator, creating one...")
@@ -39,7 +39,7 @@ func CreateLogsAggregator(
 			objAttrProvider,
 			kubernetesManager)
 		if err != nil {
-			return nil, nil, stacktrace.Propagate(err, "An error occurred creating logs aggregator deployment.")
+			return nil, removeLogsAggregatorFunc, stacktrace.Propagate(err, "An error occurred creating logs aggregator deployment.")
 		}
 		shouldRemoveLogsAggregator = true
 		defer func() {
@@ -57,7 +57,7 @@ func CreateLogsAggregator(
 
 		logsAggregatorObj, err = getLogsAggregatorObjectFromKubernetesResources(ctx, kubernetesManager, kubernetesResources)
 		if err != nil {
-			return nil, nil, stacktrace.Propagate(err, "An error occurred getting the logs aggregator object from kubernetes resources.")
+			return nil, removeLogsAggregatorFunc, stacktrace.Propagate(err, "An error occurred getting the logs aggregator object from kubernetes resources.")
 		}
 	}
 
@@ -65,7 +65,7 @@ func CreateLogsAggregator(
 
 	healthCheckEndpoint, healthCheckPortNum := logsAggregatorDeployment.GetHTTPHealthCheckEndpointAndPort()
 	if err = waitForLogsAggregatorAvailability(ctx, healthCheckEndpoint, healthCheckPortNum, kubernetesResources, kubernetesManager); err != nil {
-		return nil, nil, stacktrace.Propagate(err, "An error occurred while waiting for the logs aggregator deployment to become available")
+		return nil, removeLogsAggregatorFunc, stacktrace.Propagate(err, "An error occurred while waiting for the logs aggregator deployment to become available")
 	}
 	logrus.Debugf("...logs aggregator is available in namepsace '%v'", kubernetesResources.namespace.Name)
 

--- a/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_aggregator_functions/implementations/vector/consts.go
+++ b/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_aggregator_functions/implementations/vector/consts.go
@@ -13,9 +13,13 @@ const (
 	apiPortStr = "8686"
 	apiPort    = 8686
 
+	// mount the data directory as the disk buffer for file sink is contained here and needs to be persisted onto the k8s node in case vector restarts
+	vectorDataDirVolumeName = "vectorDataDirVol"
+	vectorDataDirMountPath  = "/vector-data-dir"
+
 	vectorConfigFileName = "vector.toml"
 	vectorConfigFmtStr   = `
-    data_dir = "/vector-data-dir"
+    data_dir = "%v"
 
     [api]
     enabled = true
@@ -38,6 +42,8 @@ const (
     type = "console"
     inputs = ["fluentbit"]
     target = "stdout"
+    buffer.type = "disk"
+    buffer.when_full = "block"
 
     [sinks.stdout_sink.encoding]
     codec = "json"

--- a/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_aggregator_functions/implementations/vector/consts.go
+++ b/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_aggregator_functions/implementations/vector/consts.go
@@ -2,7 +2,7 @@ package vector
 
 const (
 	vectorContainerName = "vector"
-	vectorImage         = "timberio/vector:0.31.0-debian"
+	vectorImage         = "timberio/vector:0.45.0-debian"
 
 	vectorConfigVolumeName = "vector-config"
 	vectorConfigMountPath  = "/etc/vector"
@@ -14,7 +14,7 @@ const (
 	apiPort    = 8686
 
 	// mount the data directory as the disk buffer for file sink is contained here and needs to be persisted onto the k8s node in case vector restarts
-	vectorDataDirVolumeName = "vectorDataDirVol"
+	vectorDataDirVolumeName = "varlibvector"
 	vectorDataDirMountPath  = "/var/lib/vector"
 
 	vectorConfigFileName = "vector.toml"
@@ -33,7 +33,11 @@ const (
     type = "file"
     inputs = ["fluentbit"]
     path = "%v/%%G/%%V/{{ enclave_uuid }}/{{ service_uuid }}.json"
-    buffer.when_full = "block"
+    
+	[sinks.file_sink.buffer]
+	type = "disk"
+	max_size = 268435488
+    when_full = "block"
 
     [sinks.file_sink.encoding]
     codec = "json"
@@ -42,8 +46,6 @@ const (
     type = "console"
     inputs = ["fluentbit"]
     target = "stdout"
-    buffer.type = "disk"
-    buffer.when_full = "block"
 
     [sinks.stdout_sink.encoding]
     codec = "json"

--- a/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_aggregator_functions/implementations/vector/consts.go
+++ b/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_aggregator_functions/implementations/vector/consts.go
@@ -15,7 +15,7 @@ const (
 
 	// mount the data directory as the disk buffer for file sink is contained here and needs to be persisted onto the k8s node in case vector restarts
 	vectorDataDirVolumeName = "vectorDataDirVol"
-	vectorDataDirMountPath  = "/vector-data-dir"
+	vectorDataDirMountPath  = "/var/lib/vector"
 
 	vectorConfigFileName = "vector.toml"
 	vectorConfigFmtStr   = `

--- a/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_aggregator_functions/implementations/vector/vector_logs_aggregator_deployment.go
+++ b/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_aggregator_functions/implementations/vector/vector_logs_aggregator_deployment.go
@@ -483,14 +483,14 @@ func (vector *vectorLogsAggregatorDeployment) Clean(ctx context.Context, logsAgg
 	}
 
 	// scale up the deployment again
-	//if err := kubernetesManager.ScaleDeployment(ctx, logsAggregatorDeployment.Namespace, logsAggregatorDeployment.Name, postCleanNumReplicas); err != nil {
-	//	return stacktrace.Propagate(err, "An error occurred scaling deployment '%v' in namespace '%v' to '%v'.", logsAggregatorDeployment.Name, logsAggregatorDeployment.Namespace, postCleanNumReplicas)
-	//}
+	if err := kubernetesManager.ScaleDeployment(ctx, logsAggregatorDeployment.Namespace, logsAggregatorDeployment.Name, postCleanNumReplicas); err != nil {
+		return stacktrace.Propagate(err, "An error occurred scaling deployment '%v' in namespace '%v' to '%v'.", logsAggregatorDeployment.Name, logsAggregatorDeployment.Namespace, postCleanNumReplicas)
+	}
 
 	// before continuing, ensure logs aggregator is up again
-	//if err := waitForPodManagedByDeployment(ctx, logsAggregatorDeployment, kubernetesManager); err != nil {
-	//	return stacktrace.Propagate(err, "An error occurred waiting for a pod managed by deployment '%v' to become available.", logsAggregatorDeployment.Name)
-	//}
+	if err := waitForPodManagedByDeployment(ctx, logsAggregatorDeployment, kubernetesManager); err != nil {
+		return stacktrace.Propagate(err, "An error occurred waiting for a pod managed by deployment '%v' to become available.", logsAggregatorDeployment.Name)
+	}
 
 	logrus.Debugf("Successfully cleaned logs aggregator.")
 

--- a/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_aggregator_functions/implementations/vector/vector_logs_aggregator_deployment.go
+++ b/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_aggregator_functions/implementations/vector/vector_logs_aggregator_deployment.go
@@ -618,9 +618,9 @@ func (vector *vectorLogsAggregatorDeployment) Clean(ctx context.Context, logsAgg
 	logrus.Infof("Output of clean '%v': %v, exit code: %v", cleanCmd, output.String(), resultExitCode)
 
 	// scale up the deployment again
-	if err := kubernetesManager.ScaleDeployment(ctx, logsAggregatorDeployment.Namespace, logsAggregatorDeployment.Name, 1); err != nil {
-		return stacktrace.Propagate(err, "An error occurred scaling deployment '%v' in namespace '%v' to '%v'.", logsAggregatorDeployment.Name, logsAggregatorDeployment.Namespace, 1)
-	}
+	//if err := kubernetesManager.ScaleDeployment(ctx, logsAggregatorDeployment.Namespace, logsAggregatorDeployment.Name, 1); err != nil {
+	//	return stacktrace.Propagate(err, "An error occurred scaling deployment '%v' in namespace '%v' to '%v'.", logsAggregatorDeployment.Name, logsAggregatorDeployment.Namespace, 1)
+	//}
 
 	logrus.Infof("Successfully cleaned logs aggregator.")
 

--- a/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_aggregator_functions/implementations/vector/vector_logs_aggregator_deployment.go
+++ b/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_aggregator_functions/implementations/vector/vector_logs_aggregator_deployment.go
@@ -483,9 +483,9 @@ func (vector *vectorLogsAggregatorDeployment) Clean(ctx context.Context, logsAgg
 	}
 
 	// scale up the deployment again
-	if err := kubernetesManager.ScaleDeployment(ctx, logsAggregatorDeployment.Namespace, logsAggregatorDeployment.Name, postCleanNumReplicas); err != nil {
-		return stacktrace.Propagate(err, "An error occurred scaling deployment '%v' in namespace '%v' to '%v'.", logsAggregatorDeployment.Name, logsAggregatorDeployment.Namespace, postCleanNumReplicas)
-	}
+	//if err := kubernetesManager.ScaleDeployment(ctx, logsAggregatorDeployment.Namespace, logsAggregatorDeployment.Name, postCleanNumReplicas); err != nil {
+	//	return stacktrace.Propagate(err, "An error occurred scaling deployment '%v' in namespace '%v' to '%v'.", logsAggregatorDeployment.Name, logsAggregatorDeployment.Namespace, postCleanNumReplicas)
+	//}
 
 	// before continuing, ensure logs aggregator is up again
 	if err := waitForPodManagedByDeployment(ctx, logsAggregatorDeployment, kubernetesManager); err != nil {

--- a/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_aggregator_functions/implementations/vector/vector_logs_aggregator_deployment.go
+++ b/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_aggregator_functions/implementations/vector/vector_logs_aggregator_deployment.go
@@ -214,6 +214,14 @@ func createLogsAggregatorDeployment(
 					MountPropagation: nil,
 					SubPathExpr:      "",
 				},
+				{
+					Name:             vectorDataDirVolumeName,
+					ReadOnly:         false,
+					MountPath:        vectorConfigVolumeName,
+					SubPath:          "",
+					MountPropagation: nil,
+					SubPathExpr:      "",
+				},
 			},
 			VolumeDevices:            nil,
 			LivenessProbe:            nil,
@@ -238,6 +246,10 @@ func createLogsAggregatorDeployment(
 		{
 			Name:         kurtosisLogsVolumeName,
 			VolumeSource: kubernetesManager.GetVolumeSourceForHostPath(kurtosisLogsMountPath),
+		},
+		{
+			Name:         vectorConfigVolumeName,
+			VolumeSource: kubernetesManager.GetVolumeSourceForHostPath(vectorDataDirMountPath),
 		},
 	}
 
@@ -382,6 +394,7 @@ func createLogsAggregatorConfigMap(
 		map[string]string{
 			vectorConfigFileName: fmt.Sprintf(
 				vectorConfigFmtStr,
+				vectorDataDirMountPath,
 				apiPortStr,
 				logListeningPortNum,
 				kurtosisLogsMountPath),

--- a/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_aggregator_functions/implementations/vector/vector_logs_aggregator_deployment.go
+++ b/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_aggregator_functions/implementations/vector/vector_logs_aggregator_deployment.go
@@ -553,12 +553,14 @@ func (vector *vectorLogsAggregatorDeployment) Clean(ctx context.Context, logsAgg
 	)
 	defer func() {
 		// Don't block on removing this remove directory pod because this can take a while sometimes in k8s
-		removeCtx := context.Background()
 		go func() {
-			err := kubernetesManager.RemovePod(removeCtx, removePod)
-			if err != nil {
-				logrus.Warnf("Attempted to remove pod '%v' in namespace '%v' but an error occurred:\n%v", removePod.Name, logsAggregatorDeployment.Namespace, err.Error())
-				logrus.Warn("You may have to remove this pod manually.")
+			removeCtx := context.Background()
+			if removePod != nil {
+				err := kubernetesManager.RemovePod(removeCtx, removePod)
+				if err != nil {
+					logrus.Warnf("Attempted to remove pod '%v' in namespace '%v' but an error occurred:\n%v", removePod.Name, logsAggregatorDeployment.Namespace, err.Error())
+					logrus.Warn("You may have to remove this pod manually.")
+				}
 			}
 		}()
 	}()

--- a/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_aggregator_functions/implementations/vector/vector_logs_aggregator_deployment.go
+++ b/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_aggregator_functions/implementations/vector/vector_logs_aggregator_deployment.go
@@ -444,3 +444,19 @@ func (vector *vectorLogsAggregatorDeployment) GetLogsBaseDirPath() string {
 func (vector *vectorLogsAggregatorDeployment) GetHTTPHealthCheckEndpointAndPort() (string, uint16) {
 	return "/health", apiPort
 }
+
+func (vector *vectorLogsAggregatorDeployment) Clean(ctx context.Context, logsAggregatorDeployment *appsv1.Deployment, kubernetesManager *kubernetes_manager.KubernetesManager) error {
+	// run an exec on the logs aggregator daemon pod that removes
+	pods, err := kubernetesManager.GetPodsManagedByDeployment(ctx, logsAggregatorDeployment)
+	if err != nil {
+		return stacktrace.Propagate(err, "An error occurred getting pods managed by deployment '%v' in namespace '%v'.", logsAggregatorDeployment.Name, logsAggregatorDeployment.Namespace)
+	}
+	if len(pods) == 0 {
+		return stacktrace.Propagate(err, "No pods found for logs aggregator deployment ", logsAggregatorDeployment.Name, logsAggregatorDeployment.Namespace)
+	}
+	if len(pods) > 1 {
+		return stacktrace.Propagate(err, "More than one pod found for logs aggregator deployment.", logsAggregatorDeployment.Name, logsAggregatorDeployment.Namespace)
+	}
+
+	return nil
+}

--- a/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_aggregator_functions/implementations/vector/vector_logs_aggregator_deployment.go
+++ b/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_aggregator_functions/implementations/vector/vector_logs_aggregator_deployment.go
@@ -583,7 +583,7 @@ func (vector *vectorLogsAggregatorDeployment) Clean(ctx context.Context, logsAgg
 		go func() {
 			err := kubernetesManager.RemovePod(ctx, removePod)
 			if err != nil {
-				logrus.Warnf("Attempted to remove pod '%v' in namespace '%v' but an error occurred.", removePod.Name, logsAggregatorDeployment.Namespace)
+				logrus.Warnf("Attempted to remove pod '%v' in namespace '%v' but an error occurred:\n%v", removePod.Name, logsAggregatorDeployment.Namespace, err.Error())
 				logrus.Warn("You may have to remove this pod manually.")
 			}
 		}()
@@ -614,6 +614,7 @@ func (vector *vectorLogsAggregatorDeployment) Clean(ctx context.Context, logsAgg
 		logrus.Infof("output of clean: %v, exit code: %v", output.String(), resultExitCode)
 		return stacktrace.NewError("Expected empty output from running exec command '%v' but instead retrieved output string '%v'", cleanCmd, output.String())
 	}
+	logrus.Infof("output of clean '%v': %v, exit code: %v", cleanCmd, output.String(), resultExitCode)
 
 	// scale up the deployment again
 	if err := kubernetesManager.ScaleDeployment(ctx, logsAggregatorDeployment.Namespace, logsAggregatorDeployment.Name, 1); err != nil {

--- a/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_aggregator_functions/implementations/vector/vector_logs_aggregator_deployment.go
+++ b/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_aggregator_functions/implementations/vector/vector_logs_aggregator_deployment.go
@@ -484,6 +484,7 @@ func (vector *vectorLogsAggregatorDeployment) Clean(ctx context.Context, logsAgg
 	isPrivileged := true
 	hasHostPidAccess := true
 	hasHostNetworkAcess := true
+	removePodMountPath := fmt.Sprintf("host%v", vectorDataDirMountPath)
 	removePod, err := kubernetesManager.CreatePod(ctx,
 		logsAggregatorDeployment.Namespace,
 		"remove-vector-data-pod",
@@ -514,7 +515,7 @@ func (vector *vectorLogsAggregatorDeployment) Clean(ctx context.Context, logsAgg
 					{
 						Name:             vectorDataDirVolumeName,
 						ReadOnly:         false,
-						MountPath:        vectorDataDirMountPath,
+						MountPath:        removePodMountPath,
 						SubPath:          "",
 						MountPropagation: nil,
 						SubPathExpr:      "",
@@ -568,7 +569,7 @@ func (vector *vectorLogsAggregatorDeployment) Clean(ctx context.Context, logsAgg
 		return stacktrace.Propagate(err, "An error occurred creating pod '%v' in namespace '%v'.", "availabilityChecker", removePod)
 	}
 
-	cleanCmd := []string{"rm", "-rf", vectorDataDirMountPath}
+	cleanCmd := []string{"rm", "-rf", removePodMountPath}
 	output := &bytes.Buffer{}
 	concurrentWriter := concurrent_writer.NewConcurrentWriter(output)
 	resultExitCode, err := kubernetesManager.RunExecCommand(

--- a/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_aggregator_functions/implementations/vector/vector_logs_aggregator_deployment.go
+++ b/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_aggregator_functions/implementations/vector/vector_logs_aggregator_deployment.go
@@ -538,7 +538,7 @@ func (vector *vectorLogsAggregatorDeployment) Clean(ctx context.Context, logsAgg
 		},
 		[]apiv1.Volume{
 			{
-				Name:         vectorDataDirMountPath,
+				Name:         vectorDataDirVolumeName,
 				VolumeSource: kubernetesManager.GetVolumeSourceForHostPath(vectorDataDirMountPath),
 			},
 		},

--- a/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_aggregator_functions/implementations/vector/vector_logs_aggregator_deployment.go
+++ b/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_aggregator_functions/implementations/vector/vector_logs_aggregator_deployment.go
@@ -571,7 +571,8 @@ func (vector *vectorLogsAggregatorDeployment) Clean(ctx context.Context, logsAgg
 		return stacktrace.Propagate(err, "An error occurred creating pod '%v' in namespace '%v'.", removePodName, logsAggregatorDeployment.Namespace)
 	}
 
-	cleanCmd := []string{"rm", "-rf", fmt.Sprintf("%v%v", hostMountPath, vectorDataDirMountPath)}
+	dirPathToRemoveAndEmpty := fmt.Sprintf("%v%v", hostMountPath, vectorDataDirMountPath)
+	cleanCmd := []string{"rm", "-rf", dirPathToRemoveAndEmpty, "&&", "rmdir", "-p", dirPathToRemoveAndEmpty}
 	output := &bytes.Buffer{}
 	concurrentWriter := concurrent_writer.NewConcurrentWriter(output)
 	resultExitCode, err := kubernetesManager.RunExecCommand(

--- a/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_aggregator_functions/implementations/vector/vector_logs_aggregator_deployment.go
+++ b/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_aggregator_functions/implementations/vector/vector_logs_aggregator_deployment.go
@@ -488,9 +488,9 @@ func (vector *vectorLogsAggregatorDeployment) Clean(ctx context.Context, logsAgg
 	//}
 
 	// before continuing, ensure logs aggregator is up again
-	if err := waitForPodManagedByDeployment(ctx, logsAggregatorDeployment, kubernetesManager); err != nil {
-		return stacktrace.Propagate(err, "An error occurred waiting for a pod managed by deployment '%v' to become available.", logsAggregatorDeployment.Name)
-	}
+	//if err := waitForPodManagedByDeployment(ctx, logsAggregatorDeployment, kubernetesManager); err != nil {
+	//	return stacktrace.Propagate(err, "An error occurred waiting for a pod managed by deployment '%v' to become available.", logsAggregatorDeployment.Name)
+	//}
 
 	logrus.Debugf("Successfully cleaned logs aggregator.")
 

--- a/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_aggregator_functions/implementations/vector/vector_logs_aggregator_deployment.go
+++ b/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_aggregator_functions/implementations/vector/vector_logs_aggregator_deployment.go
@@ -483,7 +483,7 @@ func (vector *vectorLogsAggregatorDeployment) Clean(ctx context.Context, logsAgg
 	// pod needs to be privileged to access host filesystem
 	isPrivileged := true
 	hasHostPidAccess := true
-	hasHostNetworkAcess := true
+	hasHostNetworkAccess := true
 	removePodName := "remove-vector-data-pod"
 	hostVolumeName := "host"
 	hostMountPath := "/host"
@@ -552,7 +552,7 @@ func (vector *vectorLogsAggregatorDeployment) Clean(ctx context.Context, logsAgg
 			"kubernetes.io/hostname": nodeName,
 		},
 		hasHostPidAccess,
-		hasHostNetworkAcess,
+		hasHostNetworkAccess,
 	)
 	defer func() {
 		// Don't block on removing this remove directory pod because this can take a while sometimes in k8s

--- a/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_aggregator_functions/logs_aggregator_deployment.go
+++ b/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_aggregator_functions/logs_aggregator_deployment.go
@@ -31,4 +31,11 @@ type LogsAggregatorDeployment interface {
 
 	// GetHTTPHealthCheckEndpointAndPort returns a string and int of the http endpoint and port to request aggregator health status
 	GetHTTPHealthCheckEndpointAndPort() (string, uint16)
+
+	// Clean removes any resources the logs aggregator creates for durability of logs in the case of crashes (e.g. disk buffers)
+	Clean(
+		ctx context.Context,
+		logsAggregator *appsv1.Deployment,
+		kubernetesManager *kubernetes_manager.KubernetesManager,
+	) error
 }

--- a/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_aggregator_functions/shared_helpers.go
+++ b/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_aggregator_functions/shared_helpers.go
@@ -246,59 +246,50 @@ func waitForLogsAggregatorAvailability(
 
 	availabilityCheckUrl := fmt.Sprintf("http://%v:%v%v", aggregatorHost, healthCheckPortNum, healthCheckEndpoint)
 	containerName := "availability-check-container"
-	pod, err := kubernetesManager.CreatePod(
-		ctx,
-		k8sResources.namespace.Name,
-		"availability-checker-pod",
-		nil,
-		nil,
-		nil,
-		[]apiv1.Container{
-			{
-				Name:  containerName,
-				Image: "badouralix/curl-jq",
-				Command: []string{
-					"sh",
-					"-c",
-					"sleep 10000000s",
-				},
-				Args:       nil,
-				WorkingDir: "",
-				Ports:      nil,
-				EnvFrom:    nil,
-				Env:        nil,
-				Resources: apiv1.ResourceRequirements{
-					Limits:   nil,
-					Requests: nil,
-					Claims:   nil,
-				},
-				ResizePolicy:             nil,
-				VolumeMounts:             nil,
-				VolumeDevices:            nil,
-				LivenessProbe:            nil,
-				ReadinessProbe:           nil,
-				StartupProbe:             nil,
-				Lifecycle:                nil,
-				TerminationMessagePath:   "",
-				TerminationMessagePolicy: "",
-				ImagePullPolicy:          "",
-				SecurityContext:          nil,
-				Stdin:                    false,
-				StdinOnce:                false,
-				TTY:                      false,
+	pod, err := kubernetesManager.CreatePod(ctx, k8sResources.namespace.Name, "availability-checker-pod", nil, nil, nil, []apiv1.Container{
+		{
+			Name:  containerName,
+			Image: "badouralix/curl-jq",
+			Command: []string{
+				"sh",
+				"-c",
+				"sleep 10000000s",
 			},
+			Args:       nil,
+			WorkingDir: "",
+			Ports:      nil,
+			EnvFrom:    nil,
+			Env:        nil,
+			Resources: apiv1.ResourceRequirements{
+				Limits:   nil,
+				Requests: nil,
+				Claims:   nil,
+			},
+			ResizePolicy:             nil,
+			VolumeMounts:             nil,
+			VolumeDevices:            nil,
+			LivenessProbe:            nil,
+			ReadinessProbe:           nil,
+			StartupProbe:             nil,
+			Lifecycle:                nil,
+			TerminationMessagePath:   "",
+			TerminationMessagePolicy: "",
+			ImagePullPolicy:          "",
+			SecurityContext:          nil,
+			Stdin:                    false,
+			StdinOnce:                false,
+			TTY:                      false,
 		},
-		nil,
-		"",
-		"",
-		nil,
-		nil)
+	}, nil, "", "", nil, nil, false, false)
 	defer func() {
-		err := kubernetesManager.RemovePod(ctx, pod)
-		if err != nil {
-			logrus.Warnf("Attempted to remove availability checker pod '%v' in namespace '%v' but an err occurred.", pod.Name, availabilityCheckerNamespace)
-			logrus.Warn("You may have to remove this pod manually.")
-		}
+		// Don't block on removing the availability checker pod because this can take a while sometimes in k8s
+		go func() {
+			err := kubernetesManager.RemovePod(ctx, pod)
+			if err != nil {
+				logrus.Warnf("Attempted to remove availability checker pod '%v' in namespace '%v' but an err occurred.", pod.Name, availabilityCheckerNamespace)
+				logrus.Warn("You may have to remove this pod manually.")
+			}
+		}()
 	}()
 	if err != nil {
 		return stacktrace.Propagate(err, "An error occurred creating pod '%v' in namespace '%v'.", "availabilityChecker", availabilityCheckerNamespace)

--- a/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_collector_functions/clean_logs_collector.go
+++ b/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_collector_functions/clean_logs_collector.go
@@ -1,0 +1,23 @@
+package logs_collector_functions
+
+import (
+	"context"
+	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_manager"
+	"github.com/kurtosis-tech/stacktrace"
+)
+
+func CleanLogsCollector(
+	ctx context.Context,
+	logsCollectorDaemonSet LogsCollectorDaemonSet,
+	kubernetesManager *kubernetes_manager.KubernetesManager) error {
+	_, k8sResources, err := getLogsCollectorObjAndResourcesForCluster(ctx, kubernetesManager)
+	if err != nil {
+		return stacktrace.Propagate(err, "An error occurred getting logs collector object and resources for cluster.")
+	}
+
+	if err := logsCollectorDaemonSet.Clean(ctx, k8sResources.daemonSet, kubernetesManager); err != nil {
+		return stacktrace.Propagate(err, "An error occurred cleaning logs collector daemon set '%v'", k8sResources.daemonSet.Name)
+	}
+
+	return nil
+}

--- a/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_collector_functions/create_logs_collector.go
+++ b/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_collector_functions/create_logs_collector.go
@@ -41,7 +41,7 @@ func CreateLogsCollector(
 
 	logsCollectorObj, kubernetesResources, err = getLogsCollectorObjAndResourcesForCluster(ctx, kubernetesManager)
 	if err != nil {
-		return nil, nil, stacktrace.Propagate(err, "An error occurred getting logs collector object and resources for cluster.")
+		return nil, removeLogsCollectorFunc, stacktrace.Propagate(err, "An error occurred getting logs collector object and resources for cluster.")
 	}
 
 	if logsCollectorObj != nil {
@@ -61,7 +61,7 @@ func CreateLogsCollector(
 			kubernetesManager,
 		)
 		if err != nil {
-			return nil, nil, stacktrace.Propagate(
+			return nil, removeLogsCollectorFunc, stacktrace.Propagate(
 				err,
 				"An error occurred starting the logs collector daemon set with logs collector with '%v', HTTP port number '%v', TCP port id '%v', and HTTP port id '%v'",
 				logsCollectorTcpPortNumber,
@@ -88,14 +88,14 @@ func CreateLogsCollector(
 
 		logsCollectorObj, err = getLogsCollectorsObjectFromKubernetesResources(ctx, kubernetesManager, kubernetesResources)
 		if err != nil {
-			return nil, nil, stacktrace.Propagate(err, "An error occurred getting the logs collector object from kubernetes resources.")
+			return nil, removeLogsCollectorFunc, stacktrace.Propagate(err, "An error occurred getting the logs collector object from kubernetes resources.")
 		}
 	}
 
 	logrus.Debugf("Checking for logs collector availability in namespace '%v'...", kubernetesResources.namespace.Name)
 
 	if err = waitForLogsCollectorAvailability(ctx, logsCollectorHttpPortNumber, kubernetesResources, kubernetesManager); err != nil {
-		return nil, nil, stacktrace.Propagate(err, "An error occurred while waiting for the logs collector daemon set to become available")
+		return nil, removeLogsCollectorFunc, stacktrace.Propagate(err, "An error occurred while waiting for the logs collector daemon set to become available")
 	}
 	logrus.Debugf("...logs collector is available in namepsace '%v'", kubernetesResources.namespace.Name)
 

--- a/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_collector_functions/implementations/fluentbit/fluentbit_logs_collector_daemonset.go
+++ b/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_collector_functions/implementations/fluentbit/fluentbit_logs_collector_daemonset.go
@@ -638,20 +638,20 @@ func (fluentbit *fluentbitLogsCollector) Clean(
 		}
 	}
 
-	// patch daemon set again to have no node selectors, allowing daemon set to schedule log collector pods
-	//err = kubernetesManager.UpdateDaemonSetWithNodeSelectors(
-	//	ctx,
-	//	logsCollectorDaemonSet,
-	//	map[string]string{},
-	//)
-	//if err != nil {
-	//	return stacktrace.Propagate(err, "An error occurred updating daemon set '%v' with node selectors '%v'", logsCollectorDaemonSet.Name, evictNodeSelectors)
-	//}
+	//patch daemon set again to have no node selectors, allowing daemon set to schedule log collector pods
+	err = kubernetesManager.UpdateDaemonSetWithNodeSelectors(
+		ctx,
+		logsCollectorDaemonSet,
+		map[string]string{},
+	)
+	if err != nil {
+		return stacktrace.Propagate(err, "An error occurred updating daemon set '%v' with node selectors '%v'", logsCollectorDaemonSet.Name, evictNodeSelectors)
+	}
 
-	// before continuing, ensure logs collector is up again
-	//if err := waitForAtLeastOneActivePodManagedByDaemonSet(ctx, logsCollectorDaemonSet, kubernetesManager); err != nil {
-	//	return stacktrace.Propagate(err, "An error occurred waiting for at least one pod managed by daemon set '%v' has become available.", logsCollectorDaemonSet.Name)
-	//}
+	//before continuing, ensure logs collector is up again
+	if err := waitForAtLeastOneActivePodManagedByDaemonSet(ctx, logsCollectorDaemonSet, kubernetesManager); err != nil {
+		return stacktrace.Propagate(err, "An error occurred waiting for at least one pod managed by daemon set '%v' has become available.", logsCollectorDaemonSet.Name)
+	}
 
 	logrus.Infof("Successfully cleaned logs collector.")
 

--- a/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_collector_functions/implementations/fluentbit/fluentbit_logs_collector_daemonset.go
+++ b/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_collector_functions/implementations/fluentbit/fluentbit_logs_collector_daemonset.go
@@ -588,3 +588,9 @@ func createLogsCollectorClusterRoleBinding(
 
 	return clusterRoleBindingObj, nil
 }
+
+func (fluentbit *fluentbitLogsCollector) Clean(
+	ctx context.Context,
+	kubernetesManager *kubernetes_manager.KubernetesManager) error {
+	return nil
+}

--- a/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_collector_functions/implementations/fluentbit/fluentbit_logs_collector_daemonset.go
+++ b/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_collector_functions/implementations/fluentbit/fluentbit_logs_collector_daemonset.go
@@ -597,6 +597,63 @@ func (fluentbit *fluentbitLogsCollector) Clean(
 	ctx context.Context,
 	logsCollectorDaemonSet *appsv1.DaemonSet,
 	kubernetesManager *kubernetes_manager.KubernetesManager) error {
-	//
+	pods, err := kubernetesManager.GetPodsManagedByDaemonSet(ctx, logsCollectorDaemonSet)
+	if err != nil {
+		return stacktrace.Propagate(err, "An error occurred getting pods managed by daemon set '%v' in namespace '%v'.", logsCollectorDaemonSet.Name, logsCollectorDaemonSet.Namespace)
+	}
+	if len(pods) == 0 {
+		return stacktrace.Propagate(err, "No pods found for logs collector daemon set '%v' in namespace '%v'.", logsCollectorDaemonSet.Name, logsCollectorDaemonSet.Namespace)
+	}
+	nodeNames := make([]string, len(pods))
+	for _, pod := range pods {
+		nodeNames = append(nodeNames, pod.Spec.NodeName)
+	}
+
+	logrus.Infof("Cleaning the fluent bit logs collector daemon set...")
+
+	// patch damon set to have node selector that evicts all pods
+	evictNodeSelectors := map[string]string{
+		"non-existent-label": "true",
+	}
+	err = kubernetesManager.UpdateDaemonSetWithNodeSelectors(
+		ctx,
+		logsCollectorDaemonSet,
+		evictNodeSelectors,
+	)
+	if err != nil {
+		return stacktrace.Propagate(err, "An error occurred updating daemon set '%v' with node selectors '%v'", logsCollectorDaemonSet.Name, evictNodeSelectors)
+	}
+
+	// need to wait for pods to be terminated to unmount checkpoint volumes
+	for _, pod := range pods {
+		if err := kubernetesManager.WaitForPodTermination(ctx, pod.Namespace, pod.Name); err != nil {
+			return stacktrace.Propagate(err, "An error occurred waiting for pod '%v' in namespace '%v'.", pod.Name, pod.Namespace)
+		}
+	}
+
+	// execute remove on all pods
+	for _, node := range nodeNames {
+		if err = kubernetesManager.RemoveDirPathFromNode(ctx, logsCollectorDaemonSet.Namespace, node, fluentBitCheckpointDbMountPath); err != nil {
+			return stacktrace.Propagate(err, "An error occurred removing dir path '%v' from node '%v' via a pod in namespace '%v'.", fluentBitCheckpointDbMountPath, node, logsCollectorDaemonSet.Namespace)
+		}
+	}
+
+	// patch daemon set again to have no node selectors, allowing daemon set to schedule log collector pods
+	err = kubernetesManager.UpdateDaemonSetWithNodeSelectors(
+		ctx,
+		logsCollectorDaemonSet,
+		nil,
+	)
+	if err != nil {
+		return stacktrace.Propagate(err, "An error occurred updating daemon set '%v' with node selectors '%v'", logsCollectorDaemonSet.Name, evictNodeSelectors)
+	}
+
+	// before continuing, ensure logs collector is up again
+	if err := waitForAtLeastOneActivePodManagedByDaemonSet(ctx, logsCollectorDaemonSet, kubernetesManager); err != nil {
+		return stacktrace.Propagate(err, "An error occurred waiting for at least one pod managed by daemon set '%v' has become available.", logsCollectorDaemonSet.Name)
+	}
+
+	logrus.Infof("Successfully cleaned logs collector.")
+
 	return nil
 }

--- a/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_collector_functions/implementations/fluentbit/fluentbit_logs_collector_daemonset.go
+++ b/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_collector_functions/implementations/fluentbit/fluentbit_logs_collector_daemonset.go
@@ -604,8 +604,9 @@ func (fluentbit *fluentbitLogsCollector) Clean(
 	if len(pods) == 0 {
 		return stacktrace.Propagate(err, "No pods found for logs collector daemon set '%v' in namespace '%v'.", logsCollectorDaemonSet.Name, logsCollectorDaemonSet.Namespace)
 	}
-	nodeNames := make([]string, len(pods))
+	var nodeNames []string
 	for _, pod := range pods {
+		logrus.Infof("pod '%v' on node '%v'", pod.Name, pod.Spec.NodeName)
 		nodeNames = append(nodeNames, pod.Spec.NodeName)
 	}
 
@@ -642,7 +643,7 @@ func (fluentbit *fluentbitLogsCollector) Clean(
 	err = kubernetesManager.UpdateDaemonSetWithNodeSelectors(
 		ctx,
 		logsCollectorDaemonSet,
-		nil,
+		map[string]string{},
 	)
 	if err != nil {
 		return stacktrace.Propagate(err, "An error occurred updating daemon set '%v' with node selectors '%v'", logsCollectorDaemonSet.Name, evictNodeSelectors)

--- a/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_collector_functions/implementations/fluentbit/fluentbit_logs_collector_daemonset.go
+++ b/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_collector_functions/implementations/fluentbit/fluentbit_logs_collector_daemonset.go
@@ -606,7 +606,6 @@ func (fluentbit *fluentbitLogsCollector) Clean(
 	}
 	var nodeNames []string
 	for _, pod := range pods {
-		logrus.Infof("pod '%v' on node '%v'", pod.Name, pod.Spec.NodeName)
 		nodeNames = append(nodeNames, pod.Spec.NodeName)
 	}
 
@@ -640,14 +639,14 @@ func (fluentbit *fluentbitLogsCollector) Clean(
 	}
 
 	// patch daemon set again to have no node selectors, allowing daemon set to schedule log collector pods
-	err = kubernetesManager.UpdateDaemonSetWithNodeSelectors(
-		ctx,
-		logsCollectorDaemonSet,
-		map[string]string{},
-	)
-	if err != nil {
-		return stacktrace.Propagate(err, "An error occurred updating daemon set '%v' with node selectors '%v'", logsCollectorDaemonSet.Name, evictNodeSelectors)
-	}
+	//err = kubernetesManager.UpdateDaemonSetWithNodeSelectors(
+	//	ctx,
+	//	logsCollectorDaemonSet,
+	//	map[string]string{},
+	//)
+	//if err != nil {
+	//	return stacktrace.Propagate(err, "An error occurred updating daemon set '%v' with node selectors '%v'", logsCollectorDaemonSet.Name, evictNodeSelectors)
+	//}
 
 	// before continuing, ensure logs collector is up again
 	if err := waitForAtLeastOneActivePodManagedByDaemonSet(ctx, logsCollectorDaemonSet, kubernetesManager); err != nil {

--- a/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_collector_functions/implementations/fluentbit/fluentbit_logs_collector_daemonset.go
+++ b/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_collector_functions/implementations/fluentbit/fluentbit_logs_collector_daemonset.go
@@ -591,6 +591,7 @@ func createLogsCollectorClusterRoleBinding(
 
 func (fluentbit *fluentbitLogsCollector) Clean(
 	ctx context.Context,
+	logsCollectorDaemonSet *appsv1.DaemonSet,
 	kubernetesManager *kubernetes_manager.KubernetesManager) error {
 	return nil
 }

--- a/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_collector_functions/implementations/fluentbit/fluentbit_logs_collector_daemonset.go
+++ b/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_collector_functions/implementations/fluentbit/fluentbit_logs_collector_daemonset.go
@@ -649,9 +649,9 @@ func (fluentbit *fluentbitLogsCollector) Clean(
 	//}
 
 	// before continuing, ensure logs collector is up again
-	if err := waitForAtLeastOneActivePodManagedByDaemonSet(ctx, logsCollectorDaemonSet, kubernetesManager); err != nil {
-		return stacktrace.Propagate(err, "An error occurred waiting for at least one pod managed by daemon set '%v' has become available.", logsCollectorDaemonSet.Name)
-	}
+	//if err := waitForAtLeastOneActivePodManagedByDaemonSet(ctx, logsCollectorDaemonSet, kubernetesManager); err != nil {
+	//	return stacktrace.Propagate(err, "An error occurred waiting for at least one pod managed by daemon set '%v' has become available.", logsCollectorDaemonSet.Name)
+	//}
 
 	logrus.Infof("Successfully cleaned logs collector.")
 

--- a/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_collector_functions/implementations/fluentbit/fluentbit_logs_collector_daemonset.go
+++ b/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_collector_functions/implementations/fluentbit/fluentbit_logs_collector_daemonset.go
@@ -589,9 +589,14 @@ func createLogsCollectorClusterRoleBinding(
 	return clusterRoleBindingObj, nil
 }
 
+// Clean cleans up the checkpoint databases created by fluent bit that store locations to continue tailing from in case of restarts, to do this:
+// 1) scales down the fluent bit daemon set to remove pods from all nodes
+// 2) creates a privileged pod with access to underlying nodes filesystem
+// 3) removes fluent bit checkpoint path on each node's filesystem
 func (fluentbit *fluentbitLogsCollector) Clean(
 	ctx context.Context,
 	logsCollectorDaemonSet *appsv1.DaemonSet,
 	kubernetesManager *kubernetes_manager.KubernetesManager) error {
+	//
 	return nil
 }

--- a/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_collector_functions/logs_collector_daemonset.go
+++ b/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_collector_functions/logs_collector_daemonset.go
@@ -32,4 +32,11 @@ type LogsCollectorDaemonSet interface {
 
 	// GetHttpHealthCheckEndpoint returns endpoint for verifying the availability of the logs collector application on pods managed by the daemon set
 	GetHttpHealthCheckEndpoint() string
+
+	// Clean removes any resources the logs collector creates for durability of logs in the case of crashes (e.g. checkpoint dbs)
+	Clean(
+		ctx context.Context,
+		logsCollectorDaemonSet *appsv1.DaemonSet,
+		kubernetesManager *kubernetes_manager.KubernetesManager,
+	) error
 }

--- a/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/user_services_functions/start_user_services.go
+++ b/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/user_services_functions/start_user_services.go
@@ -410,20 +410,7 @@ func createStartServiceOperation(
 		}
 
 		podName := podAttributes.GetName().GetString()
-		createdPod, err := kubernetesManager.CreatePod(
-			ctx,
-			namespaceName,
-			podName,
-			podLabelsStrs,
-			podAnnotationsStrs,
-			podInitContainers,
-			podContainers,
-			podVolumes,
-			userServiceServiceAccountName,
-			restartPolicy,
-			tolerations,
-			nodeSelectors,
-		)
+		createdPod, err := kubernetesManager.CreatePod(ctx, namespaceName, podName, podLabelsStrs, podAnnotationsStrs, podInitContainers, podContainers, podVolumes, userServiceServiceAccountName, restartPolicy, tolerations, nodeSelectors, false, false)
 		if err != nil {
 			return nil, stacktrace.Propagate(err, "An error occurred creating pod '%v' using image '%v'", podName, containerImageName)
 		}

--- a/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_manager/consts/kubernetes_consts.go
+++ b/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_manager/consts/kubernetes_consts.go
@@ -27,6 +27,7 @@ const (
 	ConfigMapsKubernetesResource             = "configmaps"
 	DaemonSetsKubernetesResource             = "daemonsets"
 	DeploymentsKubernetesResource            = "deployments"
+	DeploymentsScaleKubernetesResource       = "deployments/scale"
 
 	ClusterRoleKubernetesResourceType = "ClusterRole"
 	RoleKubernetesResourceType        = "Role"

--- a/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_manager/kubernetes_manager.go
+++ b/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_manager/kubernetes_manager.go
@@ -1433,6 +1433,7 @@ func (manager *KubernetesManager) UpdateDaemonSetWithNodeSelectors(ctx context.C
 	if err != nil {
 		return stacktrace.Propagate(err, "An error occurred patching daemon set '%v' in namespace '%v' with patch data '%v'.", daemonSet.Name, daemonSet.Namespace, patchData)
 	}
+	logrus.Infof("Successfully patched daemon set with node selector %v and patch data '%v'", nodeSelector, patchData)
 
 	return nil
 }
@@ -2204,6 +2205,8 @@ func (manager *KubernetesManager) RemoveDirPathFromNode(ctx context.Context, nam
 		return stacktrace.NewError("Expected empty output from running exec command '%v' but instead retrieved output string '%v'", removeDirCmd, output.String())
 	}
 
+	logrus.Infof("Output of clean '%v': %v, exit code: %v", removeDirCmd, output.String(), resultExitCode)
+	logrus.Info("Successfully removed dir path.")
 	return nil
 }
 

--- a/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_manager/kubernetes_manager.go
+++ b/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_manager/kubernetes_manager.go
@@ -1433,7 +1433,7 @@ func (manager *KubernetesManager) UpdateDaemonSetWithNodeSelectors(ctx context.C
 	if err != nil {
 		return stacktrace.Propagate(err, "An error occurred patching daemon set '%v' in namespace '%v' with patch data '%v'.", daemonSet.Name, daemonSet.Namespace, patchData)
 	}
-	logrus.Infof("Successfully patched daemon set with node selector %v and patch data '%v'", nodeSelector, patchData)
+	logrus.Debugf("Successfully patched daemon set with node selector %v and patch data '%v'", nodeSelector, patchData)
 
 	return nil
 }
@@ -2205,8 +2205,7 @@ func (manager *KubernetesManager) RemoveDirPathFromNode(ctx context.Context, nam
 		return stacktrace.NewError("Expected empty output from running exec command '%v' but instead retrieved output string '%v'", removeDirCmd, output.String())
 	}
 
-	logrus.Infof("Output of clean '%v': %v, exit code: %v", removeDirCmd, output.String(), resultExitCode)
-	logrus.Info("Successfully removed dir path.")
+	logrus.Debugf("Successfully removed contents of dir path '%v' on node '%v'.", dirPathToRemove, nodeName)
 	return nil
 }
 

--- a/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_manager/kubernetes_manager.go
+++ b/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_manager/kubernetes_manager.go
@@ -1423,7 +1423,10 @@ func (manager *KubernetesManager) UpdateDaemonSetWithNodeSelectors(ctx context.C
 		types.JSONPatchType,
 		patchData,
 		metav1.PatchOptions{
-			TypeMeta:        metav1.TypeMeta{},
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "",
+				APIVersion: "",
+			},
 			DryRun:          nil,
 			Force:           nil,
 			FieldManager:    "",
@@ -1602,7 +1605,10 @@ func (manager *KubernetesManager) ScaleDeployment(ctx context.Context, namespace
 	oldReplicas := scale.Spec.Replicas
 	scale.Spec.Replicas = replicas
 	_, err = deploymentClient.UpdateScale(ctx, name, scale, metav1.UpdateOptions{
-		TypeMeta:        metav1.TypeMeta{},
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "",
+			APIVersion: "",
+		},
 		DryRun:          nil,
 		FieldManager:    "",
 		FieldValidation: "",
@@ -2142,7 +2148,17 @@ func (manager *KubernetesManager) RemoveDirPathFromNode(ctx context.Context, nam
 				TerminationMessagePolicy: "",
 				ImagePullPolicy:          "",
 				SecurityContext: &apiv1.SecurityContext{
-					Privileged: &isPrivileged,
+					Privileged:               &isPrivileged,
+					Capabilities:             nil,
+					SeccompProfile:           nil,
+					ProcMount:                nil,
+					ReadOnlyRootFilesystem:   nil,
+					AllowPrivilegeEscalation: nil,
+					RunAsNonRoot:             nil,
+					RunAsGroup:               nil,
+					RunAsUser:                nil,
+					SELinuxOptions:           nil,
+					WindowsOptions:           nil,
 				},
 				Stdin:     false,
 				StdinOnce: false,


### PR DESCRIPTION
## Description
This removes any checkpointing dbs or buffers stored by fluentbit log collectors and vector log aggregators when users run a `clean -a`. 

## Is this change user facing?
NO

