### PR TITLE
feat: tolerations and node selectors on tasks

### DIFF
--- a/container-engine-lib/lib/backend_interface/objects/service/service_config.go
+++ b/container-engine-lib/lib/backend_interface/objects/service/service_config.go
@@ -81,8 +81,30 @@ type privateServiceConfig struct {
 	TtyEnabled bool
 }
 
-func CreateServiceConfig(containerImageName string, imageBuildSpec *image_build_spec.ImageBuildSpec, imageRegistrySpec *image_registry_spec.ImageRegistrySpec, nixBuildSpec *nix_build_spec.NixBuildSpec, privatePorts map[string]*port_spec.PortSpec, publicPorts map[string]*port_spec.PortSpec, entrypointArgs []string, cmdArgs []string, envVars map[string]string, filesArtifactExpansion *service_directory.FilesArtifactsExpansion, persistentDirectories *service_directory.PersistentDirectories, cpuAllocationMillicpus uint64, memoryAllocationMegabytes uint64, privateIPAddrPlaceholder string, minCpuMilliCpus uint64, minMemoryMegaBytes uint64, labels map[string]string, user *service_user.ServiceUser, tolerations []v1.Toleration, nodeSelectors map[string]string, imageDownloadMode image_download_mode.ImageDownloadMode, tiniEnabled bool, ttyEnabled bool) (*ServiceConfig, error) {
-
+func CreateServiceConfig(
+	containerImageName string,
+	imageBuildSpec *image_build_spec.ImageBuildSpec,
+	imageRegistrySpec *image_registry_spec.ImageRegistrySpec,
+	nixBuildSpec *nix_build_spec.NixBuildSpec,
+	privatePorts map[string]*port_spec.PortSpec,
+	publicPorts map[string]*port_spec.PortSpec,
+	entrypointArgs []string,
+	cmdArgs []string,
+	envVars map[string]string,
+	filesArtifactExpansion *service_directory.FilesArtifactsExpansion,
+	persistentDirectories *service_directory.PersistentDirectories,
+	cpuAllocationMillicpus uint64,
+	memoryAllocationMegabytes uint64,
+	privateIPAddrPlaceholder string,
+	minCpuMilliCpus uint64,
+	minMemoryMegaBytes uint64,
+	labels map[string]string,
+	user *service_user.ServiceUser,
+	tolerations []v1.Toleration,
+	nodeSelectors map[string]string,
+	imageDownloadMode image_download_mode.ImageDownloadMode,
+	tiniEnabled bool,
+	ttyEnabled bool) (*ServiceConfig, error) {
 	if err := ValidateServiceConfigLabels(labels); err != nil {
 		return nil, stacktrace.Propagate(err, "Invalid service config labels '%+v'", labels)
 	}

--- a/core/server/api_container/server/startosis_engine/kurtosis_instruction/tasks/run_python.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_instruction/tasks/run_python.go
@@ -134,7 +134,7 @@ func NewRunPythonService(
 					IsOptional:        true,
 					ZeroValueProvider: builtin_argument.ZeroValueProvider[*starlark.List],
 					Validator: func(value starlark.Value) *startosis_errors.InterpretationError {
-						return builtin_argument.StringMappingToString(value, TolerationsArgName)
+						return nil
 					},
 				},
 			},

--- a/core/server/api_container/server/startosis_engine/kurtosis_instruction/tasks/run_python.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_instruction/tasks/run_python.go
@@ -278,18 +278,22 @@ func (builtin *RunPythonCapabilities) Interpret(locatorOfModuleInWhichThisBuilti
 	}
 
 	envVars, interpretationErr := extractEnvVarsIfDefined(arguments)
-	if err != nil {
+	if interpretationErr != nil {
 		return nil, interpretationErr
 	}
 
-	nodeSelectors := map[string]string{}
-	nodeSelectorsStarlark, interpretationErr := builtin_argument.ExtractArgumentValue[*starlark.Dict](arguments, NodeSelectorsArgName)
+	nodeSelectors, interpretationErr := extractNodeSelectorsIfDefined(arguments)
+	if interpretationErr != nil {
+		return nil, interpretationErr
+	}
+
+	tolerations, interpretationErr := extractTolerationsIfDefined(arguments)
 	if interpretationErr != nil {
 		return nil, interpretationErr
 	}
 
 	// build a service config from image and files artifacts expansion.
-	builtin.serviceConfig, err = getServiceConfig(maybeImageName, maybeImageBuildSpec, maybeImageRegistrySpec, maybeNixBuildSpec, filesArtifactExpansion, envVars)
+	builtin.serviceConfig, err = getServiceConfig(maybeImageName, maybeImageBuildSpec, maybeImageRegistrySpec, maybeNixBuildSpec, filesArtifactExpansion, envVars, nodeSelectors, tolerations)
 	if err != nil {
 		return nil, startosis_errors.WrapWithInterpretationError(err, "An error occurred creating service config for run python.")
 	}

--- a/core/server/api_container/server/startosis_engine/kurtosis_instruction/tasks/run_python.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_instruction/tasks/run_python.go
@@ -129,6 +129,14 @@ func NewRunPythonService(
 						return builtin_argument.StringMappingToString(value, NodeSelectorsArgName)
 					},
 				},
+				{
+					Name:              TolerationsArgName,
+					IsOptional:        true,
+					ZeroValueProvider: builtin_argument.ZeroValueProvider[*starlark.List],
+					Validator: func(value starlark.Value) *startosis_errors.InterpretationError {
+						return builtin_argument.StringMappingToString(value, TolerationsArgName)
+					},
+				},
 			},
 		},
 
