### PR TITLE
feat: add get cluster type

### DIFF
--- a/core/server/api_container/main.go
+++ b/core/server/api_container/main.go
@@ -228,7 +228,7 @@ func runMain() error {
 	}
 
 	// TODO: Consolidate Interpreter, Validator and Executor into a single interface
-	startosisInterpreter := startosis_engine.NewStartosisInterpreter(serviceNetwork, gitPackageContentProvider, runtimeValueStore, starlarkValueSerde, serverArgs.EnclaveEnvVars, interpretationTimeValueStore)
+	startosisInterpreter := startosis_engine.NewStartosisInterpreter(serviceNetwork, gitPackageContentProvider, runtimeValueStore, starlarkValueSerde, serverArgs.EnclaveEnvVars, interpretationTimeValueStore, serverArgs.KurtosisBackendType)
 	startosisRunner := startosis_engine.NewStartosisRunner(
 		startosisInterpreter,
 		startosis_engine.NewStartosisValidator(&kurtosisBackend, serviceNetwork, filesArtifactStore),

--- a/core/server/api_container/server/startosis_engine/kurtosis_builtins.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_builtins.go
@@ -2,6 +2,7 @@ package startosis_engine
 
 import (
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/image_download_mode"
+	"github.com/kurtosis-tech/kurtosis/core/launcher/args"
 	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/service_network"
 	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/builtins"
 	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/builtins/import_module"
@@ -10,6 +11,7 @@ import (
 	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/interpretation_time_value_store"
 	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/kurtosis_instruction/add_service"
 	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/kurtosis_instruction/exec"
+	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/kurtosis_instruction/get_cluster_type"
 	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/kurtosis_instruction/get_files_artifact"
 	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/kurtosis_instruction/get_service"
 	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/kurtosis_instruction/get_services"
@@ -24,7 +26,6 @@ import (
 	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/kurtosis_instruction/tasks"
 	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/kurtosis_instruction/upload_files"
 	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/kurtosis_instruction/verify"
-	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/kurtosis_instruction/wait"
 	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/kurtosis_starlark_framework/kurtosis_plan_instruction"
 	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/kurtosis_types"
 	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/kurtosis_types/directory"
@@ -68,6 +69,7 @@ func KurtosisPlanInstructions(
 	nonBlockingMode bool,
 	interpretationTimeValueStore *interpretation_time_value_store.InterpretationTimeValueStore,
 	imageDownloadMode image_download_mode.ImageDownloadMode,
+	kurtosisBackendType args.KurtosisBackendType,
 ) []*kurtosis_plan_instruction.KurtosisPlanInstruction {
 	return []*kurtosis_plan_instruction.KurtosisPlanInstruction{
 		add_service.NewAddService(serviceNetwork, runtimeValueStore, packageId, packageContentProvider, packageReplaceOptions, interpretationTimeValueStore, imageDownloadMode),
@@ -88,7 +90,7 @@ func KurtosisPlanInstructions(
 		stop_service.NewStopService(serviceNetwork),
 		store_service_files.NewStoreServiceFiles(serviceNetwork),
 		upload_files.NewUploadFiles(packageId, serviceNetwork, packageContentProvider, packageReplaceOptions),
-		wait.NewWait(serviceNetwork, runtimeValueStore),
+		get_cluster_type.NewGetClusterType(kurtosisBackendType),
 	}
 }
 

--- a/core/server/api_container/server/startosis_engine/kurtosis_builtins.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_builtins.go
@@ -26,6 +26,7 @@ import (
 	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/kurtosis_instruction/tasks"
 	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/kurtosis_instruction/upload_files"
 	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/kurtosis_instruction/verify"
+	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/kurtosis_instruction/wait"
 	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/kurtosis_starlark_framework/kurtosis_plan_instruction"
 	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/kurtosis_types"
 	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/kurtosis_types/directory"
@@ -90,6 +91,7 @@ func KurtosisPlanInstructions(
 		stop_service.NewStopService(serviceNetwork),
 		store_service_files.NewStoreServiceFiles(serviceNetwork),
 		upload_files.NewUploadFiles(packageId, serviceNetwork, packageContentProvider, packageReplaceOptions),
+		wait.NewWait(serviceNetwork, runtimeValueStore),
 		get_cluster_type.NewGetClusterType(kurtosisBackendType),
 	}
 }

--- a/core/server/api_container/server/startosis_engine/kurtosis_instruction/get_cluster_type/get_cluster_type.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_instruction/get_cluster_type/get_cluster_type.go
@@ -65,6 +65,7 @@ func (builtin *GetClusterTypeCapabilities) TryResolveWith(instructionsAreEqual b
 }
 
 func (builtin *GetClusterTypeCapabilities) FillPersistableAttributes(builder *enclave_plan_persistence.EnclavePlanInstructionBuilder) {
+	builder.SetType(GetClusterTypeBuiltinName)
 }
 
 func (builtin *GetClusterTypeCapabilities) UpdatePlan(planYaml *plan_yaml.PlanYamlGenerator) error {

--- a/core/server/api_container/server/startosis_engine/kurtosis_instruction/get_cluster_type/get_cluster_type.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_instruction/get_cluster_type/get_cluster_type.go
@@ -1,0 +1,77 @@
+package get_cluster_type
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/kurtosis-tech/kurtosis/core/launcher/args"
+	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/enclave_plan_persistence"
+	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/enclave_structure"
+	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/kurtosis_starlark_framework"
+	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/kurtosis_starlark_framework/builtin_argument"
+	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/kurtosis_starlark_framework/kurtosis_plan_instruction"
+	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/plan_yaml"
+	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/startosis_errors"
+	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/startosis_validator"
+	"go.starlark.net/starlark"
+)
+
+const (
+	GetClusterTypeBuiltinName = "get_cluster_type"
+
+	descriptionFormatStr = "Fetching cluster type '%v'"
+)
+
+func NewGetClusterType(kurtosisBackendType args.KurtosisBackendType) *kurtosis_plan_instruction.KurtosisPlanInstruction {
+	return &kurtosis_plan_instruction.KurtosisPlanInstruction{
+		KurtosisBaseBuiltin: &kurtosis_starlark_framework.KurtosisBaseBuiltin{
+			Name:        GetClusterTypeBuiltinName,
+			Arguments:   []*builtin_argument.BuiltinArgument{},
+			Deprecation: nil,
+		},
+		Capabilities: func() kurtosis_plan_instruction.KurtosisPlanInstructionCapabilities {
+			return &GetClusterTypeCapabilities{
+				clusterType: kurtosisBackendType.String(),
+				description: fmt.Sprintf(descriptionFormatStr, kurtosisBackendType.String()),
+			}
+		},
+		DefaultDisplayArguments: map[string]bool{},
+	}
+}
+
+type GetClusterTypeCapabilities struct {
+	clusterType string
+	description string
+}
+
+func (builtin *GetClusterTypeCapabilities) Interpret(_ string, arguments *builtin_argument.ArgumentValuesSet) (starlark.Value, *startosis_errors.InterpretationError) {
+	return starlark.String(builtin.clusterType), nil
+}
+
+func (builtin *GetClusterTypeCapabilities) Validate(_ *builtin_argument.ArgumentValuesSet, validatorEnvironment *startosis_validator.ValidatorEnvironment) *startosis_errors.ValidationError {
+	return nil
+}
+
+func (builtin *GetClusterTypeCapabilities) Execute(_ context.Context, _ *builtin_argument.ArgumentValuesSet) (string, error) {
+	// Note this is a no-op
+	return fmt.Sprintf("Fetched cluster type '%v'", builtin.clusterType), nil
+}
+
+func (builtin *GetClusterTypeCapabilities) TryResolveWith(instructionsAreEqual bool, _ *enclave_plan_persistence.EnclavePlanInstruction, enclaveComponents *enclave_structure.EnclaveComponents) enclave_structure.InstructionResolutionStatus {
+	if instructionsAreEqual {
+		return enclave_structure.InstructionIsEqual
+	}
+	return enclave_structure.InstructionIsUnknown
+}
+
+func (builtin *GetClusterTypeCapabilities) FillPersistableAttributes(builder *enclave_plan_persistence.EnclavePlanInstructionBuilder) {
+}
+
+func (builtin *GetClusterTypeCapabilities) UpdatePlan(planYaml *plan_yaml.PlanYamlGenerator) error {
+	// get cluster type does not affect the planYaml
+	return nil
+}
+
+func (builtin *GetClusterTypeCapabilities) Description() string {
+	return builtin.description
+}

--- a/core/server/api_container/server/startosis_engine/startosis_interpreter_idempotent_test.go
+++ b/core/server/api_container/server/startosis_engine/startosis_interpreter_idempotent_test.go
@@ -2,9 +2,13 @@ package startosis_engine
 
 import (
 	"context"
+	"net"
+	"testing"
+
 	"github.com/google/uuid"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/enclave"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/image_download_mode"
+	"github.com/kurtosis-tech/kurtosis/core/launcher/args"
 	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/service_network"
 	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/enclave_plan_persistence"
 	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/enclave_structure"
@@ -20,8 +24,6 @@ import (
 	"github.com/stretchr/testify/suite"
 	"go.starlark.net/starlark"
 	"go.starlark.net/starlarkstruct"
-	"net"
-	"testing"
 )
 
 const (
@@ -72,7 +74,7 @@ func (suite *StartosisInterpreterIdempotentTestSuite) SetupTest() {
 		service_network.NewApiContainerInfo(net.IPv4(0, 0, 0, 0), uint16(1234), "0.0.0"),
 	)
 	serviceNetwork.EXPECT().GetEnclaveUuid().Maybe().Return(enclaveUuid)
-	suite.interpreter = NewStartosisInterpreter(serviceNetwork, suite.packageContentProvider, runtimeValueStore, starlarkValueSerde, "", interpretationTimeValueStore)
+	suite.interpreter = NewStartosisInterpreter(serviceNetwork, suite.packageContentProvider, runtimeValueStore, starlarkValueSerde, "", interpretationTimeValueStore, args.KurtosisBackendType_Docker)
 }
 
 func TestRunStartosisInterpreterIdempotentTestSuite(t *testing.T) {

--- a/core/server/api_container/server/startosis_engine/startosis_interpreter_plan_yaml_generator_test.go
+++ b/core/server/api_container/server/startosis_engine/startosis_interpreter_plan_yaml_generator_test.go
@@ -3,9 +3,13 @@ package startosis_engine
 import (
 	"context"
 	"fmt"
+	"net"
+	"testing"
+
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/enclave"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/image_download_mode"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/service"
+	"github.com/kurtosis-tech/kurtosis/core/launcher/args"
 	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/service_network"
 	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/interpretation_time_value_store"
 	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/kurtosis_instruction/shared_helpers"
@@ -15,8 +19,6 @@ import (
 	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/startosis_packages/mock_package_content_provider"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"net"
-	"testing"
 )
 
 const (
@@ -69,7 +71,7 @@ func (suite *StartosisIntepreterPlanYamlGeneratorTestSuite) SetupTest() {
 		mockApicVersion)
 	suite.serviceNetwork.EXPECT().GetApiContainerInfo().Return(apiContainerInfo)
 
-	suite.interpreter = NewStartosisInterpreter(suite.serviceNetwork, suite.packageContentProvider, suite.runtimeValueStore, nil, "", suite.interpretationTimeValueStore)
+	suite.interpreter = NewStartosisInterpreter(suite.serviceNetwork, suite.packageContentProvider, suite.runtimeValueStore, nil, "", suite.interpretationTimeValueStore, args.KurtosisBackendType_Docker)
 }
 
 func TestRunStartosisIntepreterPlanYamlGeneratorTestSuite(t *testing.T) {

--- a/core/server/api_container/server/startosis_engine/startosis_interpreter_test.go
+++ b/core/server/api_container/server/startosis_engine/startosis_interpreter_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/enclave"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/image_download_mode"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/service"
+	"github.com/kurtosis-tech/kurtosis/core/launcher/args"
 	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/service_network"
 	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/builtins/print_builtin"
 	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/builtins/time_now_builtin"
@@ -84,7 +85,7 @@ func (suite *StartosisInterpreterTestSuite) SetupTest() {
 	suite.interpretationTimeValueStore = interpretationTimeValueStore
 	require.NotNil(suite.T(), interpretationTimeValueStore)
 
-	suite.interpreter = NewStartosisInterpreter(suite.serviceNetwork, suite.packageContentProvider, suite.runtimeValueStore, nil, "", suite.interpretationTimeValueStore)
+	suite.interpreter = NewStartosisInterpreter(suite.serviceNetwork, suite.packageContentProvider, suite.runtimeValueStore, nil, "", suite.interpretationTimeValueStore, args.KurtosisBackendType_Docker)
 
 	service.NewServiceRegistration(
 		testServiceName,
@@ -1101,7 +1102,7 @@ def run(plan):
 	}
 
 	// We'll create a new interpreter using the processBuiltins transformer above
-	interpreter := NewStartosisInterpreterWithBuiltinsProcessor(suite.serviceNetwork, suite.packageContentProvider, suite.runtimeValueStore, nil, "", suite.interpretationTimeValueStore, processBuiltins)
+	interpreter := NewStartosisInterpreterWithBuiltinsProcessor(suite.serviceNetwork, suite.packageContentProvider, suite.runtimeValueStore, nil, "", suite.interpretationTimeValueStore, processBuiltins, args.KurtosisBackendType_Docker)
 
 	_, _, interpretationError := interpreter.Interpret(context.Background(), startosis_constants.PackageIdPlaceholderForStandaloneScript, useDefaultMainFunctionName, noPackageReplaceOptions, startosis_constants.PlaceHolderMainFileForPlaceStandAloneScript, script, startosis_constants.EmptyInputArgs, defaultNonBlockingMode, emptyEnclaveComponents, emptyInstructionsPlanMask, defaultImageDownloadMode)
 
@@ -1126,7 +1127,7 @@ def run(plan):
 	}
 
 	// We'll create a new interpreter using the processBuiltins transformer above
-	interpreter := NewStartosisInterpreterWithBuiltinsProcessor(suite.serviceNetwork, suite.packageContentProvider, suite.runtimeValueStore, nil, "", suite.interpretationTimeValueStore, processBuiltins)
+	interpreter := NewStartosisInterpreterWithBuiltinsProcessor(suite.serviceNetwork, suite.packageContentProvider, suite.runtimeValueStore, nil, "", suite.interpretationTimeValueStore, processBuiltins, args.KurtosisBackendType_Docker)
 
 	// If everything goes well we should see no error & message on the output
 	_, instructionsPlan, interpretationError := interpreter.Interpret(context.Background(), startosis_constants.PackageIdPlaceholderForStandaloneScript, useDefaultMainFunctionName, noPackageReplaceOptions, startosis_constants.PlaceHolderMainFileForPlaceStandAloneScript, script, startosis_constants.EmptyInputArgs, defaultNonBlockingMode, emptyEnclaveComponents, emptyInstructionsPlanMask, defaultImageDownloadMode)

--- a/docs/docs/api-reference/starlark-reference/plan.md
+++ b/docs/docs/api-reference/starlark-reference/plan.md
@@ -891,13 +891,15 @@ get_cluster_type
 The `get_cluster_type` instruction returns the type of cluster backend that Kurtosis is currently running on.
 
 ```python
-# Returns a string representing the cluster type (e.g., "docker", "kubernetes")
+# Returns a string representing the cluster type ("docker", "kubernetes", "podman")
 cluster_type = plan.get_cluster_type()
+if cluster_type == "docker":
+    ...
 
 plan.print("Running on cluster type: " + cluster_type)
 ```
 
-This instruction takes no arguments and returns a string indicating the backend cluster type. This is useful when you need to conditionally execute different logic based on whether you're running on Docker, Kubernetes, or other supported backends.
+This instruction takes no arguments and returns a string indicating the backend cluster type. This is useful when you need to conditionally execute different logic based on whether you're running on Docker, Kubernetes, or other supported backends. Possi
 
 
 

--- a/docs/docs/api-reference/starlark-reference/plan.md
+++ b/docs/docs/api-reference/starlark-reference/plan.md
@@ -885,6 +885,22 @@ recipe_result = plan.wait(
 plan.print(recipe_result["code"])
 ```
 
+get_cluster_type
+----------------
+
+The `get_cluster_type` instruction returns the type of cluster backend that Kurtosis is currently running on.
+
+```python
+# Returns a string representing the cluster type (e.g., "docker", "kubernetes")
+cluster_type = plan.get_cluster_type()
+
+plan.print("Running on cluster type: " + cluster_type)
+```
+
+This instruction takes no arguments and returns a string indicating the backend cluster type. This is useful when you need to conditionally execute different logic based on whether you're running on Docker, Kubernetes, or other supported backends.
+
+
+
 
 <!--------------- ONLY LINKS BELOW THIS POINT ---------------------->
 [add-service]: #add_service

--- a/enclave-manager/web/README.md
+++ b/enclave-manager/web/README.md
@@ -91,7 +91,7 @@ You don’t have to ever use `eject`. The curated feature set is suitable for sm
 - React router (v6) - we avoid using route actions and loaders as they didn't seem to have good Typescript support, created codepaths that were tricky to follow (by excessively fragmenting code) and generally seemed to increase complexity rather than improve development velocity.
 - Chakra UI
 - TanStack table - used for managing the state of tables throughout the application
-- React hook form - used for forms where any validation is required. Generally the [Smart Form Component pattern](https://react-hook-form.com/advanced-usage#SmartFormComponent) is followed to create form components that can be composed together arbitrarily.
+- React hook form - used for forms where any validation is required. Generally the Smart Form Component pattern is followed to create form components that can be composed together arbitrarily.
 - Reactflow - used for the graph in the enclave builder.
 - Virtuoso - used for rendering streams of logs without dumping all of the text into the DOM.
 - Monaco - used anywhere we want to display blocks of code, or for editing code in the browser.


### PR DESCRIPTION
## Description
Adds a `get_cluster_type` instruction which returns a string equal to the name of the cluster type used.
```
def run(plan, args):
    cluster_type = plan.get_cluster_type()
    if cluster_type == "docker":
        plan.print("Docker cluster type")
    elif cluster_type == "kubernetes":
        plan.print("Kubernetes cluster type")
```

## Is this change user facing?
YES

## References

