### PR TITLE
ci: fix flaky test `TestStartosis_AddServiceWithReadyConditionsCheckFail`

### DIFF
--- a/core/server/api_container/server/startosis_engine/kurtosis_instruction/shared_helpers/service_helpers.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_instruction/shared_helpers/service_helpers.go
@@ -23,8 +23,6 @@ const (
 	bufferedChannelSize = 2
 	starlarkThreadName  = "starlark-value-serde-for-test-thread"
 	configArgName       = "config"
-
-	timeoutExtensionDivider = 4
 )
 
 func NewDummyStarlarkValueSerDeForTest() *kurtosis_types.StarlarkValueSerde {

--- a/core/server/api_container/server/startosis_engine/kurtosis_instruction/shared_helpers/service_helpers.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_instruction/shared_helpers/service_helpers.go
@@ -21,6 +21,7 @@ import (
 
 const (
 	bufferedChannelSize = 2
+	timeoutMultiplier   = 2
 	starlarkThreadName  = "starlark-value-serde-for-test-thread"
 	configArgName       = "config"
 )
@@ -67,7 +68,7 @@ func ExecuteServiceAssertionWithRecipe(
 	}()
 	// By passing 'contextWithDeadline' to recipe execution, we can make sure that when timeout is reached, the underlying
 	// request is aborted. 'timeoutChan' serves as an exit signal for the loop repeating the recipe execution.
-	contextWithDeadline, cancelContext := context.WithTimeout(ctx, 2*timeout)
+	contextWithDeadline, cancelContext := context.WithTimeout(ctx, timeoutMultiplier*timeout)
 	defer cancelContext()
 	timeoutChan := time.After(timeout)
 

--- a/core/server/api_container/server/startosis_engine/kurtosis_instruction/shared_helpers/service_helpers.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_instruction/shared_helpers/service_helpers.go
@@ -74,7 +74,7 @@ func ExecuteServiceAssertionWithRecipe(
 	// request is aborted.
 
 	// tedi(07-19-25): added a buffer to the context timeout to ensure the exit from timeoutChan is received before the context deadline is exceeded.
-	// otherwise, a race condition occurs where the context deadline is exceeded before the timeoutChan is received occurs and the code exits with a context deadline exceeded error
+	// otherwise, a race condition occurs where sometimes, context deadline is exceeded before the timeoutChan signal is received occurs and the code exits with a context deadline exceeded error
 	// not too sure if this is the best way to do it/why the ctxWithDeadline is needed but fixes flaky CI test for now - more context in original PR for this code here:
 	// https://github.com/kurtosis-tech/kurtosis/pull/480
 	ctxWithDeadline, cancelContext := context.WithTimeout(ctx, timeout+timeout/timeoutExtensionDivider)

--- a/core/server/api_container/server/startosis_engine/kurtosis_instruction/shared_helpers/service_helpers.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_instruction/shared_helpers/service_helpers.go
@@ -2,6 +2,9 @@ package shared_helpers
 
 import (
 	"context"
+	"reflect"
+	"time"
+
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/image_download_mode"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/service"
 	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/service_network"
@@ -14,8 +17,6 @@ import (
 	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/startosis_packages"
 	"github.com/kurtosis-tech/stacktrace"
 	"go.starlark.net/starlark"
-	"reflect"
-	"time"
 )
 
 const (
@@ -66,7 +67,7 @@ func ExecuteServiceAssertionWithRecipe(
 	}()
 	// By passing 'contextWithDeadline' to recipe execution, we can make sure that when timeout is reached, the underlying
 	// request is aborted. 'timeoutChan' serves as an exit signal for the loop repeating the recipe execution.
-	contextWithDeadline, cancelContext := context.WithTimeout(ctx, timeout)
+	contextWithDeadline, cancelContext := context.WithTimeout(ctx, 2*timeout)
 	defer cancelContext()
 	timeoutChan := time.After(timeout)
 

--- a/internal_testsuites/golang/testsuite/startosis_add_service_test/startosis_add_service_with_ready_conditions_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_add_service_test/startosis_add_service_with_ready_conditions_test.go
@@ -20,8 +20,8 @@ def run(plan):
 		field="code",
 		assertion="==",
 		target_value=%v,
-		interval="15s",
-		timeout="45s"
+		interval="1s",
+		timeout="40s"
     )
 
 	service_config = ServiceConfig(
@@ -29,7 +29,8 @@ def run(plan):
 		ports = {
 			"http-port": PortSpec(number = 8080, transport_protocol = "TCP")
 		},
-        ready_conditions = ready_conditions
+        ready_conditions = ready_conditions,
+		cmd = ["sh", "-c", "sleep 10 && node ./index.js"]
 	)
 
 	plan.add_service(name = "ws-ready-conditions-%v", config = service_config)

--- a/internal_testsuites/golang/testsuite/startosis_add_service_test/startosis_add_service_with_ready_conditions_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_add_service_test/startosis_add_service_with_ready_conditions_test.go
@@ -21,7 +21,7 @@ def run(plan):
 		assertion="==",
 		target_value=%v,
 		interval="1s",
-		timeout="5s"
+		timeout="40s"
     )
 
 	service_config = ServiceConfig(
@@ -30,7 +30,6 @@ def run(plan):
 			"http-port": PortSpec(number = 8080, transport_protocol = "TCP")
 		},
         ready_conditions = ready_conditions,
-		cmd = ["sh", "-c", "sleep 10 && node ./index.js"]
 	)
 
 	plan.add_service(name = "ws-ready-conditions-%v", config = service_config)

--- a/internal_testsuites/golang/testsuite/startosis_add_service_test/startosis_add_service_with_ready_conditions_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_add_service_test/startosis_add_service_with_ready_conditions_test.go
@@ -29,7 +29,7 @@ def run(plan):
 		ports = {
 			"http-port": PortSpec(number = 8080, transport_protocol = "TCP")
 		},
-        ready_conditions = ready_conditions,
+        ready_conditions = ready_conditions
 	)
 
 	plan.add_service(name = "ws-ready-conditions-%v", config = service_config)

--- a/internal_testsuites/golang/testsuite/startosis_add_service_test/startosis_add_service_with_ready_conditions_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_add_service_test/startosis_add_service_with_ready_conditions_test.go
@@ -21,7 +21,7 @@ def run(plan):
 		assertion="==",
 		target_value=%v,
 		interval="1s",
-		timeout="40s"
+		timeout="5s"
     )
 
 	service_config = ServiceConfig(

--- a/internal_testsuites/golang/testsuite/startosis_add_service_test/startosis_add_service_with_ready_conditions_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_add_service_test/startosis_add_service_with_ready_conditions_test.go
@@ -3,6 +3,7 @@ package startosis_add_service_test
 import (
 	"context"
 	"fmt"
+
 	"github.com/stretchr/testify/require"
 )
 
@@ -19,8 +20,8 @@ def run(plan):
 		field="code",
 		assertion="==",
 		target_value=%v,
-		interval="1s",
-		timeout="40s"
+		interval="15s",
+		timeout="45s"
     )
 
 	service_config = ServiceConfig(


### PR DESCRIPTION
## Description
`TestStartosis_AddServiceWithReadyConditionsCheckFail` occasionally fails in CI:
![Screenshot 2025-06-18 at 4 15 44 PM](https://github.com/user-attachments/assets/35ab2201-2ba7-4896-9a15-5ff7b6705411)


https://github.com/kurtosis-tech/kurtosis/blob/fccb53c2e41043164a45db856d85bfaf4847dd12/core/server/api_container/server/startosis_engine/kurtosis_instruction/shared_helpers/service_helpers.go#L134

`ctxWithDeadline` and `interruptChan` are set to the same `timeout`. A race condition was happening where if `ctxWithDeadline` timed out before `interruptChan` signaled, the `execFunc` would get called -> fail with `context deadline exceeded` making the last error a `recipeErr`. When `interruptChan` eventually signaled, the loop would exit with that `recipeErr` (the one displayed in the pic) as opposed to the expected `assertErr`.

To fix this, I added a small buffer to `ctxWithDeadline` timeout so `interruptChan` triggers before context deadline is exceeded. Not too sure how both are being used to track timeouts or why `ctxWithDeadline` is used instead of `ctxWithCancel` but much of that context is in this PR: https://github.com/kurtosis-tech/kurtosis/pull/480

## Is this change user facing?
NO
