### PR TITLE
fix: reduce logs agg container timeout

### DIFF
--- a/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/logs_aggregator_functions/implementations/vector/vector_logs_aggregator_container.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/logs_aggregator_functions/implementations/vector/vector_logs_aggregator_container.go
@@ -19,7 +19,7 @@ const (
 	maxCleanRetries                    = 2
 	timeBetweenCleanRetries            = 200 * time.Millisecond
 	cleaningSuccessStatusCode          = 0
-	stopLogsAggregatorContainerTimeout = 10 * time.Second
+	stopLogsAggregatorContainerTimeout = 1 * time.Second
 )
 
 type vectorLogsAggregatorContainer struct{}


### PR DESCRIPTION
## Description
`clean -a` was taking a long time because of this time out. 


## Is this change user facing?
YES