### PR TITLE
fix: task edits on k8s

### DIFF
--- a/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/user_services_functions/start_user_services.go
+++ b/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/user_services_functions/start_user_services.go
@@ -3,8 +3,9 @@ package user_services_functions
 import (
 	"context"
 	"fmt"
-	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/image_download_mode"
 	"strings"
+
+	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/image_download_mode"
 
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/service_user"
 
@@ -889,6 +890,7 @@ func createRegisterUserServiceOperation(
 			},
 		}
 
+		logrus.Infof("Creating Kubernetes service in enclave '%v' with ID '%v'", enclaveID, serviceName)
 		createdService, err := kubernetesManager.CreateService(
 			ctx,
 			namespaceName,

--- a/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/user_services_functions/start_user_services.go
+++ b/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/user_services_functions/start_user_services.go
@@ -890,7 +890,6 @@ func createRegisterUserServiceOperation(
 			},
 		}
 
-		logrus.Infof("Creating Kubernetes service in enclave '%v' with ID '%v'", enclaveID, serviceName)
 		createdService, err := kubernetesManager.CreateService(
 			ctx,
 			namespaceName,

--- a/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/user_services_functions/stop_user_services.go
+++ b/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/user_services_functions/stop_user_services.go
@@ -2,6 +2,7 @@ package user_services_functions
 
 import (
 	"context"
+
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/shared_helpers"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_manager"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/enclave"

--- a/core/server/api_container/server/service_network/default_service_network.go
+++ b/core/server/api_container/server/service_network/default_service_network.go
@@ -24,7 +24,7 @@ import (
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/database_accessors/enclave_db/service_registration"
 	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/service_network/render_templates"
 	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/service_network/service_identifiers"
-	"github.com/kurtosis-tech/kurtosis/path-compression"
+	path_compression "github.com/kurtosis-tech/kurtosis/path-compression"
 
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/enclave"
@@ -864,6 +864,7 @@ func (network *DefaultServiceNetwork) registerService(
 ) {
 	serviceSuccessfullyRegistered := false
 
+	logrus.Infof("Registering service '%s' in enclave '%v'", serviceName, network.enclaveUuid)
 	serviceToRegister := map[service.ServiceName]bool{
 		serviceName: true,
 	}

--- a/core/server/api_container/server/startosis_engine/kurtosis_instruction/add_service/add_service.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_instruction/add_service/add_service.go
@@ -3,6 +3,8 @@ package add_service
 import (
 	"context"
 	"fmt"
+	"reflect"
+
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/image_download_mode"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/service"
 	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/service_network"
@@ -22,8 +24,8 @@ import (
 	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/startosis_packages"
 	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/startosis_validator"
 	"github.com/kurtosis-tech/stacktrace"
+	"github.com/sirupsen/logrus"
 	"go.starlark.net/starlark"
-	"reflect"
 )
 
 const (
@@ -204,8 +206,10 @@ func (builtin *AddServiceCapabilities) Execute(ctx context.Context, _ *builtin_a
 		return "", stacktrace.Propagate(err, "An error occurred getting service registration for service '%s'", builtin.serviceName)
 	}
 	if exist {
+		logrus.Infof("Updating service '%s'", replacedServiceName)
 		startedService, err = builtin.serviceNetwork.UpdateService(ctx, replacedServiceName, replacedServiceConfig)
 	} else {
+		logrus.Infof("Adding brand new service '%s'", replacedServiceName)
 		startedService, err = builtin.serviceNetwork.AddService(ctx, replacedServiceName, replacedServiceConfig)
 	}
 	if err != nil {

--- a/core/server/api_container/server/startosis_engine/kurtosis_instruction/tasks/run_python.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_instruction/tasks/run_python.go
@@ -27,7 +27,6 @@ import (
 	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/startosis_packages"
 	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/startosis_validator"
 	"github.com/kurtosis-tech/stacktrace"
-	"github.com/sirupsen/logrus"
 	"go.starlark.net/starlark"
 	"go.starlark.net/starlarkstruct"
 )
@@ -350,12 +349,9 @@ func (builtin *RunPythonCapabilities) Execute(ctx context.Context, _ *builtin_ar
 	if err != nil {
 		return "", stacktrace.Propagate(err, "An error occurred getting service registration for run_python task '%s'", builtin.name)
 	}
-	logrus.Infof("Does '%v' exist? %v", builtin.name, exist)
 	if exist {
-		logrus.Infof("Updating task '%v' with image '%v'", builtin.name, builtin.serviceConfig.GetContainerImageName())
 		_, err = builtin.serviceNetwork.UpdateService(ctx, service.ServiceName(builtin.name), builtin.serviceConfig)
 	} else {
-		logrus.Infof("Adding task '%v' with image '%v'", builtin.name, builtin.serviceConfig.GetContainerImageName())
 		_, err = builtin.serviceNetwork.AddService(ctx, service.ServiceName(builtin.name), builtin.serviceConfig)
 	}
 	if err != nil {

--- a/core/server/api_container/server/startosis_engine/kurtosis_instruction/tasks/run_sh.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_instruction/tasks/run_sh.go
@@ -25,7 +25,6 @@ import (
 	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/startosis_packages"
 	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/startosis_validator"
 	"github.com/kurtosis-tech/stacktrace"
-	"github.com/sirupsen/logrus"
 	"go.starlark.net/starlark"
 	"go.starlark.net/starlarkstruct"
 )
@@ -311,12 +310,9 @@ func (builtin *RunShCapabilities) Execute(ctx context.Context, _ *builtin_argume
 	if err != nil {
 		return "", stacktrace.Propagate(err, "An error occurred getting service registration for run_sh task '%s'", builtin.name)
 	}
-	logrus.Infof("Does '%v' exist? %v", builtin.name, exist)
 	if exist {
-		logrus.Infof("Updating task '%v' with image '%v'", builtin.name, builtin.serviceConfig.GetContainerImageName())
 		_, err = builtin.serviceNetwork.UpdateService(ctx, service.ServiceName(builtin.name), serviceConfigWithReplacedEnvVars)
 	} else {
-		logrus.Infof("Adding task '%v' with image '%v'", builtin.name, builtin.serviceConfig.GetContainerImageName())
 		_, err = builtin.serviceNetwork.AddService(ctx, service.ServiceName(builtin.name), serviceConfigWithReplacedEnvVars)
 	}
 	if err != nil {

--- a/core/server/api_container/server/startosis_engine/kurtosis_instruction/tasks/tasks_shared.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_instruction/tasks/tasks_shared.go
@@ -3,14 +3,15 @@ package tasks
 import (
 	"context"
 	"fmt"
+	"reflect"
+	"strings"
+	"time"
+
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/image_build_spec"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/image_download_mode"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/image_registry_spec"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/nix_build_spec"
 	"github.com/xtgo/uuid"
-	"reflect"
-	"strings"
-	"time"
 
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/exec_result"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/service"
@@ -311,9 +312,9 @@ func formatErrorMessage(errorMessage string, errorFromExec string) string {
 }
 
 func removeService(ctx context.Context, serviceNetwork service_network.ServiceNetwork, serviceName string) error {
-	_, err := serviceNetwork.RemoveService(ctx, serviceName)
+	err := serviceNetwork.StopService(ctx, serviceName)
 	if err != nil {
-		return stacktrace.Propagate(err, "error occurred while removing task with name %v", serviceName)
+		return stacktrace.Propagate(err, "error occurred while stopping task with name %v", serviceName)
 	}
 	return nil
 }


### PR DESCRIPTION
## Description
Enclave edits were not working for packages with tasks. This was because of the way that the service network service registrations and service k8s objects for tasks were being handled. This fix makes two changes:

![image](https://github.com/user-attachments/assets/3735c933-2a8f-4fd2-b366-b1476e010f32)

1. Copies `add_service` for tasks where if a task exists, it should only be updated on an enclave edit instead of added again.
2. To get the above to work, a check for the tasks service registration is made. However, `serviceNetwork.RemoveService` would remove the tasks pods, ingress (as desired) after execution but also the tasks service registration. This change uses `serviceNetwork.StopService` which will also remove the tasks pods, ingress but not the tasks service registration. This way a subsequent edit will check the service registration, sees it exists, and update, instead of add.



This does have two effects:
- kt enclave inspect will now show the status of task as stopped, whereas before the service wouldn't appear in enclave inspect
- edits will not work when using `--non-blocking-mode` because `serviceNetwork.StopService` will never get called

TODO:

- [ ] Expose DestroyService on service network
- [ ] Use serviceNetwork.DestroyService instead of serviceNetwork.RemoveService
- [ ] Document what the differences are