### PR TITLE
fix: don't print empty args on detailed verbosity

### DIFF
--- a/cli/cli/helpers/output_printers/kurtosis_instruction_printer.go
+++ b/cli/cli/helpers/output_printers/kurtosis_instruction_printer.go
@@ -224,7 +224,9 @@ func formatInstructionToReadableString(instruction *kurtosis_core_rpc_api_bindin
 			} else {
 				serializedArg = arg.GetSerializedArgValue()
 			}
-			serializedInstructionComponents = append(serializedInstructionComponents, serializedArg)
+			if serializedArg != "" {
+				serializedInstructionComponents = append(serializedInstructionComponents, serializedArg)
+			}
 		}
 	}
 


### PR DESCRIPTION
## Description
Before:
<img width="913" height="278" alt="Screenshot 2025-08-27 at 9 35 24 AM" src="https://github.com/user-attachments/assets/4e0e026f-58ab-4980-8bd7-85dcc3af0f9d" />
After:
<img width="906" height="183" alt="Screenshot 2025-08-27 at 9 34 41 AM" src="https://github.com/user-attachments/assets/3ffaaef1-00ec-4bcc-bf8f-103b13c145a5" />

