### PR TITLE
fix(core): impl update plan for add services

### DIFF
--- a/core/server/api_container/server/startosis_engine/kurtosis_instruction/add_service/add_service.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_instruction/add_service/add_service.go
@@ -290,36 +290,9 @@ func (builtin *AddServiceCapabilities) FillPersistableAttributes(builder *enclav
 }
 
 func (builtin *AddServiceCapabilities) UpdatePlan(planYaml *plan_yaml.PlanYamlGenerator) error {
-	var buildContextLocator string
-	var targetStage string
-	var registryAddress string
-	var interpretationErr *startosis_errors.InterpretationError
-
-	// set image values based on type of image
-	if builtin.imageVal != nil {
-		switch starlarkImgVal := builtin.imageVal.(type) {
-		case *service_config.ImageBuildSpec:
-			buildContextLocator, interpretationErr = starlarkImgVal.GetBuildContextLocator()
-			if interpretationErr != nil {
-				return startosis_errors.WrapWithInterpretationError(interpretationErr, "An error occurred getting build context locator")
-			}
-			targetStage, interpretationErr = starlarkImgVal.GetTargetStage()
-			if interpretationErr != nil {
-				return startosis_errors.WrapWithInterpretationError(interpretationErr, "An error occurred getting target stage.")
-			}
-		case *service_config.ImageSpec:
-			registryAddress, interpretationErr = starlarkImgVal.GetRegistryAddrIfSet()
-			if interpretationErr != nil {
-				return startosis_errors.WrapWithInterpretationError(interpretationErr, "An error occurred getting registry address.")
-			}
-		default:
-			// assume NixBuildSpec or regular image
-		}
-	}
-
-	err := planYaml.AddService(builtin.serviceName, builtin.returnValue, builtin.serviceConfig, buildContextLocator, targetStage, registryAddress)
+	err := updatePlanYamlWithService(planYaml, builtin.serviceName, builtin.returnValue, builtin.serviceConfig, builtin.imageVal)
 	if err != nil {
-		return stacktrace.NewError("An error occurred updating the plan with service: %v", builtin.serviceName)
+		return err
 	}
 	return nil
 }

--- a/core/server/api_container/server/startosis_engine/kurtosis_instruction/add_service/add_service_shared.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_instruction/add_service/add_service_shared.go
@@ -115,7 +115,7 @@ func validateSingleService(validatorEnvironment *startosis_validator.ValidatorEn
 	} else if serviceConfig.GetNixBuildSpec() != nil {
 		validatorEnvironment.AppendRequiredNixBuild(serviceConfig.GetContainerImageName(), serviceConfig.GetNixBuildSpec())
 	} else {
-		validatorEnvironment.AppendRequiredImagePull(serviceConfig.GetContainerImageName()) // THIS IS WHERE THE IMAGE IS ADDED TO THE VALIDATOR ENVIRONMENT
+		validatorEnvironment.AppendRequiredImagePull(serviceConfig.GetContainerImageName())
 	}
 
 	var portIds []string

--- a/core/server/api_container/server/startosis_engine/kurtosis_instruction/add_service/add_service_shared.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_instruction/add_service/add_service_shared.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/kurtosis_types"
 	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/kurtosis_types/port_spec"
 	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/kurtosis_types/service_config"
+	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/plan_yaml"
 	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/runtime_value_store"
 	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/startosis_errors"
 	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/startosis_validator"
@@ -114,7 +115,7 @@ func validateSingleService(validatorEnvironment *startosis_validator.ValidatorEn
 	} else if serviceConfig.GetNixBuildSpec() != nil {
 		validatorEnvironment.AppendRequiredNixBuild(serviceConfig.GetContainerImageName(), serviceConfig.GetNixBuildSpec())
 	} else {
-		validatorEnvironment.AppendRequiredImagePull(serviceConfig.GetContainerImageName())
+		validatorEnvironment.AppendRequiredImagePull(serviceConfig.GetContainerImageName()) // THIS IS WHERE THE IMAGE IS ADDED TO THE VALIDATOR ENVIRONMENT
 	}
 
 	var portIds []string
