### PR TITLE
fix: use rootless docker for starting the engine

### DIFF
--- a/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/docker_kurtosis_backend_api_container_functions.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/docker_kurtosis_backend_api_container_functions.go
@@ -191,9 +191,13 @@ func (backend *DockerKurtosisBackend) CreateAPIContainer(
 		usedPorts[debugServerDockerPort] = docker_manager.NewManualPublishingSpec(uint16(apicDebugServerPort))
 	}
 
+	// Get the appropriate Docker socket path for mounting into the container
+	hostDockerSocketPath := shared_helpers.GetHostDockerSocketPath()
+
 	bindMounts := map[string]string{
-		// Necessary so that the API container can interact with the Docker engine
-		consts.DockerSocketFilepath: consts.DockerSocketFilepath,
+		// Mount the host's Docker socket to the standard location inside the container
+		// This allows the API container to interact with the Docker daemon
+		hostDockerSocketPath: consts.DockerSocketFilepath,
 	}
 
 	volumeMounts := map[string]string{

--- a/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/reverse_proxy_functions/implementations/traefik/traefik_container_config_provider.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/reverse_proxy_functions/implementations/traefik/traefik_container_config_provider.go
@@ -35,9 +35,13 @@ func (traefik *traefikContainerConfigProvider) GetContainerArgs(
 	networkId string,
 ) (*docker_manager.CreateAndStartContainerArgs, error) {
 
+	// Get the appropriate Docker socket path for mounting into the container
+	hostDockerSocketPath := shared_helpers.GetHostDockerSocketPath()
+
 	bindMounts := map[string]string{
-		// Necessary so that the reverse proxy can interact with the Docker engine
-		consts.DockerSocketFilepath: consts.DockerSocketFilepath,
+		// Mount the host's Docker socket to the standard location inside the container
+		// This allows the reverse proxy to interact with the Docker daemon
+		hostDockerSocketPath: consts.DockerSocketFilepath,
 	}
 
 	traefikConfigContentStr, err := traefik.config.GetConfigFileContent(configFileTemplate)

--- a/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/shared_helpers/shared_helpers.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/shared_helpers/shared_helpers.go
@@ -772,3 +772,24 @@ func dumpContainerInfo(
 
 	return nil
 }
+
+// GetHostDockerSocketPath returns the appropriate Docker socket path to use for mounting into containers.
+// It checks if DOCKER_HOST environment variable specifies a custom Unix socket and validates its existence.
+// If no custom socket is found or it doesn't exist, it returns the default Docker socket path.
+func GetHostDockerSocketPath() string {
+	// By default, use the standard Docker socket location
+	hostDockerSocketPath := consts.DockerSocketFilepath
+
+	// Check if DOCKER_HOST environment variable specifies a custom Unix socket
+	if dockerHostEnv := os.Getenv("DOCKER_HOST"); dockerHostEnv != "" {
+		if strings.HasPrefix(dockerHostEnv, "unix://") {
+			customSocketPath := strings.TrimPrefix(dockerHostEnv, "unix://")
+			// Verify the custom socket actually exists before using it
+			if _, err := os.Stat(customSocketPath); err == nil {
+				hostDockerSocketPath = customSocketPath
+			}
+		}
+	}
+
+	return hostDockerSocketPath
+}


### PR DESCRIPTION
## Description
Fix Kurtosis engine startup failure when using rootless Docker with custom socket path.

When Docker is configured to use a rootless user socket location (e.g., /run/user/1000/docker.sock for rootless Docker), the Kurtosis engine container fails to start because it attempts to mount the hardcoded /var/run/docker.sock path, which doesn't exist. This causes the engine to fail with a "permission denied" error when trying to connect to the Docker daemon.

This change detects if the DOCKER_HOST environment variable is set to a Unix socket path, validates that the socket file exists, and uses it for mounting into the engine container instead of the hardcoded default. The socket is still mounted to /var/run/docker.sock inside the container to maintain compatibility with the existing engine code.

## REMINDER: Tag Reviewers, so they get notified to review
@tedim52 


