### PR TITLE
chore: Expose labels on ServiceContext struct

### DIFF
--- a/api/golang/core/lib/enclaves/enclave_context.go
+++ b/api/golang/core/lib/enclaves/enclave_context.go
@@ -20,11 +20,12 @@ package enclaves
 import (
 	"context"
 	"encoding/json"
-	"github.com/kurtosis-tech/kurtosis/path-compression"
 	"io"
 	"os"
 	"path"
 	"strings"
+
+	path_compression "github.com/kurtosis-tech/kurtosis/path-compression"
 
 	yaml_convert "github.com/ghodss/yaml"
 	"github.com/kurtosis-tech/kurtosis/api/golang/core/kurtosis_core_rpc_api_bindings"
@@ -739,6 +740,7 @@ func (enclaveCtx *EnclaveContext) convertServiceInfoToServiceContext(serviceInfo
 		serviceCtxPrivatePorts,
 		serviceInfo.GetMaybePublicIpAddr(),
 		serviceCtxPublicPorts,
+		serviceInfo.Labels,
 	)
 
 	return serviceContext, nil

--- a/api/golang/core/lib/services/service_context.go
+++ b/api/golang/core/lib/services/service_context.go
@@ -19,6 +19,7 @@ package services
 
 import (
 	"context"
+
 	"github.com/kurtosis-tech/kurtosis/api/golang/core/kurtosis_core_rpc_api_bindings"
 	"github.com/kurtosis-tech/kurtosis/api/golang/core/lib/binding_constructors"
 	"github.com/kurtosis-tech/stacktrace"
@@ -36,6 +37,9 @@ type ServiceContext struct {
 	// Network location outside the enclave
 	publicIpAddr string
 	publicPorts  map[string]*PortSpec
+
+	// Service labels
+	labels map[string]string
 }
 
 func NewServiceContext(
@@ -46,6 +50,7 @@ func NewServiceContext(
 	privatePorts map[string]*PortSpec,
 	publicIpAddr string,
 	publicPorts map[string]*PortSpec,
+	labels map[string]string,
 ) *ServiceContext {
 	return &ServiceContext{
 		client:        client,
@@ -55,6 +60,7 @@ func NewServiceContext(
 		privatePorts:  privatePorts,
 		publicIpAddr:  publicIpAddr,
 		publicPorts:   publicPorts,
+		labels:        labels,
 	}
 }
 
@@ -80,6 +86,10 @@ func (service *ServiceContext) GetMaybePublicIPAddress() string {
 
 func (service *ServiceContext) GetPublicPorts() map[string]*PortSpec {
 	return service.publicPorts
+}
+
+func (service *ServiceContext) GetLabels() map[string]string {
+	return service.labels
 }
 
 func (service *ServiceContext) ExecCommand(command []string) (int32, string, error) {


### PR DESCRIPTION
## Description
<!-- Describe this change, how it works, and the motivation behind it. -->

This PR exposes service labels on the `ServiceContext` struct so that they can be inspected by clients using the Go SDK. 

We would benefit hugely from having labels exposed so that we can easily integrate `ethpandaops/optimism-package` with our new E2E framework.

## Is this change user facing?
YES
<!-- If yes, please add the "user facing" label to the PR -->
<!-- If yes, don't forget to include docs changes where relevant -->

## References (if applicable)
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
<!-- You can auto-close issues by putting "Fixes #XXXX" here. -->