@@ -341,4 +342,45 @@ func addServiceToDependencyGraph(
 	dependencyGraph.ProducesRuntimeValue(instructionUuid, hostname)
 	return nil
 
+}
+
+func updatePlanYamlWithService(
+	planYaml *plan_yaml.PlanYamlGenerator,
+	serviceName service.ServiceName,
+	returnValue *kurtosis_types.Service,
+	serviceConfig *service.ServiceConfig,
+	imageVal starlark.Value,
+) error {
+	var buildContextLocator string
+	var targetStage string
+	var registryAddress string
+	var interpretationErr *startosis_errors.InterpretationError
+
+	// set image values based on type of image
+	if imageVal != nil {
+		switch starlarkImgVal := imageVal.(type) {
+		case *service_config.ImageBuildSpec:
+			buildContextLocator, interpretationErr = starlarkImgVal.GetBuildContextLocator()
+			if interpretationErr != nil {
+				return startosis_errors.WrapWithInterpretationError(interpretationErr, "An error occurred getting build context locator")
+			}
+			targetStage, interpretationErr = starlarkImgVal.GetTargetStage()
+			if interpretationErr != nil {
+				return startosis_errors.WrapWithInterpretationError(interpretationErr, "An error occurred getting target stage.")
+			}
+		case *service_config.ImageSpec:
+			registryAddress, interpretationErr = starlarkImgVal.GetRegistryAddrIfSet()
+			if interpretationErr != nil {
+				return startosis_errors.WrapWithInterpretationError(interpretationErr, "An error occurred getting registry address.")
+			}
+		default:
+			// assume NixBuildSpec or regular image
+		}
+	}
+
+	err := planYaml.AddService(serviceName, returnValue, serviceConfig, buildContextLocator, targetStage, registryAddress)
+	if err != nil {
+		return stacktrace.NewError("An error occurred updating the plan with service: %v", serviceName)
+	}
+	return nil
 }

--- a/core/server/api_container/server/startosis_engine/kurtosis_instruction/add_service/add_services.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_instruction/add_service/add_services.go
@@ -378,7 +378,9 @@ func (builtin *AddServicesCapabilities) allServicesReadinessCheck(
 }
 
 func (builtin *AddServicesCapabilities) UpdatePlan(plan *plan_yaml.PlanYamlGenerator) error {
-	var emptyImageVal starlark.Value = nil // ImageBuildSpec, ImageSpec, and NixBuildSpec are not supported yet for add_services, only container image name
+	// ImageBuildSpec, ImageSpec, and NixBuildSpec are not supported yet for add_services, only container image name
+	// Providing emptyImgVal will cause the plan yaml generator to use the container image name as the image name
+	var emptyImgVal starlark.Value = nil
 	for serviceName, serviceConfig := range builtin.serviceConfigs {
 		returnValue, found, err := builtin.returnValue.Get(starlark.String(serviceName))
 		if err != nil {
@@ -391,7 +393,7 @@ func (builtin *AddServicesCapabilities) UpdatePlan(plan *plan_yaml.PlanYamlGener
 		if !ok {
 			return stacktrace.NewError("Expected to be able to cast the return value for service '%s' to a Service object, but got '%s'", serviceName, reflect.TypeOf(returnValue))
 		}
-		err = updatePlanYamlWithService(plan, serviceName, returnValueService, serviceConfig, emptyImageVal)
+		err = updatePlanYamlWithService(plan, serviceName, returnValueService, serviceConfig, emptyImgVal)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Description
Users were noticing that some dependencies weren't being reflected in `kurtosis run --dependencies`. This was because `UpdatePlan` hadn't been implemented for `add_services` yet, so any images/dependencies associated with an `add_services` instruction wouldn't get returned.


## Is this change user facing?
YES