@@ -163,6 +171,8 @@ func NewRunPythonService(
 			FilesArgName:           true,
 			StoreFilesArgName:      true,
 			WaitArgName:            true,
+			NodeSelectorsArgName:   true,
+			TolerationsArgName:     true,
 		},
 	}
 }

--- a/core/server/api_container/server/startosis_engine/kurtosis_instruction/tasks/run_sh.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_instruction/tasks/run_sh.go
@@ -112,11 +112,11 @@ func NewRunShService(
 					},
 				},
 				{
-					Name:              NodeSelectorsArgName,
+					Name:              TolerationsArgName,
 					IsOptional:        true,
 					ZeroValueProvider: builtin_argument.ZeroValueProvider[*starlark.Dict],
 					Validator: func(value starlark.Value) *startosis_errors.InterpretationError {
-						return builtin_argument.StringMappingToString(value, NodeSelectorsArgName)
+						return builtin_argument.StringMappingToString(value, TolerationsArgName)
 					},
 				},
 			},

--- a/core/server/api_container/server/startosis_engine/kurtosis_instruction/tasks/run_sh.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_instruction/tasks/run_sh.go
@@ -116,7 +116,7 @@ func NewRunShService(
 					IsOptional:        true,
 					ZeroValueProvider: builtin_argument.ZeroValueProvider[*starlark.List],
 					Validator: func(value starlark.Value) *startosis_errors.InterpretationError {
-						return builtin_argument.StringMappingToString(value, TolerationsArgName)
+						return nil
 					},
 				},
 			},

