### PR TITLE
fix: don't publish udp ports

### DIFF
--- a/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/shared_helpers/shared_helpers.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/shared_helpers/shared_helpers.go
@@ -135,6 +135,8 @@ func GetDockerPortFromPortSpec(portSpec *port_spec.PortSpec) (nat.Port, error) {
 	return dockerPort, nil
 }
 
+// private port spec comes from the deserialized label - could this be one a port we didn't mean to publish?
+// all machine host port bindings comes from the actual published docker container ports
 func GetPublicPortBindingFromPrivatePortSpec(privatePortSpec *port_spec.PortSpec, allHostMachinePortBindings map[nat.Port]*nat.PortBinding) (
 	resultPublicIpAddr net.IP,
 	resultPublicPortSpec *port_spec.PortSpec,
@@ -224,8 +226,8 @@ func TransformPortSpecToDockerPort(portSpec *port_spec.PortSpec) (nat.Port, erro
 // TODO Extract this to DockerKurtosisBackend and use it everywhere, for Engines and API containers?
 func GetIpAndPortInfoFromContainer(
 	containerName string,
-	labels map[string]string,
-	hostMachinePortBindings map[nat.Port]*nat.PortBinding,
+	labels map[string]string, // label that was found the container
+	hostMachinePortBindings map[nat.Port]*nat.PortBinding, // host machine port bindings that were found
 ) (
 	resultPrivateIp net.IP,
 	resultPrivatePortSpecs map[string]*port_spec.PortSpec,
@@ -251,6 +253,8 @@ func GetIpAndPortInfoFromContainer(
 		)
 	}
 
+	// would we need to filter out ports we didn't mean to publish?
+	// figure out what ports get added to the PortSpecsDockerLabelKey
 	privatePortSpecs, err := docker_port_spec_serializer.DeserializePortSpecs(serializedPortSpecs)
 	if err != nil {
 		if err != nil {

--- a/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/shared_helpers/shared_helpers.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/shared_helpers/shared_helpers.go
@@ -251,13 +251,9 @@ func GetIpAndPortInfoFromContainer(
 		)
 	}
 
-	// would we need to filter out ports we didn't mean to publish?
-	// figure out what ports get added to the PortSpecsDockerLabelKey
 	privatePortSpecs, err := docker_port_spec_serializer.DeserializePortSpecs(serializedPortSpecs)
 	if err != nil {
-		if err != nil {
-			return nil, nil, nil, nil, stacktrace.Propagate(err, "Couldn't deserialize port spec string '%v'", serializedPortSpecs)
-		}
+		return nil, nil, nil, nil, stacktrace.Propagate(err, "Couldn't deserialize port spec string '%v'", serializedPortSpecs)
 	}
 
 	var containerPublicIp net.IP

--- a/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/shared_helpers/shared_helpers.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/shared_helpers/shared_helpers.go
@@ -223,8 +223,8 @@ func TransformPortSpecToDockerPort(portSpec *port_spec.PortSpec) (nat.Port, erro
 // TODO Extract this to DockerKurtosisBackend and use it everywhere, for Engines and API containers?
 func GetIpAndPortInfoFromContainer(
 	containerName string,
-	labels map[string]string, // label that was found the container
-	hostMachinePortBindings map[nat.Port]*nat.PortBinding, // host machine port bindings that were found
+	labels map[string]string,
+	hostMachinePortBindings map[nat.Port]*nat.PortBinding,
 ) (
 	resultPrivateIp net.IP,
 	resultPrivatePortSpecs map[string]*port_spec.PortSpec,
@@ -263,7 +263,7 @@ func GetIpAndPortInfoFromContainer(
 
 	publishedPrivateSpecs := map[string]*port_spec.PortSpec{}
 	for portId, privatePortSpec := range privatePortSpecs {
-		// filter out the private port specs that didn't get published so we don't attempt to retrieve a public port that doesn't exist
+		// filter out the UDP private port specs (as they don't get published) so we don't attempt to retrieve a public port that doesn't exist
 		if privatePortSpec.GetTransportProtocol() == port_spec.TransportProtocol_UDP {
 			continue
 		}

--- a/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/shared_helpers/shared_helpers.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/shared_helpers/shared_helpers.go
@@ -265,7 +265,7 @@ func GetIpAndPortInfoFromContainer(
 	// filter out the private port specs that didn't get published so we don't attempt to retrieve a public port that doesn't exist
 	publishedPrivateSpecs := map[string]*port_spec.PortSpec{}
 	for portId, privatePortSpec := range privatePortSpecs {
-		if _, found := unPublishedPrivatePortIds[portId]; !found {
+		if _, found := unPublishedPrivatePortIds[portId]; found {
 			continue
 		}
 		publishedPrivateSpecs[portId] = privatePortSpec

--- a/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/user_services_functions/start_user_services.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/user_services_functions/start_user_services.go
@@ -670,6 +670,7 @@ func createStartServiceOperation(
 			if err != nil {
 				return nil, stacktrace.Propagate(err, "An error occurred converting private port spec '%v' to a Docker port", portId)
 			}
+
 			//TODO this is a huge hack to temporarily enable static ports for NEAR until we have a more productized solution
 			if portShouldBeManuallyPublished(portId, publicPorts) {
 				publicPortSpec, found := publicPorts[portId]
@@ -678,7 +679,7 @@ func createStartServiceOperation(
 				}
 				dockerUsedPorts[dockerPort] = docker_manager.NewManualPublishingSpec(publicPortSpec.GetNumber())
 			} else {
-				dockerUsedPorts[dockerPort] = docker_manager.NewAutomaticPublishingSpec()
+				dockerUsedPorts[dockerPort] = docker_manager.NewAutomaticPublishingSpec() // most private ports go here
 			}
 		}
 
@@ -689,7 +690,7 @@ func createStartServiceOperation(
 		).WithStaticIP(
 			privateIpAddr,
 		).WithUsedPorts(
-			dockerUsedPorts,
+			dockerUsedPorts, // if its UDP - don't publish it - just expose it
 		).WithEnvironmentVariables(
 			envVars,
 		).WithLabels(
@@ -767,7 +768,7 @@ func createStartServiceOperation(
 		_, _, maybePublicIp, maybePublicPortSpecs, err := shared_helpers.GetIpAndPortInfoFromContainer(
 			containerName.GetString(),
 			labelStrs,
-			hostMachinePortBindings,
+			hostMachinePortBindings, // th
 		)
 		if err != nil {
 			return nil, stacktrace.Propagate(err, "An error occurred getting the public IP and ports from container '%v'", containerName)

--- a/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/user_services_functions/start_user_services.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/user_services_functions/start_user_services.go
@@ -674,9 +674,8 @@ func createStartServiceOperation(
 
 			//TODO this is a huge hack to temporarily enable static ports for NEAR until we have a more productized solution
 			if privatePortSpec.GetTransportProtocol() == port_spec.TransportProtocol_UDP {
-				// We don't publish UDP ports to the host machine - we only expose them
-				// After Docker Desktop 4.41.2 https://github.com/docker/for-mac/issues/7754, Docker Desktop doesn't publish UDP ports to the host machine
-				// We avoid attempting publishing them to prevent errors downstream
+				// After Docker Desktop 4.41.2 https://github.com/docker/for-mac/issues/7754, Docker Desktop doesn't properly publish UDP ports to the host machine
+				// To avoid errors downstream checking for published UDP ports, we only expose them
 				unPublishedPrivatePortIds[portId] = true
 				dockerUsedPorts[dockerPort] = docker_manager.NewNoPublishingSpec()
 			} else if portShouldBeManuallyPublished(portId, publicPorts) {

--- a/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/user_services_functions/start_user_services.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/user_services_functions/start_user_services.go
@@ -671,7 +671,6 @@ func createStartServiceOperation(
 			if err != nil {
 				return nil, stacktrace.Propagate(err, "An error occurred converting private port spec '%v' to a Docker port", portId)
 			}
-
 			//TODO this is a huge hack to temporarily enable static ports for NEAR until we have a more productized solution
 			if privatePortSpec.GetTransportProtocol() == port_spec.TransportProtocol_UDP {
 				// After Docker Desktop 4.41.2 https://github.com/docker/for-mac/issues/7754, Docker Desktop doesn't properly publish UDP ports to the host machine
@@ -685,7 +684,7 @@ func createStartServiceOperation(
 				}
 				dockerUsedPorts[dockerPort] = docker_manager.NewManualPublishingSpec(publicPortSpec.GetNumber())
 			} else {
-				dockerUsedPorts[dockerPort] = docker_manager.NewAutomaticPublishingSpec() // most private ports go here
+				dockerUsedPorts[dockerPort] = docker_manager.NewAutomaticPublishingSpec()
 			}
 		}
 
@@ -696,7 +695,7 @@ func createStartServiceOperation(
 		).WithStaticIP(
 			privateIpAddr,
 		).WithUsedPorts(
-			dockerUsedPorts, // if its UDP - don't publish it - just expose it
+			dockerUsedPorts,
 		).WithEnvironmentVariables(
 			envVars,
 		).WithLabels(
@@ -775,7 +774,10 @@ func createStartServiceOperation(
 			containerName.GetString(),
 			labelStrs,
 			hostMachinePortBindings,
+<<<<<<< HEAD
 			unPublishedPrivatePortIds,
+=======
+>>>>>>> parent of 00391aae0 (cmts)
 		)
 		if err != nil {
 			return nil, stacktrace.Propagate(err, "An error occurred getting the public IP and ports from container '%v'", containerName)

--- a/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/user_services_functions/start_user_services.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/user_services_functions/start_user_services.go
@@ -665,7 +665,6 @@ func createStartServiceOperation(
 		}
 
 		dockerUsedPorts := map[nat.Port]docker_manager.PortPublishSpec{}
-		unPublishedPrivatePortIds := map[string]bool{}
 		for portId, privatePortSpec := range privatePorts {
 			dockerPort, err := shared_helpers.TransformPortSpecToDockerPort(privatePortSpec)
 			if err != nil {
@@ -675,7 +674,6 @@ func createStartServiceOperation(
 			if privatePortSpec.GetTransportProtocol() == port_spec.TransportProtocol_UDP {
 				// After Docker Desktop 4.41.2 https://github.com/docker/for-mac/issues/7754, Docker Desktop doesn't properly publish UDP ports to the host machine
 				// To avoid errors downstream checking for published UDP ports, we only expose them
-				unPublishedPrivatePortIds[portId] = true
 				dockerUsedPorts[dockerPort] = docker_manager.NewNoPublishingSpec()
 			} else if portShouldBeManuallyPublished(portId, publicPorts) {
 				publicPortSpec, found := publicPorts[portId]
@@ -774,7 +772,6 @@ func createStartServiceOperation(
 			containerName.GetString(),
 			labelStrs,
 			hostMachinePortBindings,
-			unPublishedPrivatePortIds,
 		)
 		if err != nil {
 			return nil, stacktrace.Propagate(err, "An error occurred getting the public IP and ports from container '%v'", containerName)

--- a/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/user_services_functions/start_user_services.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/user_services_functions/start_user_services.go
@@ -774,10 +774,7 @@ func createStartServiceOperation(
 			containerName.GetString(),
 			labelStrs,
 			hostMachinePortBindings,
-<<<<<<< HEAD
 			unPublishedPrivatePortIds,
-=======
->>>>>>> parent of 00391aae0 (cmts)
 		)
 		if err != nil {
 			return nil, stacktrace.Propagate(err, "An error occurred getting the public IP and ports from container '%v'", containerName)

--- a/container-engine-lib/lib/backend_impls/docker/docker_manager/docker_manager.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_manager/docker_manager.go
@@ -660,7 +660,7 @@ func (manager *DockerManager) CreateAndStartContainer(
 	containerConfigPtr, err := manager.getContainerCfg(
 		dockerImage,
 		isInteractiveMode,
-		usedPortsSet, // these get set as ExposedPorts in the container config
+		usedPortsSet,
 		args.entrypointArgs,
 		args.cmdArgs,
 		args.envVariables,
@@ -676,7 +676,7 @@ func (manager *DockerManager) CreateAndStartContainer(
 		args.networkMode,
 		args.bindMounts,
 		args.volumeMounts,
-		args.usedPorts, // these are used to determine if the port should be published to the host machine and how
+		args.usedPorts,
 		args.needsAccessToDockerHostMachine,
 		args.cpuAllocationMillicpus,
 		args.memoryAllocationMegabytes,
@@ -774,7 +774,7 @@ func (manager *DockerManager) CreateAndStartContainer(
 
 	publishedPortsSet := map[nat.Port]bool{}
 	for containerPort, publishSpec := range args.usedPorts {
-		if publishSpec.mustBeFoundAfterContainerStart() { // udp ports don't need to be found after container start because they are not published
+		if publishSpec.mustBeFoundAfterContainerStart() {
 			publishedPortsSet[containerPort] = true
 		}
 	}
@@ -808,7 +808,7 @@ func (manager *DockerManager) CreateAndStartContainer(
 				)
 			}
 			logrus.Tracef("Network settings: %+v", networkSettings)
-			allInterfaceHostPortBindings := networkSettings.Ports // does this include hosts published to host?
+			allInterfaceHostPortBindings := networkSettings.Ports
 			if allInterfaceHostPortBindings == nil {
 				return "", nil, stacktrace.NewError(
 					"%v ports on container '%v' were to be published to the host machine, but the container host port bindings were null",
@@ -818,7 +818,7 @@ func (manager *DockerManager) CreateAndStartContainer(
 			}
 			logrus.Tracef("Network settings -> ports: %+v", allInterfaceHostPortBindings)
 
-			allHostPortBindingsOnExpectedInterface := getHostPortBindingsOnExpectedInterface(allInterfaceHostPortBindings) // now wittles it down to just the published ones
+			allHostPortBindingsOnExpectedInterface := getHostPortBindingsOnExpectedInterface(allInterfaceHostPortBindings)
 
 			// Filter to the ports matching the ports we wanted to publish
 			usedHostPortBindingsOnExpectedInterface := map[nat.Port]*nat.PortBinding{}
@@ -1841,9 +1841,9 @@ func (manager *DockerManager) getContainerHostConfig(
 	for containerPort, publishSpec := range usedPortsWithPublishSpec {
 		publishSpecType := publishSpec.getType()
 		switch publishSpecType {
-		case noPublishing: // we don't want to publish UDP ports to the host machine - we only want to expose them
+		case noPublishing:
 			continue
-		case automaticPublishing: // these are for private ports that get random ports exposed
+		case automaticPublishing:
 			hostIp := ""
 			if manager.podmanMode {
 				hostIp = expectedHostIp // podman requires to be 0.0.0.0
@@ -1855,7 +1855,7 @@ func (manager *DockerManager) getContainerHostConfig(
 					HostPort: "",
 				},
 			}
-		case manualPublishing: // these are only for public ports - not private ports.
+		case manualPublishing:
 			manualSpec, ok := publishSpec.(*manuallySpecifiedPortPublishSpec)
 			if !ok {
 				return nil, stacktrace.NewError(


### PR DESCRIPTION
## Description
Users on Docker Desktop 4.42.0> been experiencing this error: `Caused by: No host machine port binding was specified for Docker port '9001/udp' which corresponds to port spec with num '9001' and protocol 'UDP'`. because Docker Desktop is unsuccessfully publishing UDP ports since 4.41.2 https://github.com/docker/desktop-feedback/issues/191. 

Users have had to resort to downgrading [Docker Desktop or switching to Orbstack](https://github.com/ethpandaops/ethereum-package/issues/1075#issuecomment-3238121736). This PR creates a workaround inside by opting to not publish UDP ports. UDP ports will still be exposed on the container and accessible by other services in the network, but they will not be published to the host machine. 

This should be okay for users of the https://github.com/ethpandaops/ethereum-package as it's not common to access a UDP port from localhost however it could cause a breaking change for any users depending on a UDP port exposed to localhost for access to a service inside an enclave.


## Is this change user facing?
YES

## References:
https://github.com/docker/desktop-feedback/issues/191
https://github.com/ethpandaops/ethereum-package/issues/1075#issuecomment-3238121736
