### PR TITLE
fix: add podman mode to publish script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1214,7 +1214,8 @@ jobs:
           image_name_to_publish_semver="${IMAGE_ORG_AND_REPO}:${version_to_publish}"
           image_name_to_publish_latest="${IMAGE_ORG_AND_REPO}:latest"
           push_to_dockerhub=true
-          scripts/docker-image-builder.sh "${push_to_dockerhub}" "${dockerfile_filepath}" "${image_name_with_version}" "${image_name_to_publish_semver}" "${image_name_to_publish_latest}"
+          podman_mode=false
+          scripts/docker-image-builder.sh "${push_to_dockerhub}" "${dockerfile_filepath}" "${podman_mode}" "${image_name_with_version}" "${image_name_to_publish_semver}" "${image_name_to_publish_latest}"
 
   publish_api_container_server_image:
     docker:
@@ -1256,7 +1257,8 @@ jobs:
           image_name_to_publish_semver="${IMAGE_ORG_AND_REPO}:${version_to_publish}"
           image_name_to_publish_latest="${IMAGE_ORG_AND_REPO}:latest"
           push_to_dockerhub=true
-          scripts/docker-image-builder.sh "${push_to_dockerhub}" "${dockerfile_filepath}" "${image_name_with_version}" "${image_name_to_publish_semver}" "${image_name_to_publish_latest}"
+          podman_mode=false
+          scripts/docker-image-builder.sh "${push_to_dockerhub}" "${dockerfile_filepath}" "${podman_mode}" "${image_name_with_version}" "${image_name_to_publish_semver}" "${image_name_to_publish_latest}"
 
   publish_engine_server_image:
     docker:
@@ -1303,7 +1305,8 @@ jobs:
           image_name_to_publish_semver="${IMAGE_ORG_AND_REPO}:${version_to_publish}"
           image_name_to_publish_latest="${IMAGE_ORG_AND_REPO}:latest"
           push_to_dockerhub=true
-          scripts/docker-image-builder.sh "${push_to_dockerhub}" "${dockerfile_filepath}" "${image_name_with_version}" "${image_name_to_publish_semver}" "${image_name_to_publish_latest}"
+          podman_mode=false
+          scripts/docker-image-builder.sh "${push_to_dockerhub}" "${dockerfile_filepath}" "${podman_mode}" "${image_name_with_version}" "${image_name_to_publish_semver}" "${image_name_to_publish_latest}"
 
   push_cli_artifacts:
     # we use this docker/tilt-releaser image for cli jobs because starlark-lsp requires it to build

--- a/scripts/docker-image-builder.sh
+++ b/scripts/docker-image-builder.sh
@@ -104,9 +104,9 @@ fi
 
 ## Actually build the Docker image
 if "${podman_mode}"; then
-  docker_buildx_cmd="sudo podman buildx build ${push_flag} --platform ${buildx_platform_arg} ${image_tags_concatenated} -f ${dockerfile_filepath} ${dockerfile_dirpath}"
+  docker_buildx_cmd="podman buildx build ${push_flag} --platform ${buildx_platform_arg} ${image_tags_concatenated} -f ${dockerfile_filepath} ${dockerfile_dirpath}"
 else
-  docker_buildx_cmd="sudo docker buildx build ${push_flag} --platform ${buildx_platform_arg} ${image_tags_concatenated} -f ${dockerfile_filepath} ${dockerfile_dirpath}"
+  docker_buildx_cmd="docker buildx build ${push_flag} --platform ${buildx_platform_arg} ${image_tags_concatenated} -f ${dockerfile_filepath} ${dockerfile_dirpath}"
 fi
 echo "Running the following docker buildx command:"
 echo "${docker_buildx_cmd}"


### PR DESCRIPTION
## Description
CI publish jobs weren't updated with `podman_mode` input arg so publish steps on release `1.9.0` failed.


## Is this change user facing?
NO

