### PR TITLE
chore(ci): upgrade checkout to v5

### DIFF
--- a/.github/workflows/breaking-change-description-title-update.yml
+++ b/.github/workflows/breaking-change-description-title-update.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           sha: ${{ github.event.pull_request.head.sha }}
         id: PR
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - run: |

--- a/.github/workflows/change-versions.yml
+++ b/.github/workflows/change-versions.yml
@@ -9,7 +9,7 @@ jobs:
     if: contains(github.head_ref, 'release-please')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           token: "${{ secrets.RELEASER_TOKEN }}"
           fetch-depth: 0

--- a/.github/workflows/check-proto-break.yml
+++ b/.github/workflows/check-proto-break.yml
@@ -13,7 +13,7 @@ jobs:
     outputs:
       change: ${{ steps.check.outputs.change }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           go-version: '1.20'
           fetch-depth: 0
@@ -33,7 +33,7 @@ jobs:
       with:
         go-version: '1.20'
     - run: go install github.com/bufbuild/buf/cmd/buf@v1.26.1
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         fetch-depth: 0
     - name: Check if PR is breaking

--- a/.github/workflows/gofmt.yml
+++ b/.github/workflows/gofmt.yml
@@ -16,7 +16,7 @@ jobs:
     outputs:
       change: ${{ steps.check.outputs.change }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           go-version: '1.23'
           fetch-depth: 0

--- a/.github/workflows/golang-package-tag.yml
+++ b/.github/workflows/golang-package-tag.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Get current version
         run: echo "CURRENT_VERSION=$(cat version.txt)" >> $GITHUB_ENV
       - name: Tag golang package

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -26,7 +26,7 @@ jobs:
     outputs:
       change: ${{ steps.check.outputs.change }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           go-version: '1.23'
           fetch-depth: 0
@@ -61,7 +61,7 @@ jobs:
         if: ${{ needs.check-if-code-change.outputs.change == 'true' }}
         with:
           go-version: '1.23'
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         if: ${{ needs.check-if-code-change.outputs.change == 'true' }}
       # Generate versions
       - run: scripts/generate-kurtosis-version.sh

--- a/.github/workflows/push-docs.yml
+++ b/.github/workflows/push-docs.yml
@@ -31,7 +31,7 @@ jobs:
       }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Enforce to use yarn


### PR DESCRIPTION
## Description
Maintenance update to actions/checkout@v5 to align with the current runner stack (Node 24); nothing else modified.
Release notes: https://github.com/actions/checkout/releases/tag/v5.0.0

## Is this change user facing?
NO

