### PR TITLE
fix: return empty deployment if not found

### DIFF
--- a/cli/cli/commands/service/service_helpers/service_helpers.go
+++ b/cli/cli/commands/service/service_helpers/service_helpers.go
@@ -130,7 +130,7 @@ func GetAddServiceStarlarkScript(serviceName string, serviceConfigStarlark strin
 }
 
 func RunAddServiceStarlarkScript(ctx context.Context, serviceName, enclaveIdentifier, starlarkScript string, enclaveCtx *enclaves.EnclaveContext) (*enclaves.StarlarkRunResult, error) {
-	logrus.Infof("ADD SERVICE STARLARK:\n%v", starlarkScript)
+	logrus.Debugf("Add service starlark:\n%v", starlarkScript)
 	starlarkRunResult, err := enclaveCtx.RunStarlarkScriptBlocking(ctx, starlarkScript, starlark_run_config.NewRunStarlarkConfig())
 	if err != nil {
 		return nil, stacktrace.Propagate(err, "An error has occurred when running Starlark to add service")

--- a/docs/docs/cli-reference/service-add.md
+++ b/docs/docs/cli-reference/service-add.md
@@ -21,7 +21,13 @@ Much like `docker run`, this command has multiple options available to customize
 1. The `--env` flag can be used to specify a set of environment variables that should be set when running the service
 1. The `--ports` flag can be used to set the ports that the service will listen on
 
-If you have an existing service config in JSON format (for example, one that was output using `kurtosis service inspect`), you can use the `--json-service-config` flag to add a service using that config:
+To override the service's CMD, add a `--` after the image name and then pass in your CMD args like so:
+
+```bash
+kurtosis service add --entrypoint sh my-enclave test-service alpine -- -c "echo 'Hello world'"
+```
+
+Alternatively, if you have an existing service config in JSON format (for example, one that was output using `kurtosis service inspect`), you can use the `--json-service-config` flag to add a service using that config:
 
 ```bash
 kurtosis service add my-enclave test-service --json-service-config ./my-service-config.json
@@ -30,7 +36,7 @@ kurtosis service add my-enclave test-service --json-service-config ./my-service-
 To read the JSON config from stdin, use:
 
 ```bash
-kurtosis service add my-enclave test-service ubuntu:latest --json-service-config - < ./my-service-config.json
+kurtosis service add my-enclave test-service --json-service-config - < ./my-service-config.json
 ```
 
 :::note Override

--- a/docs/docs/cli-reference/service-add.md
+++ b/docs/docs/cli-reference/service-add.md
@@ -10,18 +10,30 @@ To add a service to an enclave, run:
 kurtosis service add $THE_ENCLAVE_IDENTIFIER $THE_SERVICE_IDENTIFIER $CONTAINER_IMAGE
 ```
 
-where `$THE_ENCLAVE_IDENTIFIER` and the `$THE_SERVICE_IDENTIFIER` are [resource identifiers](../advanced-concepts/resource-identifier.md) for the enclave and service, respectively. 
+where `$THE_ENCLAVE_IDENTIFIER` and the `$THE_SERVICE_IDENTIFIER` are [resource identifiers](../advanced-concepts/resource-identifier.md) for the enclave and service, respectively.
 Note, the service identifier needs to be formatted according to RFC 1035. Specifically, 1-63 lowercase alphanumeric characters with dashes and cannot start or end with dashes. Also service names
-have to start with a lowercase alphabet. 
+have to start with a lowercase alphabet.
 
 Much like `docker run`, this command has multiple options available to customize the service that's started:
 
+1. The `--cmd` flag can be used to override the default command that the container runs
 1. The `--entrypoint` flag can be passed in to override the binary the service runs
 1. The `--env` flag can be used to specify a set of environment variables that should be set when running the service
 1. The `--ports` flag can be used to set the ports that the service will listen on
 
-To override the service's CMD, add a `--` after the image name and then pass in your CMD args like so:
+If you have an existing service config in JSON format (for example, one that was output using `kurtosis service inspect`), you can use the `--json-service-config` flag to add a service using that config:
 
 ```bash
-kurtosis service add --entrypoint sh my-enclave test-service alpine -- -c "echo 'Hello world'"
+kurtosis service add my-enclave test-service --json-service-config ./my-service-config.json
 ```
+
+To read the JSON config from stdin, use:
+
+```bash
+kurtosis service add my-enclave test-service ubuntu:latest --json-service-config - < ./my-service-config.json
+```
+
+:::note Override
+When using `--json-service-config`, the standard flags and args like `--image`, `--cmd`, `--entrypoint`, `--env`, and `$CONTAINER_IMAGE` will be ignored in favor of the provided config.
+:::
+

--- a/docs/docs/cli-reference/service-inspect.md
+++ b/docs/docs/cli-reference/service-inspect.md
@@ -22,3 +22,8 @@ Running the above command will print detailed information about:
 
 By default, the service UUID is shortened. To view the full UUID of your service, add the following flag:
 * `--full-uuid`
+
+You can also control the output format using the `--output` (`-o`) flag:
+* `--output yaml` will print the service config in YAML format
+* `--output json` will print the service config in JSON format (this can be piped into `service add` via `--json-service-config`)
+* If `--output` is omitted, the result will be printed in a human-readable format

--- a/docs/docs/cli-reference/service-update.md
+++ b/docs/docs/cli-reference/service-update.md
@@ -33,7 +33,7 @@ kurtosis service update my-enclave test-service \
   --ports "port1:8080/tcp"
 ```
 
-:::note Restarted container
+:::note Restarted Container
 This command replaces the existing service with a new container using the updated configuration. The service will be briefly stopped and restarted as part of this process.
 :::
 

--- a/docs/docs/cli-reference/service-update.md
+++ b/docs/docs/cli-reference/service-update.md
@@ -1,0 +1,39 @@
+---
+title: service update
+sidebar_label: service update
+slug: /service-update
+---
+
+To update an existing service in an enclave, run:
+
+```bash
+kurtosis service update $THE_ENCLAVE_IDENTIFIER $THE_SERVICE_IDENTIFIER [flags]
+```
+
+where `$THE_ENCLAVE_IDENTIFIER` and `$THE_SERVICE_IDENTIFIER` are [resource identifiers](../advanced-concepts/resource-identifier.md) for the enclave and service, respectively.
+
+This command updates a service in-place by modifying its configuration. Only the specified parameters will be changed — the rest of the service config will remain as-is.
+
+Much like `docker run`, this command has multiple options available to customize the updated service:
+
+1. The `--image` flag can be used to update the service’s container image
+1. The `--entrypoint` flag can override the binary the service runs
+1. The `--env` flag can be used to set or override environment variables. Env var overrides with the same key will override existing env vars.
+1. The `--ports` flag can be used to add or override private port definitions. Port overrides with the same port id will override existing port bindings.
+1. The `--files` flag can be used to mount new file artifacts. Files artifacts overrides with the same key will override existing files artifact mounts.
+1. The `--cmd` flag can be used to override the CMD that is run when the container starts
+
+Example:
+
+```bash
+kurtosis service update my-enclave test-service \
+  --image my-custom-image \
+  --entrypoint my-binary \
+  --env "FOO:bar,BAR:baz" \
+  --ports "port1:8080/tcp"
+```
+
+:::note Restarted container
+This command replaces the existing service with a new container using the updated configuration. The service will be briefly stopped and restarted as part of this process.
+:::
+


### PR DESCRIPTION
## Description
Restarts on grafloki start over k8s were not working because of the way the not found error was being handled. This change returns a nil object if a deployment isn't found by k8s instead of returning an error.


