### PR TITLE
fix: docker auth wasn't being used by engine and API

### DIFF
--- a/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/engine_functions/create_engine.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/engine_functions/create_engine.go
@@ -269,6 +269,7 @@ func CreateEngine(
 	if err = dockerManager.CreateVolume(ctx, dockerConfigStorageVolNameStr, dockerConfigStorageVolLabelStrs); err != nil {
 		return nil, stacktrace.Propagate(err, "An error occurred creating Docker config storage volume.")
 	}
+	logrus.Tracef("Creating Docker config storage")
 	err = docker_config_storage_creator.CreateDockerConfigStorage(ctx, targetNetworkId, dockerConfigStorageVolNameStr, consts.DockerConfigStorageDirPath, dockerManager)
 	if err != nil {
 		return nil, stacktrace.Propagate(err, "An error occurred creating Docker config storage.")

--- a/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/engine_functions/docker_config_storage_creator/docker_config_storage_creator.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/engine_functions/docker_config_storage_creator/docker_config_storage_creator.go
@@ -111,14 +111,19 @@ func storeConfigInVolume(
 	}
 
 	// Add the auths for each registry
+	logrus.Tracef("Getting auth from docker config for registries: %v", registries)
 	for _, registry := range registries {
+		logrus.Tracef("Getting auth from docker config for registry: %s", registry)
 		creds, err := docker_manager.GetAuthFromDockerConfig(registry)
 		if err != nil {
 			logrus.Warnf("An error occurred getting auth for registry '%v' from Docker config: %v", registry, err)
 		}
 		// creds can be nil if the registry doesn't have auth
-		if err != nil && creds != nil {
+		if err == nil && creds != nil {
 			cfg.Auths[registry] = *creds
+			logrus.Tracef("Found auth config for docker registry: %s", registry)
+		} else {
+			logrus.Tracef("No auth config found for docker registry: %s", registry)
 		}
 	}
 

--- a/container-engine-lib/lib/backend_impls/docker/docker_manager/docker_auth.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_manager/docker_auth.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/sirupsen/logrus"
 	"os"
 	"os/exec"
 	"strings"
@@ -14,6 +13,7 @@ import (
 	"github.com/docker/docker/api/types/registry"
 	dockerregistry "github.com/docker/docker/registry"
 	"github.com/kurtosis-tech/stacktrace"
+	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -36,6 +36,8 @@ func loadDockerAuth() (RegistryAuthConfig, error) {
 		configFilePath = configFilePath + "/config.json"
 	}
 
+	logrus.Infof("Loading docker auth from config file: %s", configFilePath)
+
 	file, err := os.ReadFile(configFilePath)
 	if errors.Is(err, os.ErrNotExist) {
 		// If the auth config doesn't exist, return an empty auth config
@@ -48,6 +50,15 @@ func loadDockerAuth() (RegistryAuthConfig, error) {
 	var authConfig RegistryAuthConfig
 	if err := json.Unmarshal(file, &authConfig); err != nil {
 		return emptyRegistryAuthConfig(), stacktrace.Propagate(err, "error unmarshalling Docker config file at '%s'", configFilePath)
+	}
+
+	// Remove trailing slashes from registry URLs
+	for registry, auth := range authConfig.Auths {
+		if strings.HasSuffix(registry, "/") {
+			delete(authConfig.Auths, registry)
+			registry = strings.TrimSuffix(registry, "/")
+			authConfig.Auths[registry] = auth
+		}
 	}
 
 	return authConfig, nil
@@ -144,14 +155,18 @@ func GetAuthFromDockerConfig(repo string) (*registry.AuthConfig, error) {
 	}
 
 	// if repo string doesn't contain a repo prefix assume its an official docker library image
-	if !strings.Contains(repo, "/") {
+	if !strings.Contains(repo, "/") && !strings.Contains(repo, ".") {
 		repo = "library/" + repo
 	}
 
 	registryHost := dockerregistry.ConvertToHostname(repo)
 
-	if !strings.Contains(registryHost, ".") || registryHost == "docker.io" || registryHost == "registry-1.docker.io" {
-		registryHost = "https://index.docker.io/v1/"
+	// Deal with the default Docker Hub registry.
+	if !strings.Contains(registryHost, ".") ||
+		registryHost == "docker.io" ||
+		registryHost == "registry-1.docker.io" ||
+		registryHost == "index.docker.io" {
+		registryHost = "https://index.docker.io/v1"
 	}
 
 	// Check if the URL contains "://", meaning it already has a protocol

--- a/container-engine-lib/lib/backend_impls/docker/docker_manager/docker_manager.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_manager/docker_manager.go
@@ -2297,6 +2297,7 @@ func pullImage(dockerClient *client.Client, imageName string, registrySpec *imag
 			logrus.Warnf("Falling back to pulling image with no auth config.")
 		} else {
 			imagePullOptions.RegistryAuth = authFromConfig
+			logrus.Infof("Using authentication to pull image: %s", imageName)
 		}
 	}
 


### PR DESCRIPTION
## Description
<!-- Describe this change, how it works, and the motivation behind it. -->

There is a bug in the docker config storage creator which was introduced in here https://github.com/kurtosis-tech/kurtosis/pull/2579 . This bug causes no auth to ever be used by the API and Engine containers. 
This PR fixes that and also adds some more tests for edge cases for repo addresses that can exist in the config.json. 

```diff
- if err != nil && creds != nil {
+ if err == nil && creds != nil {
```

## REMINDER: Tag Reviewers, so they get notified to review

## Is this change user facing?
NO
<!-- If yes, please add the "user facing" label to the PR -->
<!-- If yes, don't forget to include docs changes where relevant -->

## References (if applicable)
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
<!-- You can auto-close issues by putting "Fixes #XXXX" here. -->
