### PR TITLE
fix: kurtosis service update with wait=None

### DIFF
--- a/api/golang/core/lib/services/service_config_builder.go
+++ b/api/golang/core/lib/services/service_config_builder.go
@@ -60,8 +60,12 @@ func portToStarlark(port *kurtosis_core_rpc_api_bindings.Port) string {
 	if port.GetTransportProtocol() != kurtosis_core_rpc_api_bindings.Port_TCP {
 		starlarkFields = append(starlarkFields, fmt.Sprintf(`transport_protocol="%s"`, port.GetTransportProtocol().String()))
 	}
-	if port.GetMaybeWaitTimeout() != "" {
-		starlarkFields = append(starlarkFields, fmt.Sprintf(`wait="%s"`, port.GetMaybeWaitTimeout()))
+	waitTimeout := port.GetMaybeWaitTimeout()
+	if waitTimeout == "" {
+		// When wait=None is set in Starlark, the proto field MaybeWaitTimeout is an empty string.
+		starlarkFields = append(starlarkFields, `wait=None`)
+	} else {
+		starlarkFields = append(starlarkFields, fmt.Sprintf(`wait="%s"`, waitTimeout))
 	}
 	return fmt.Sprintf("PortSpec(%s)", strings.Join(starlarkFields, ","))
 }

--- a/docs/docs/cli-reference/service-update.md
+++ b/docs/docs/cli-reference/service-update.md
@@ -37,3 +37,6 @@ kurtosis service update my-enclave test-service \
 This command replaces the existing service with a new container using the updated configuration. The service will be briefly stopped and restarted as part of this process.
 :::
 
+:::note Port wait
+When you update a service, any custom `wait` configuration set on its ports will be cleared. All updated ports will have `wait=None` after this operation, regardless of their previous setting.
+:::


### PR DESCRIPTION
## Description
<!-- Describe this change, how it works, and the motivation behind it. -->

Closes #2813 

Before the fix - the port spec doesn't contain `wait=None` and the operation fails:

```bash
$ kt --cli-log-level=debug service update test service-1 --image nginx:latest
...
DEBU[2025-10-23T14:39:59Z] Update service starlark:
def run(plan):
	plan.add_service(name = "service-1", config = ServiceConfig(image="nginx:latest", ports={"test": PortSpec(number=2000)}, entrypoint=["/docker-entrypoint.sh"], cmd=["nginx", "-g", "daemon off;"], env_vars={"PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin","NGINX_VERSION": "1.28.0","NJS_VERSION": "0.8.10","NJS_RELEASE": "1~bookworm","PKG_RELEASE": "1~bookworm","DYNPKG_RELEASE": "1~bookworm"}))
...
# service update fails
```

After the fix - the port spec contains `wait=None` and the operation succeeds:

```bash
$ kt --cli-log-level=debug service update test service-1 --image nginx:latest
...
DEBU[2025-10-23T14:59:31Z] Update service starlark:
def run(plan):
	plan.add_service(name = "service-1", config = ServiceConfig(image="nginx:latest", ports={"test": PortSpec(number=2000,wait=None)}, entrypoint=["/docker-entrypoint.sh"], cmd=["nginx", "-g", "daemon off;"], env_vars={"NGINX_VERSION": "1.28.0","NJS_VERSION": "0.8.10","NJS_RELEASE": "1~bookworm","PKG_RELEASE": "1~bookworm","DYNPKG_RELEASE": "1~bookworm","PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"}))
...
# service update succeeds
```

Tested against Xavi's PoC:

```bash
kt run --enclave test .
kt --cli-log-level=debug service update test nginx --image nginx:latest
```


## Is this change user facing?
YES
<!-- If yes, please add the "user facing" label to the PR -->
<!-- If yes, don't forget to include docs changes where relevant -->