--- a/core/server/api_container/server/startosis_engine/kurtosis_instruction/tasks/run_sh.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_instruction/tasks/run_sh.go
@@ -114,7 +114,7 @@ func NewRunShService(
 				{
 					Name:              TolerationsArgName,
 					IsOptional:        true,
-					ZeroValueProvider: builtin_argument.ZeroValueProvider[*starlark.Dict],
+					ZeroValueProvider: builtin_argument.ZeroValueProvider[*starlark.List],
 					Validator: func(value starlark.Value) *startosis_errors.InterpretationError {
 						return builtin_argument.StringMappingToString(value, TolerationsArgName)
 					},

--- a/core/server/api_container/server/startosis_engine/kurtosis_instruction/tasks/tasks_shared.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_instruction/tasks/tasks_shared.go
@@ -3,14 +3,15 @@ package tasks
 import (
 	"context"
 	"fmt"
+	"reflect"
+	"strings"
+	"time"
+
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/image_build_spec"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/image_download_mode"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/image_registry_spec"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/nix_build_spec"
 	"github.com/xtgo/uuid"
-	"reflect"
-	"strings"
-	"time"
 
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/exec_result"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/service"
@@ -41,6 +42,7 @@ const (
 	EnvVarsArgName         = "env_vars"
 	AcceptableCodesArgName = "acceptable_codes"
 	SkipCodeCheckArgName   = "skip_code_check"
+	NodeSelectorsArgName   = "node_selectors"
 	defaultSkipCodeCheck   = false
 
 	newlineChar = "\n"

--- a/core/server/api_container/server/startosis_engine/kurtosis_instruction/tasks/tasks_shared.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_instruction/tasks/tasks_shared.go
@@ -12,6 +12,7 @@ import (
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/image_registry_spec"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/nix_build_spec"
 	"github.com/xtgo/uuid"
+	v1 "k8s.io/api/core/v1"
 
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/exec_result"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/service"
@@ -43,6 +44,7 @@ const (
 	AcceptableCodesArgName = "acceptable_codes"
 	SkipCodeCheckArgName   = "skip_code_check"
 	NodeSelectorsArgName   = "node_selectors"
+	TolerationsArgName     = "tolerations"
 	defaultSkipCodeCheck   = false
 
 	newlineChar = "\n"
@@ -298,8 +300,33 @@ func getServiceConfig(
 	maybeNixBuildSpec *nix_build_spec.NixBuildSpec,
 	filesArtifactExpansion *service_directory.FilesArtifactsExpansion,
 	envVars *map[string]string,
+	nodeSelectors *map[string]string,
+	tolerations []v1.Toleration,
 ) (*service.ServiceConfig, error) {
-	serviceConfig, err := service.CreateServiceConfig(maybeImageName, maybeImageBuildSpec, maybeImageRegistrySpec, maybeNixBuildSpec, nil, nil, runCommandToStreamTaskLogs, nil, *envVars, filesArtifactExpansion, nil, 0, 0, service_config.DefaultPrivateIPAddrPlaceholder, 0, 0, map[string]string{}, nil, nil, map[string]string{}, image_download_mode.ImageDownloadMode_Missing, tiniEnabled, false)
+	serviceConfig, err := service.CreateServiceConfig(
+		maybeImageName,
+		maybeImageBuildSpec,
+		maybeImageRegistrySpec,
+		maybeNixBuildSpec,
+		nil,
+		nil,
+		runCommandToStreamTaskLogs,
+		nil,
+		*envVars,
+		filesArtifactExpansion,
+		nil,
+		0,
+		0,
+		service_config.DefaultPrivateIPAddrPlaceholder,
+		0,
+		0,
+		map[string]string{},
+		nil,
+		tolerations,
+		*nodeSelectors,
+		image_download_mode.ImageDownloadMode_Missing,
+		tiniEnabled,
+		false)
 	if err != nil {
 		return nil, stacktrace.Propagate(err, "An error occurred creating service config")
 	}
@@ -336,6 +363,42 @@ func extractEnvVarsIfDefined(arguments *builtin_argument.ArgumentValuesSet) (*ma
 		}
 	}
 	return &envVars, nil
+}
+
+func extractNodeSelectorsIfDefined(arguments *builtin_argument.ArgumentValuesSet) (*map[string]string, *startosis_errors.InterpretationError) {
+	nodeSelectors := map[string]string{}
+	if arguments.IsSet(NodeSelectorsArgName) {
+		nodeSelectorsStarlark, err := builtin_argument.ExtractArgumentValue[*starlark.Dict](arguments, NodeSelectorsArgName)
+		if err != nil {
+			return nil, startosis_errors.WrapWithInterpretationError(err, "Unable to extract value for '%s' argument", EnvVarsArgName)
+		}
+		if nodeSelectorsStarlark != nil && nodeSelectorsStarlark.Len() > 0 {
+			var interpretationErr *startosis_errors.InterpretationError
+			nodeSelectors, interpretationErr = kurtosis_types.SafeCastToMapStringString(nodeSelectorsStarlark, NodeSelectorsArgName)
+			if interpretationErr != nil {
+				return nil, interpretationErr
+			}
+		}
+	}
+	return &nodeSelectors, nil
+}
+
+func extractTolerationsIfDefined(arguments *builtin_argument.ArgumentValuesSet) ([]v1.Toleration, *startosis_errors.InterpretationError) {
+	tolerations := []v1.Toleration{}
+	if arguments.IsSet(TolerationsArgName) {
+		tolerationsStarlark, err := builtin_argument.ExtractArgumentValue[*starlark.List](arguments, TolerationsArgName)
+		if err != nil {
+			return nil, startosis_errors.WrapWithInterpretationError(err, "Unable to extract value for '%s' argument", TolerationsArgName)
+		}
+		if tolerationsStarlark != nil && tolerationsStarlark.Len() > 0 {
+			var interpretationErr *startosis_errors.InterpretationError
+			tolerations, interpretationErr = service_config.ConvertTolerations(tolerationsStarlark)
+			if interpretationErr != nil {
+				return nil, interpretationErr
+			}
+		}
+	}
+	return tolerations, nil
 }
 
 func getTaskNameFromArgs(arguments *builtin_argument.ArgumentValuesSet) (string, error) {

--- a/core/server/api_container/server/startosis_engine/kurtosis_types/service_config/service_config.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_types/service_config/service_config.go
@@ -509,7 +509,7 @@ func (config *ServiceConfig) ToKurtosisType(
 		return nil, interpretationErr
 	}
 	if found {
-		tolerations, interpretationErr = convertTolerations(tolerationsStarlarkList)
+		tolerations, interpretationErr = ConvertTolerations(tolerationsStarlarkList)
 		if interpretationErr != nil {
 			return nil, interpretationErr
 		}
@@ -770,7 +770,7 @@ func ConvertImage(
 	}
 }
 
-func convertTolerations(tolerationsList *starlark.List) ([]v1.Toleration, *startosis_errors.InterpretationError) {
+func ConvertTolerations(tolerationsList *starlark.List) ([]v1.Toleration, *startosis_errors.InterpretationError) {
 	var outputValue []v1.Toleration
 	iterator := tolerationsList.Iterate()
 	defer iterator.Done()

--- a/docs/docs/api-reference/starlark-reference/plan.md
+++ b/docs/docs/api-reference/starlark-reference/plan.md
@@ -590,6 +590,24 @@ The `run_python` instruction executes a one-time execution task. It runs the Pyt
         # OPTIONAL (Default: "180s")
         wait="180s"
 
+        # Defines Kubernetes node selectors for scheduling the task on specific nodes
+        # OPTIONAL (Default: {})
+        node_selectors = {
+            "node-type": "high-memory",
+            "zone": "us-west-1a",
+        },
+
+        # Defines Kubernetes tolerations for scheduling the task on nodes with matching taints
+        # OPTIONAL (Default: [])
+        tolerations = [
+            Toleration(
+                key="high-memory",
+                operator="Equal",
+                value="true", 
+                effect="NoSchedule"
+            ),
+        ],
+
         # A human friendly description for the end user of the package
         # OPTIONAL (Default: Running Python script)
         description = "running python script"
@@ -683,6 +701,24 @@ The `run_sh` instruction executes a one-time execution task. It runs the bash co
         # The feature is enabled by default with a default timeout of 180s
         # OPTIONAL (Default: "180s")
         wait="180s"
+
+        # Defines Kubernetes node selectors for scheduling the task on specific nodes
+        # OPTIONAL (Default: {})
+        node_selectors = {
+            "node-type": "high-memory",
+            "zone": "us-west-1a",
+        },
+
+        # Defines Kubernetes tolerations for scheduling the task on nodes with matching taints
+        # OPTIONAL (Default: [])
+        tolerations = [
+            Toleration(
+                key="high-memory",
+                operator="Equal",
+                value="true", 
+                effect="NoSchedule"
+            ),
+        ],
 
         # A human friendly description for the end user of the package
         # OPTIONAL (Default: Running sh script)


### PR DESCRIPTION
## Description
Addresses this issue, firstly by enabling setting tolerations and node selectors on tasks, as you would in a `ServiceConfig`: [add node selectors and tolerations to basic kurtosis commands](https://github.com/kurtosis-tech/kurtosis/issues/2783)
e.g.
```
def run(plan, args):
    plan.run_sh(
        run="echo 'hi'",
        node_selectors={
            "main-node":"true",
        },
        tolerations=[
             Toleration(
                 key="key",
                 operator="Equal",
                 value="value",
             )
         ]
    )
```
## Is this change user facing?
YES 

## References
[add node selectors and tolerations to basic kurtosis commands](https://github.com/kurtosis-tech/kurtosis/issues/2783)