### PR TITLE
chore: update nix to use go 1.23

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,16 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1706373441,
-        "narHash": "sha256-S1hbgNbVYhuY2L05OANWqmRzj4cElcbLuIkXTb69xkk=",
+        "lastModified": 1743576891,
+        "narHash": "sha256-vXiKURtntURybE6FMNFAVpRPr8+e8KoLPrYs9TGuAKc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "56911ef3403a9318b7621ce745f5452fb9ef6867",
+        "rev": "44a69ed688786e98a101f02b712c313f1ade37ab",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-23.11",
+        "ref": "nixos-24.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Kurtosis dev flake";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
     unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
   };
@@ -29,7 +29,7 @@
                 import ./nix-pkgs/grpc-tools-node.nix { inherit pkgs; };
             in [
               goreleaser
-              go_1_20
+              go_1_23
               gopls
               golangci-lint
               delve
@@ -61,16 +61,16 @@
           shellHook = ''
             export CARGO_NET_GIT_FETCH_WITH_CLI=true
             printf '\u001b[32m
-                                @@@@@@@@     
-                  @@@ @@     @@@   @@@      
-                @@@   @@    @@    @@        
-                @   @@    @@    @@          
-                  @@    @@    @@            
-                @@    @@    @@              
-                @   @@    @@    @@          
-                @       @@  @@    @@        
-                  @@   @@@    @@@    @@      
-                    @@@         @@@@@@@@     
+                                @@@@@@@@
+                  @@@ @@     @@@   @@@
+                @@@   @@    @@    @@
+                @   @@    @@    @@
+                  @@    @@    @@
+                @@    @@    @@
+                @   @@    @@    @@
+                @       @@  @@    @@
+                  @@   @@@    @@@    @@
+                    @@@         @@@@@@@@
             \u001b[0m
             Starting Kurtosis dev shell. Setup the alias to local compiled Kurtosis cli command "ktdev" and "ktdebug" by running:
             \e[32m


### PR DESCRIPTION
## Description
We were still using go 1.20 on nix. That wasn't working with the current codebase, which relies on go 1.23
