### PR TITLE
fix: docker auth bugs

### DIFF
--- a/container-engine-lib/lib/backend_impls/docker/docker_manager/docker_auth.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_manager/docker_auth.go
@@ -238,6 +238,8 @@ func GetAuthFromDockerConfig(repo string) (*registry.AuthConfig, error) {
 				ac.Username = string(decodedAuth[:usernamePasswordSeparatorIndex])
 				ac.Password = string(decodedAuth[usernamePasswordSeparatorIndex+1:])
 			}
+		} else {
+			return nil, stacktrace.NewError("no username or password or auth found for registry '%s'", registryHost)
 		}
 
 		return &ac, nil

--- a/container-engine-lib/lib/backend_impls/docker/docker_manager/docker_auth.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_manager/docker_auth.go
@@ -223,9 +223,12 @@ func GetAuthFromDockerConfig(repo string) (*registry.AuthConfig, error) {
 			RegistryToken: auth.RegistryToken,
 		}
 
-		// If the base64 encoded auth field is set, decode it and also set the Username and Password
-		if auth.Auth != "" {
-			// Base64 decode it and set the Username and Password
+		// If the username or password fields are set, set them in the AuthConfig (Overrides the decoded auth)
+		if auth.Username != "" && auth.Password != "" {
+			ac.Username = auth.Username
+			ac.Password = auth.Password
+		} else if auth.Auth != "" {
+			// If the base64 encoded auth field is set, decode it and also set the Username and Password
 			decodedAuth, err := base64.StdEncoding.DecodeString(auth.Auth)
 			if err != nil {
 				return nil, stacktrace.Propagate(err, "error decoding auth for registry '%s'", registryHost)
@@ -235,14 +238,6 @@ func GetAuthFromDockerConfig(repo string) (*registry.AuthConfig, error) {
 				ac.Username = string(decodedAuth[:usernamePasswordSeparatorIndex])
 				ac.Password = string(decodedAuth[usernamePasswordSeparatorIndex+1:])
 			}
-		}
-
-		// If the username or password fields are set, set them in the AuthConfig (Overrides the decoded auth)
-		if auth.Username != "" {
-			ac.Username = auth.Username
-		}
-		if auth.Password != "" {
-			ac.Password = auth.Password
 		}
 
 		return &ac, nil

--- a/container-engine-lib/lib/backend_impls/docker/docker_manager/docker_auth.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_manager/docker_auth.go
@@ -232,7 +232,6 @@ func GetAuthFromDockerConfig(repo string) (*registry.AuthConfig, error) {
 			}
 			ac.Username = string(decodedAuth[:strings.IndexByte(string(decodedAuth), ':')])
 			ac.Password = string(decodedAuth[strings.IndexByte(string(decodedAuth), ':')+1:])
-			ac.Auth = auth.Auth
 		}
 
 		// If the username or password fields are set, set them in the AuthConfig (Overrides the decoded auth)

--- a/container-engine-lib/lib/backend_impls/docker/docker_manager/docker_auth.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_manager/docker_auth.go
@@ -230,8 +230,11 @@ func GetAuthFromDockerConfig(repo string) (*registry.AuthConfig, error) {
 			if err != nil {
 				return nil, stacktrace.Propagate(err, "error decoding auth for registry '%s'", registryHost)
 			}
-			ac.Username = string(decodedAuth[:strings.IndexByte(string(decodedAuth), ':')])
-			ac.Password = string(decodedAuth[strings.IndexByte(string(decodedAuth), ':')+1:])
+			usernamePasswordSeparatorIndex := strings.IndexByte(string(decodedAuth), ':')
+			if usernamePasswordSeparatorIndex != -1 {
+				ac.Username = string(decodedAuth[:usernamePasswordSeparatorIndex])
+				ac.Password = string(decodedAuth[usernamePasswordSeparatorIndex+1:])
+			}
 		}
 
 		// If the username or password fields are set, set them in the AuthConfig (Overrides the decoded auth)

--- a/container-engine-lib/lib/backend_impls/docker/docker_manager/docker_auth_test.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_manager/docker_auth_test.go
@@ -64,40 +64,88 @@ func TestGetAuthConfigForRepoPlain(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 
 	testCases := []struct {
-		repo         string
-		expectedAuth string
+		repo                  string
+		expectedAuth          string
+		expectedUser          string
+		expectedPassword      string
+		expectedServerAddress string
 	}{
 		{
-			repo:         "docker.io/my-repo/my-image:latest",
-			expectedAuth: encodedAuthDockerHub,
+			repo:                  "alpine:3.17",
+			expectedAuth:          encodedAuthDockerHub,
+			expectedUser:          expectedUserDockerHub,
+			expectedPassword:      expectedPasswordDockerHub,
+			expectedServerAddress: "https://index.docker.io/v1/",
 		},
 		{
-			repo:         "my-repo/my-image:latest",
-			expectedAuth: encodedAuthDockerHub,
+			repo:                  "traefik",
+			expectedAuth:          encodedAuthDockerHub,
+			expectedUser:          expectedUserDockerHub,
+			expectedPassword:      expectedPasswordDockerHub,
+			expectedServerAddress: "https://index.docker.io/v1/",
 		},
 		{
-			repo:         "https://registry-1.docker.io/my-repo/my-image:latest",
-			expectedAuth: encodedAuthDockerHub,
+			repo:                  "ubuntu:latest",
+			expectedAuth:          encodedAuthDockerHub,
+			expectedUser:          expectedUserDockerHub,
+			expectedPassword:      expectedPasswordDockerHub,
+			expectedServerAddress: "https://index.docker.io/v1/",
 		},
 		{
-			repo:         "https://index.docker.io/v1/",
-			expectedAuth: encodedAuthDockerHub,
+			repo:                  "docker.io/my-repo/my-image:latest",
+			expectedAuth:          encodedAuthDockerHub,
+			expectedUser:          expectedUserDockerHub,
+			expectedPassword:      expectedPasswordDockerHub,
+			expectedServerAddress: "https://index.docker.io/v1/",
 		},
 		{
-			repo:         "https://index.docker.io/v1",
-			expectedAuth: encodedAuthDockerHub,
+			repo:                  "my-repo/my-image:latest",
+			expectedAuth:          encodedAuthDockerHub,
+			expectedUser:          expectedUserDockerHub,
+			expectedPassword:      expectedPasswordDockerHub,
+			expectedServerAddress: "https://index.docker.io/v1/",
 		},
 		{
-			repo:         "ghcr.io/my-repo/my-image:latest",
-			expectedAuth: encodedAuthGithub,
+			repo:                  "https://registry-1.docker.io/my-repo/my-image:latest",
+			expectedAuth:          encodedAuthDockerHub,
+			expectedUser:          expectedUserDockerHub,
+			expectedPassword:      expectedPasswordDockerHub,
+			expectedServerAddress: "https://index.docker.io/v1/",
 		},
 		{
-			repo:         "ghcr.io",
-			expectedAuth: encodedAuthGithub,
+			repo:                  "https://index.docker.io/v1/",
+			expectedAuth:          encodedAuthDockerHub,
+			expectedUser:          expectedUserDockerHub,
+			expectedPassword:      expectedPasswordDockerHub,
+			expectedServerAddress: "https://index.docker.io/v1/",
 		},
 		{
-			repo:         "ghcr.io/",
-			expectedAuth: encodedAuthGithub,
+			repo:                  "https://index.docker.io/v1",
+			expectedAuth:          encodedAuthDockerHub,
+			expectedUser:          expectedUserDockerHub,
+			expectedPassword:      expectedPasswordDockerHub,
+			expectedServerAddress: "https://index.docker.io/v1/",
+		},
+		{
+			repo:                  "ghcr.io/my-repo/my-image:latest",
+			expectedAuth:          encodedAuthGithub,
+			expectedUser:          expectedUserGithub,
+			expectedPassword:      expectedPasswordGithub,
+			expectedServerAddress: "https://ghcr.io/",
+		},
+		{
+			repo:                  "ghcr.io",
+			expectedAuth:          encodedAuthGithub,
+			expectedUser:          expectedUserGithub,
+			expectedPassword:      expectedPasswordGithub,
+			expectedServerAddress: "https://ghcr.io/",
+		},
+		{
+			repo:                  "ghcr.io/",
+			expectedAuth:          encodedAuthGithub,
+			expectedUser:          expectedUserGithub,
+			expectedPassword:      expectedPasswordGithub,
+			expectedServerAddress: "https://ghcr.io/",
 		},
 	}
 
@@ -106,6 +154,9 @@ func TestGetAuthConfigForRepoPlain(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotNil(t, authConfig, "Auth config should not be nil")
 		assert.Equal(t, testCase.expectedAuth, authConfig.Auth, "Auth for Docker Hub should match")
+		assert.Equal(t, testCase.expectedUser, authConfig.Username, "Username should match")
+		assert.Equal(t, testCase.expectedPassword, authConfig.Password, "Password should match")
+		assert.Equal(t, testCase.expectedServerAddress, authConfig.ServerAddress, "Server address should match")
 	}
 
 	authConfig, err := GetAuthFromDockerConfig("something-else.local")

--- a/container-engine-lib/lib/backend_impls/docker/docker_manager/docker_manager.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_manager/docker_manager.go
@@ -2441,7 +2441,6 @@ func pullImage(dockerClient *client.Client, imageName string, registrySpec *imag
 	}
 
 	out, err := dockerClient.ImagePull(pullImageCtx, imageName, imagePullOptions)
-	logrus.Infof("ImagePull LOL: %v", imagePullOptions.RegistryAuth)
 	if err != nil {
 		return stacktrace.Propagate(err, "Tried pulling image '%v' with platform '%v' but failed", imageName, platform), false
 	}


### PR DESCRIPTION
There were 2 problems:

1. We were just propagating the `Auth` field to the `X-Registry-Auth` header, via `ImagePullOptions.RegistryAuth`. 
We do need to also set the `Username`, `Password` and `ServerAddress`. The docs are not very clear, https://docs.docker.com/reference/api/engine/version/v1.45/#section/Authentication , but not having those seemed to affect the authentication. It's also weird that you don't get an error when you provide uncomplete authentication headers... anyway.

2. Images like `alpine:3.17` didn't get the right registry address. They did point to `alpine:3.17` , isntead of using `https://index.docker.io/v1/`. This made it impossible to get the credentials when pulling images that were using `.` in their tags. I made sure to strip out the tag part. 

I've also updated the tests so that these 2 situations are covered. 


I've also tested this locally, using a simple auth config file, like we use in CI runs that only looks like this:

```json
{
        "auths": {
                "https://index.docker.io/v1/": {
                        "auth": "xxxxx"
                }
        }
}
```

I also did some manual test by doing the following in a loop after removing my docker auth config:
- Run kurtosis 
- Run a package
- Cleanup enclave + stop engine
- Docker remove all images that were pulled
- Repeat

After some minutes I hit the 100 pull limit for unauthenticated requests. I kept it running like this for a couple of minutes.

Then I did a docker login which populated my ~/.docker./config.json . After restarting the engine. There were no more rate limit messages.