### PR TITLE
fix: treat podman container status stopped as exited status

### DIFF
--- a/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/user_services_functions/files_artifacts_expansion.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/user_services_functions/files_artifacts_expansion.go
@@ -168,24 +168,24 @@ func runFilesArtifactsExpander(
 			serviceUuid,
 		)
 	}
-	// defer func() {
-	// 	if !fileArtifactExpansionSuccessful {
-	// 		return
-	// 	}
-	// 	// We destroy the expander container, rather than leaving it around, so that we clean up the resource we created
-	// 	// in this function (meaning the caller doesn't have to do it)
-	// 	// We can do this because if an error occurs, we'll capture the logs of the container in the error we return
-	// 	// to the user
-	// 	if destroyContainerErr := dockerManager.RemoveContainer(ctx, containerId); destroyContainerErr != nil {
-	// 		logrus.Errorf(
-	// 			"We tried to remove the expander container '%v' with ID '%v' that we started, but doing so threw an error:\n%v",
-	// 			containerName,
-	// 			containerId,
-	// 			destroyContainerErr,
-	// 		)
-	// 		logrus.Errorf("ACTION REQUIRED: You'll need to remove files artifacts expander container '%v' manually", containerName)
-	// 	}
-	// }()
+	defer func() {
+		if !fileArtifactExpansionSuccessful {
+			return
+		}
+		// We destroy the expander container, rather than leaving it around, so that we clean up the resource we created
+		// in this function (meaning the caller doesn't have to do it)
+		// We can do this because if an error occurs, we'll capture the logs of the container in the error we return
+		// to the user
+		if destroyContainerErr := dockerManager.RemoveContainer(ctx, containerId); destroyContainerErr != nil {
+			logrus.Errorf(
+				"We tried to remove the expander container '%v' with ID '%v' that we started, but doing so threw an error:\n%v",
+				containerName,
+				containerId,
+				destroyContainerErr,
+			)
+			logrus.Errorf("ACTION REQUIRED: You'll need to remove files artifacts expander container '%v' manually", containerName)
+		}
+	}()
 
 	exitCode, err := dockerManager.WaitForExit(ctx, containerId)
 	if err != nil {

--- a/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/user_services_functions/files_artifacts_expansion.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/user_services_functions/files_artifacts_expansion.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"strings"
+
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_impls/docker/docker_manager"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_impls/docker/object_attributes_provider"
@@ -12,7 +14,6 @@ import (
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/database_accessors/enclave_db/free_ip_addr_tracker"
 	"github.com/kurtosis-tech/stacktrace"
 	"github.com/sirupsen/logrus"
-	"strings"
 )
 
 const (
@@ -167,24 +168,24 @@ func runFilesArtifactsExpander(
 			serviceUuid,
 		)
 	}
-	defer func() {
-		if !fileArtifactExpansionSuccessful {
-			return
-		}
-		// We destroy the expander container, rather than leaving it around, so that we clean up the resource we created
-		// in this function (meaning the caller doesn't have to do it)
-		// We can do this because if an error occurs, we'll capture the logs of the container in the error we return
-		// to the user
-		if destroyContainerErr := dockerManager.RemoveContainer(ctx, containerId); destroyContainerErr != nil {
-			logrus.Errorf(
-				"We tried to remove the expander container '%v' with ID '%v' that we started, but doing so threw an error:\n%v",
-				containerName,
-				containerId,
-				destroyContainerErr,
-			)
-			logrus.Errorf("ACTION REQUIRED: You'll need to remove files artifacts expander container '%v' manually", containerName)
-		}
-	}()
+	// defer func() {
+	// 	if !fileArtifactExpansionSuccessful {
+	// 		return
+	// 	}
+	// 	// We destroy the expander container, rather than leaving it around, so that we clean up the resource we created
+	// 	// in this function (meaning the caller doesn't have to do it)
+	// 	// We can do this because if an error occurs, we'll capture the logs of the container in the error we return
+	// 	// to the user
+	// 	if destroyContainerErr := dockerManager.RemoveContainer(ctx, containerId); destroyContainerErr != nil {
+	// 		logrus.Errorf(
+	// 			"We tried to remove the expander container '%v' with ID '%v' that we started, but doing so threw an error:\n%v",
+	// 			containerName,
+	// 			containerId,
+	// 			destroyContainerErr,
+	// 		)
+	// 		logrus.Errorf("ACTION REQUIRED: You'll need to remove files artifacts expander container '%v' manually", containerName)
+	// 	}
+	// }()
 
 	exitCode, err := dockerManager.WaitForExit(ctx, containerId)
 	if err != nil {

--- a/container-engine-lib/lib/backend_impls/docker/docker_manager/docker_manager.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_manager/docker_manager.go
@@ -2187,7 +2187,7 @@ func (manager *DockerManager) didContainerStartSuccessfully(ctx context.Context,
 	}
 	containerState := containerJson.State
 
-	logrus.Infof("Container status '%v' with exit code '%v'", containerState.Status, containerState.ExitCode)
+	logrus.Infof("Container with id '%v' has status '%v' and exited with exit code '%v'", containerId, containerState.Status, containerState.ExitCode)
 	containerStatus, err := getContainerStatusByDockerContainerState(containerState.Status)
 	if err != nil {
 		return false, stacktrace.Propagate(err, "An error occurred getting ContainerStatus from Docker container state '%v'", containerState.Status)

--- a/container-engine-lib/lib/backend_impls/docker/docker_manager/docker_manager.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_manager/docker_manager.go
@@ -2262,7 +2262,6 @@ func newContainerFromDockerContainer(dockerContainer types.ContainerJSON) (*dock
 }
 
 func getContainerStatusByDockerContainerState(dockerContainerState string) (docker_manager_types.ContainerStatus, error) {
-
 	containerStatus, err := docker_manager_types.ContainerStatusString(dockerContainerState)
 	if err != nil {
 		return 0, stacktrace.NewError("No container status matches Docker container state '%v'; this is a bug in Kurtosis", dockerContainerState)

--- a/container-engine-lib/lib/backend_impls/docker/docker_manager/docker_manager.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_manager/docker_manager.go
@@ -2253,7 +2253,6 @@ func newContainerFromDockerContainer(dockerContainer types.ContainerJSON) (*dock
 }
 
 func getContainerStatusByDockerContainerState(dockerContainerState string) (docker_manager_types.ContainerStatus, error) {
-	logrus.Infof("Getting container status by Docker container state '%v'", dockerContainerState)
 	if dockerContainerState == "stopped" { // treat stopped as exited
 		return docker_manager_types.ContainerStatus_Exited, nil
 	}

--- a/container-engine-lib/lib/backend_impls/docker/docker_manager/docker_manager.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_manager/docker_manager.go
@@ -161,6 +161,9 @@ const (
 	NameOfNetworkToStartEngineAndLogServiceContainersInDocker = "bridge"
 	NameOfNetworkToStartEngineAndLogServiceContainersInPodman = "podman"
 
+	dockerContainerStatusExited = "exited"
+	podmanContainerStatusExited = "stopped"
+
 	defaultContainerStopTimeout = 1 * time.Second
 )
 
@@ -2187,8 +2190,14 @@ func (manager *DockerManager) didContainerStartSuccessfully(ctx context.Context,
 	}
 	containerState := containerJson.State
 
-	logrus.Infof("Container with id '%v' has status '%v' and exited with exit code '%v'", containerId, containerState.Status, containerState.ExitCode)
-	containerStatus, err := getContainerStatusByDockerContainerState(containerState.Status)
+	logrus.Debugf("Container with id '%v' has status '%v' and exited with exit code '%v'", containerId, containerState.Status, containerState.ExitCode)
+	var containerStatusStr string
+	if manager.IsPodman() && containerState.Status == podmanContainerStatusExited {
+		containerStatusStr = dockerContainerStatusExited
+	} else {
+		containerStatusStr = containerState.Status
+	}
+	containerStatus, err := getContainerStatusByDockerContainerState(containerStatusStr)
 	if err != nil {
 		return false, stacktrace.Propagate(err, "An error occurred getting ContainerStatus from Docker container state '%v'", containerState.Status)
 	}
@@ -2253,9 +2262,7 @@ func newContainerFromDockerContainer(dockerContainer types.ContainerJSON) (*dock
 }
 
 func getContainerStatusByDockerContainerState(dockerContainerState string) (docker_manager_types.ContainerStatus, error) {
-	if dockerContainerState == "stopped" { // treat stopped as exited
-		return docker_manager_types.ContainerStatus_Exited, nil
-	}
+
 	containerStatus, err := docker_manager_types.ContainerStatusString(dockerContainerState)
 	if err != nil {
 		return 0, stacktrace.NewError("No container status matches Docker container state '%v'; this is a bug in Kurtosis", dockerContainerState)


### PR DESCRIPTION
## Description
Podman occasionally returns status stopped for containers, but that should be treated as the docker container exited status. This PR handles that case.

## Is this change user facing?
NO