### PR TITLE
fix: remove enclave identifiers

### DIFF
--- a/api/golang/engine/lib/kurtosis_context/kurtosis_context.go
+++ b/api/golang/engine/lib/kurtosis_context/kurtosis_context.go
@@ -235,25 +235,22 @@ func (kurtosisCtx *KurtosisContext) GetEnclave(ctx context.Context, enclaveIdent
 	if err != nil {
 		return nil, stacktrace.Propagate(err, "An error occurred getting existing and historical enclave identifiers ")
 	}
-	matchingEnclaveUuid := ""
+	// in the case the user has created an enclave with the same name multiple times - we only want to return the running enclave (there should only ever be one running enclave with a given name)
+	// we query for enclaves that match the provided identifier and only return the running one
+	matchingEnclaveUuids := []string{}
 	for _, enclaveInfo := range existingAndHistoricalEnclaveIdentifiers.AllIdentifiers {
-		if matchingEnclaveUuid != "" {
-			break
-		}
-
 		// if the provided identifier matches any of the known identifiers for an enclave, use that enclaves full uuid to get the enclave info
 		if enclaveInfo.Name == enclaveIdentifier ||
 			enclaveInfo.ShortenedUuid == enclaveIdentifier ||
 			enclaveInfo.EnclaveUuid == enclaveIdentifier {
-			matchingEnclaveUuid = enclaveInfo.EnclaveUuid
+			matchingEnclaveUuids = append(matchingEnclaveUuids, enclaveInfo.EnclaveUuid)
 		}
 	}
-	if matchingEnclaveUuid == "" {
+	if len(matchingEnclaveUuids) == 0 {
 		return nil, stacktrace.NewError("No enclave found with identifier '%v'", enclaveIdentifier)
 	}
-
 	getEnclaveResponse, err := kurtosisCtx.engineClient.GetEnclavesByUuids(ctx, &kurtosis_engine_rpc_api_bindings.GetEnclavesByUuidsArgs{
-		EnclaveUuids: []string{matchingEnclaveUuid},
+		EnclaveUuids: matchingEnclaveUuids,
 	})
 	if err != nil {
 		return nil, stacktrace.Propagate(
@@ -262,7 +259,16 @@ func (kurtosisCtx *KurtosisContext) GetEnclave(ctx context.Context, enclaveIdent
 			enclaveIdentifier,
 		)
 	}
-	return getEnclaveResponse.EnclaveInfo[matchingEnclaveUuid], nil
+	var runningEnclaveInfos []*kurtosis_engine_rpc_api_bindings.EnclaveInfo
+	for _, enclaveInfo := range getEnclaveResponse.EnclaveInfo {
+		if enclaveInfo.ContainersStatus == kurtosis_engine_rpc_api_bindings.EnclaveContainersStatus_EnclaveContainersStatus_RUNNING {
+			runningEnclaveInfos = append(runningEnclaveInfos, enclaveInfo)
+		}
+	}
+	if len(runningEnclaveInfos) > 1 {
+		return nil, stacktrace.NewError("More than one running enclave found with identifier '%v'. There should only ever be one running enclave with a given name for the identifier.", enclaveIdentifier)
+	}
+	return runningEnclaveInfos[0], nil
 }
 
 func (kurtosisCtx *KurtosisContext) StopEnclave(ctx context.Context, enclaveIdentifier string) error {

--- a/api/golang/engine/lib/kurtosis_context/kurtosis_context.go
+++ b/api/golang/engine/lib/kurtosis_context/kurtosis_context.go
@@ -268,6 +268,9 @@ func (kurtosisCtx *KurtosisContext) GetEnclave(ctx context.Context, enclaveIdent
 	if len(runningEnclaveInfos) > 1 {
 		return nil, stacktrace.NewError("More than one running enclave found with identifier '%v'. There should only ever be one running enclave with a given name for the identifier.", enclaveIdentifier)
 	}
+	if len(runningEnclaveInfos) == 0 {
+		return nil, stacktrace.NewError("No running enclave found with identifier '%v'", enclaveIdentifier)
+	}
 	return runningEnclaveInfos[0], nil
 }
 

--- a/api/golang/engine/lib/kurtosis_context/kurtosis_context.go
+++ b/api/golang/engine/lib/kurtosis_context/kurtosis_context.go
@@ -259,19 +259,13 @@ func (kurtosisCtx *KurtosisContext) GetEnclave(ctx context.Context, enclaveIdent
 			enclaveIdentifier,
 		)
 	}
-	var runningEnclaveInfos []*kurtosis_engine_rpc_api_bindings.EnclaveInfo
-	for _, enclaveInfo := range getEnclaveResponse.EnclaveInfo {
-		if enclaveInfo.ContainersStatus == kurtosis_engine_rpc_api_bindings.EnclaveContainersStatus_EnclaveContainersStatus_RUNNING {
-			runningEnclaveInfos = append(runningEnclaveInfos, enclaveInfo)
-		}
-	}
-	if len(runningEnclaveInfos) > 1 {
+	if len(getEnclaveResponse.EnclaveInfo) > 1 {
 		return nil, stacktrace.NewError("More than one running enclave found with identifier '%v'. There should only ever be one running enclave with a given name for the identifier.", enclaveIdentifier)
 	}
-	if len(runningEnclaveInfos) == 0 {
+	if len(getEnclaveResponse.EnclaveInfo) == 0 {
 		return nil, stacktrace.NewError("No running enclave found with identifier '%v'", enclaveIdentifier)
 	}
-	return runningEnclaveInfos[0], nil
+	return getEnclaveResponse.EnclaveInfo[enclaveIdentifier], nil
 }
 
 func (kurtosisCtx *KurtosisContext) StopEnclave(ctx context.Context, enclaveIdentifier string) error {

--- a/api/golang/engine/lib/kurtosis_context/kurtosis_context.go
+++ b/api/golang/engine/lib/kurtosis_context/kurtosis_context.go
@@ -236,6 +236,7 @@ func (kurtosisCtx *KurtosisContext) GetEnclave(ctx context.Context, enclaveIdent
 		return nil, stacktrace.Propagate(err, "An error occurred getting existing and historical enclave identifiers ")
 	}
 	matchingEnclaveUuid := ""
+	logrus.Infof("Existing and historical enclave identifiers: %v", existingAndHistoricalEnclaveIdentifiers.AllIdentifiers)
 	for _, enclaveInfo := range existingAndHistoricalEnclaveIdentifiers.AllIdentifiers {
 		if matchingEnclaveUuid != "" {
 			break

--- a/api/golang/engine/lib/kurtosis_context/kurtosis_context.go
+++ b/api/golang/engine/lib/kurtosis_context/kurtosis_context.go
@@ -265,7 +265,7 @@ func (kurtosisCtx *KurtosisContext) GetEnclave(ctx context.Context, enclaveIdent
 	if len(getEnclaveResponse.EnclaveInfo) == 0 {
 		return nil, stacktrace.NewError("No running enclave found with identifier '%v'", enclaveIdentifier)
 	}
-	return getEnclaveResponse.EnclaveInfo[enclaveIdentifier], nil
+	return getEnclaveResponse.EnclaveInfo[matchingEnclaveUuids[0]], nil
 }
 
 func (kurtosisCtx *KurtosisContext) StopEnclave(ctx context.Context, enclaveIdentifier string) error {

--- a/api/golang/engine/lib/kurtosis_context/kurtosis_context.go
+++ b/api/golang/engine/lib/kurtosis_context/kurtosis_context.go
@@ -236,7 +236,6 @@ func (kurtosisCtx *KurtosisContext) GetEnclave(ctx context.Context, enclaveIdent
 		return nil, stacktrace.Propagate(err, "An error occurred getting existing and historical enclave identifiers ")
 	}
 	matchingEnclaveUuid := ""
-	logrus.Infof("Existing and historical enclave identifiers: %v", existingAndHistoricalEnclaveIdentifiers.AllIdentifiers)
 	for _, enclaveInfo := range existingAndHistoricalEnclaveIdentifiers.AllIdentifiers {
 		if matchingEnclaveUuid != "" {
 			break

--- a/cli/cli/commands/enclave/inspect/inspect.go
+++ b/cli/cli/commands/enclave/inspect/inspect.go
@@ -143,7 +143,7 @@ func PrintEnclaveInspect(ctx context.Context, kurtosisCtx *kurtosis_context.Kurt
 	// Add creation time row
 	enclaveCreationTime := enclaveInfo.GetCreationTime()
 	if enclaveCreationTime == nil {
-		return stacktrace.Propagate(err, "Expected to get the enclave creation time from the enclave info received but it was not received, this is a bug in Kurtosis")
+		return stacktrace.NewError("Expected to get the enclave creation time from the enclave info received but it was not received, this is a bug in Kurtosis")
 	}
 	enclaveCreationTimeStr := enclaveCreationTime.AsTime().Local().Format(time.RFC1123)
 	keyValuePrinter.AddPair(enclaveCreationTimeTitleName, enclaveCreationTimeStr)

--- a/engine/server/engine/enclave_manager/enclave_manager.go
+++ b/engine/server/engine/enclave_manager/enclave_manager.go
@@ -685,7 +685,8 @@ func (manager *EnclaveManager) getEnclavesByUuidWithoutMutex(
 	for _, enclaveUuid := range enclaveUuids {
 		enclaveObj, existsEnclave := enclaves[enclaveUuid]
 		if !existsEnclave {
-			return nil, stacktrace.NewError("Enclave '%v' not found", enclaveUuids)
+			logrus.Warnf("Requested enclave '%v' not found. This is likely because the enclave is not running or has been destroyed.", enclaveUuids)
+			continue
 		}
 
 		enclaveInfo, err := getEnclaveInfoForEnclave(ctx, manager.kurtosisBackend, enclaveObj)

--- a/engine/server/engine/enclave_manager/enclave_manager.go
+++ b/engine/server/engine/enclave_manager/enclave_manager.go
@@ -291,7 +291,6 @@ func (manager *EnclaveManager) StopEnclave(ctx context.Context, enclaveIdentifie
 // TODO remove these notes - this should be working on active enclaves as well
 // Destroys an enclave, deleting all objects associated with it in the container engine (containers, volumes, networks, etc.)
 func (manager *EnclaveManager) DestroyEnclave(ctx context.Context, enclaveIdentifier string) error {
-	logrus.Infof("[DESTROY] Existing and historical enclave identifiers: %v", manager.allExistingAndHistoricalIdentifiers)
 	manager.mutex.Lock()
 	defer manager.mutex.Unlock()
 
@@ -867,10 +866,8 @@ func getEnclaveCreationTimestamp(enclave *enclave.Enclave) (*time.Time, error) {
 }
 
 func (manager *EnclaveManager) removeEnclaveIdentifierIfExists(enclaveIdentifier string) {
-	logrus.Infof("[REMOVE] Existing and historical enclave identifiers: %v", manager.allExistingAndHistoricalIdentifiers)
 	for i, enclaveIdentifierObj := range manager.allExistingAndHistoricalIdentifiers {
 		if enclaveIdentifierObj.EnclaveUuid == enclaveIdentifier || enclaveIdentifierObj.ShortenedUuid == enclaveIdentifier || enclaveIdentifierObj.Name == enclaveIdentifier {
-			fmt.Println("Removing enclave identifier", enclaveIdentifier)
 			manager.allExistingAndHistoricalIdentifiers = append(manager.allExistingAndHistoricalIdentifiers[:i], manager.allExistingAndHistoricalIdentifiers[i+1:]...)
 			break
 		}

--- a/engine/server/engine/enclave_manager/enclave_manager.go
+++ b/engine/server/engine/enclave_manager/enclave_manager.go
@@ -313,7 +313,6 @@ func (manager *EnclaveManager) DestroyEnclave(ctx context.Context, enclaveIdenti
 		if err = manager.logsDbClient.RemoveEnclaveLogs(string(enclaveUuid)); err != nil {
 			return stacktrace.Propagate(err, "An error occurred attempting to remove enclave '%v' logs after it was destroyed.", enclaveIdentifier)
 		}
-		manager.removeEnclaveIdentifierIfExists(enclaveIdentifier)
 		return nil
 	}
 	destructionErr, found := erroredEnclaves[enclaveUuid]
@@ -639,8 +638,6 @@ func (manager *EnclaveManager) cleanEnclaves(
 			logRemovalErr := stacktrace.Propagate(err, "An error occurred removing enclave '%v' logs.", enclaveId)
 			enclaveDestructionErrors = append(enclaveDestructionErrors, logRemovalErr)
 		}
-
-		manager.removeEnclaveIdentifierIfExists(string(enclaveId))
 	}
 
 	return successfullyDestroyedEnclaveIdStrs, enclaveDestructionErrors, nil
@@ -863,13 +860,4 @@ func getEnclaveCreationTimestamp(enclave *enclave.Enclave) (*time.Time, error) {
 	}
 
 	return enclaveCreationTime, nil
-}
-
-func (manager *EnclaveManager) removeEnclaveIdentifierIfExists(enclaveIdentifier string) {
-	for i, enclaveIdentifierObj := range manager.allExistingAndHistoricalIdentifiers {
-		if enclaveIdentifierObj.EnclaveUuid == enclaveIdentifier || enclaveIdentifierObj.ShortenedUuid == enclaveIdentifier || enclaveIdentifierObj.Name == enclaveIdentifier {
-			manager.allExistingAndHistoricalIdentifiers = append(manager.allExistingAndHistoricalIdentifiers[:i], manager.allExistingAndHistoricalIdentifiers[i+1:]...)
-			break
-		}
-	}
 }

--- a/engine/server/go.mod
+++ b/engine/server/go.mod
@@ -107,6 +107,7 @@ require (
 	github.com/kurtosis-tech/kurtosis/cloud/api/golang v0.0.0-20230828153722-32770ca96513 // indirect
 	github.com/kurtosis-tech/kurtosis/contexts-config-store v0.0.0 // indirect
 	github.com/kurtosis-tech/kurtosis/enclave-manager/api/golang v0.0.0-20230828153722-32770ca96513 // indirect
+	github.com/kurtosis-tech/kurtosis/kurtosis_version v0.0.0 // indirect
 	github.com/kurtosis-tech/kurtosis/path-compression v0.0.0-20240307154559-64d2929cd265 // indirect
 	github.com/labstack/gommon v0.4.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect


### PR DESCRIPTION
## Description
The updated `GetEnclave` uses `GetExistingAndHistoricalIdentifiers` which returns all enclaves, even removed ones. If two enclaves have the same name and a user attempts to `enclave inspect` by name, we don't know which enclave uuid to use. This PR updates `GetEnclave` to attempt to retrieve enclaves by all uuids that match the name and expect to receive a single running enclave. (There can never be two running enclaves with the same name)

## Is this change user facing?
YES

## References