### PR TITLE
fix: init remove funcs

### DIFF
--- a/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_aggregator_functions/create_logs_aggregator.go
+++ b/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_aggregator_functions/create_logs_aggregator.go
@@ -23,7 +23,7 @@ func CreateLogsAggregator(
 	var logsAggregatorObj *logs_aggregator.LogsAggregator
 	var kubernetesResources *logsAggregatorKubernetesResources
 	shouldRemoveLogsAggregator := false // only gets set to true if a logs aggregator is created (and might need to be removed)
-	var removeLogsAggregatorFunc func()
+	removeLogsAggregatorFunc := func() {}
 	var err error
 
 	logsAggregatorObj, kubernetesResources, err = getLogsAggregatorObjAndResourcesForCluster(ctx, kubernetesManager)
@@ -32,7 +32,6 @@ func CreateLogsAggregator(
 	}
 
 	if logsAggregatorObj != nil {
-		removeLogsAggregatorFunc = func() {} // can't create remove in this situation so jus make it a no op
 		logrus.Debug("Found existing logs aggregator deployment.")
 	} else {
 		logrus.Debug("Did not find existing logs aggregator, creating one...")

--- a/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_collector_functions/create_logs_collector.go
+++ b/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_collector_functions/create_logs_collector.go
@@ -2,6 +2,7 @@ package logs_collector_functions
 
 import (
 	"context"
+
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_manager"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_impls/kubernetes/object_attributes_provider"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/logs_aggregator"
@@ -36,7 +37,7 @@ func CreateLogsCollector(
 	var logsCollectorObj *logs_collector.LogsCollector
 	var kubernetesResources *logsCollectorKubernetesResources
 	shouldRemoveLogsCollector := false // only gets set to true if a logs collector is created (and might need to be removed)
-	var removeLogsCollectorFunc func()
+	removeLogsCollectorFunc := func() {}
 	var err error
 
 	logsCollectorObj, kubernetesResources, err = getLogsCollectorObjAndResourcesForCluster(ctx, kubernetesManager)
@@ -45,7 +46,6 @@ func CreateLogsCollector(
 	}
 
 	if logsCollectorObj != nil {
-		removeLogsCollectorFunc = func() {} // can't create remove in this situation so jus make it a no op
 		logrus.Debug("Found existing logs collector daemon set.")
 	} else {
 		logrus.Debug("Did not find existing log collector, creating one...")


### PR DESCRIPTION
## Description
`var removeLogsAggregator/CollectorFuns func()` was initializing the remove function as `nil`. 

In the case where `logsAggregator/Collector.CreateAndStart` fails or if the `get...ResourcesForCluster` call fails, the remove function never gets initialized. When the error returns, the defer will attempt to execute a nil function which causes a segfault.

Initializing the function to a no op solves this issue.

## Is this change user facing?
YES

## References
https://github.com/kurtosis-tech/kurtosis/issues/2704
https://discord.com/channels/783719264308953108/1364854129310044243/1364978226757107712