### PR TITLE
fix(docs):  typo in CLI docs `--cli-level-log` -> `--cli-log-level`

### DIFF
--- a/docs/docs/cli-reference/index.md
+++ b/docs/docs/cli-reference/index.md
@@ -68,7 +68,7 @@ This flag sets the level of details that the Kurtosis CLI will print logs with -
 `panic|fatal|error|warning|info|debug|trace`. For example, logs with error level can be printed using the command below:-
 
 ```
-kurtosis run --cli-level-log debug github.com/package-author/package-repo 
+kurtosis run --cli-log-level debug github.com/package-author/package-repo 
 ```
 
 <details>


### PR DESCRIPTION
## Description
As the title suggests, I found a typo while reading CLI docs [here](https://docs.kurtosis.com/cli/): it says
```
kurtosis run --cli-level-log debug github.com/package-author/package-repo 
```

instead of 
```
kurtosis run --cli-log-level debug github.com/package-author/package-repo 
```
## REMINDER: Tag Reviewers, so they get notified to review

## Is this change user facing?
YES
<!-- If yes, please add the "user facing" label to the PR -->
<!-- If yes, don't forget to include docs changes where relevant -->
