### PR TITLE
feat: output instruction graph

### DIFF
--- a/cli/cli/go.mod
+++ b/cli/cli/go.mod
@@ -104,6 +104,7 @@ require (
 	github.com/danieljoos/wincred v1.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/desertbit/timer v0.0.0-20180107155436-c41aec40b27f // indirect
+	github.com/disintegration/imaging v1.6.2 // indirect
 	github.com/distribution/distribution/v3 v3.0.0-20230214150026-36d8c594d7aa // indirect
 	github.com/docker/go-metrics v0.0.1 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
@@ -111,6 +112,8 @@ require (
 	github.com/emicklei/go-restful/v3 v3.10.1 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
+	github.com/flopp/go-findfont v0.1.0 // indirect
+	github.com/fogleman/gg v1.3.0 // indirect
 	github.com/francoispqt/gojay v1.2.13 // indirect
 	github.com/gammazero/deque v0.1.0 // indirect
 	github.com/gammazero/workerpool v1.1.2 // indirect
@@ -126,9 +129,11 @@ require (
 	github.com/go-playground/validator/v10 v10.14.1 // indirect
 	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
 	github.com/gobwas/ws v1.2.1 // indirect
+	github.com/goccy/go-graphviz v0.2.9 // indirect
 	github.com/godbus/dbus/v5 v5.1.0 // indirect
 	github.com/gogo/googleapis v1.4.1 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
@@ -200,6 +205,7 @@ require (
 	github.com/smacker/go-tree-sitter v0.0.0-20230226123037-c459dbde1464 // indirect
 	github.com/soheilhy/cmux v0.1.5 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
+	github.com/tetratelabs/wazero v1.8.1 // indirect
 	github.com/thlib/go-timezone-local v0.0.0-20210907160436-ef149e42d28e // indirect
 	github.com/ulikunitz/xz v0.5.11 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
@@ -223,6 +229,7 @@ require (
 	go.uber.org/multierr v1.7.0 // indirect
 	go.uber.org/zap v1.20.0 // indirect
 	golang.org/x/arch v0.4.0 // indirect
+	golang.org/x/image v0.21.0 // indirect
 	golang.org/x/mod v0.21.0 // indirect
 	golang.org/x/net v0.38.0 // indirect
 	golang.org/x/oauth2 v0.11.0 // indirect

--- a/cli/cli/go.sum
+++ b/cli/cli/go.sum
@@ -172,6 +172,8 @@ github.com/denisbrodbeck/machineid v1.0.1/go.mod h1:dJUwb7PTidGDeYyUBmXZ2GphQBbj
 github.com/desertbit/timer v0.0.0-20180107155436-c41aec40b27f h1:U5y3Y5UE0w7amNe7Z5G/twsBW0KEalRQXZzf8ufSh9I=
 github.com/desertbit/timer v0.0.0-20180107155436-c41aec40b27f/go.mod h1:xH/i4TFMt8koVQZ6WFms69WAsDWr2XsYL3Hkl7jkoLE=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+github.com/disintegration/imaging v1.6.2 h1:w1LecBlG2Lnp8B3jk5zSuNqd7b4DXhcjwek1ei82L+c=
+github.com/disintegration/imaging v1.6.2/go.mod h1:44/5580QXChDfwIclfc/PCwrr44amcmDAg8hxG0Ewe4=
 github.com/distribution/distribution/v3 v3.0.0-20230214150026-36d8c594d7aa h1:L9Ay/slwQ4ERSPaurC+TVkZrM0K98GNrEEo1En3e8as=
 github.com/distribution/distribution/v3 v3.0.0-20230214150026-36d8c594d7aa/go.mod h1:WHNsWjnIn2V1LYOrME7e8KxSeKunYHsxEm4am0BUtcI=
 github.com/dmarkham/enumer v1.5.5 h1:LpOGL3PQTPOM87rgowZEf7Z5EmkgnKqUtS92Vo+vqzs=
@@ -216,7 +218,11 @@ github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
+github.com/flopp/go-findfont v0.1.0 h1:lPn0BymDUtJo+ZkV01VS3661HL6F4qFlkhcJN55u6mU=
+github.com/flopp/go-findfont v0.1.0/go.mod h1:wKKxRDjD024Rh7VMwoU90i6ikQRCr+JTHB5n4Ejkqvw=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
+github.com/fogleman/gg v1.3.0 h1:/7zJX8F6AaYQc57WQCyN9cAIz+4bCJGO9B+dyW29am8=
+github.com/fogleman/gg v1.3.0/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/francoispqt/gojay v1.2.13 h1:d2m3sFjloqoIUQU3TsHBgj6qg/BVGlTBeHDUmyJnXKk=
 github.com/francoispqt/gojay v1.2.13/go.mod h1:ehT5mTG4ua4581f1++1WLG0vPdaA9HaiDsoyrBGkyDY=
 github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db/go.mod h1:7dvUGVsVBjqR7JHJk0brhHOZYGmfBYOrK0ZhYMEtBr4=
@@ -294,6 +300,8 @@ github.com/gobwas/pool v0.2.1/go.mod h1:q8bcK0KcYlCgd9e7WYLm9LpyS+YeLd8JVDW6Wezm
 github.com/gobwas/ws v1.0.2/go.mod h1:szmBTxLgaFppYjEmNtny/v3w89xOydFnnZMcgRRu/EM=
 github.com/gobwas/ws v1.2.1 h1:F2aeBZrm2NDsc7vbovKrWSogd4wvfAxg0FQ89/iqOTk=
 github.com/gobwas/ws v1.2.1/go.mod h1:hRKAFb8wOxFROYNsT1bqfWnhX+b5MFeJM9r2ZSwg/KY=
+github.com/goccy/go-graphviz v0.2.9 h1:4yD2MIMpxNt+sOEARDh5jTE2S/jeAKi92w72B83mWGg=
+github.com/goccy/go-graphviz v0.2.9/go.mod h1:hssjl/qbvUXGmloY81BwXt2nqoApKo7DFgDj5dLJGb8=
 github.com/goccy/go-json v0.10.2 h1:CrxCmQqYDkv1z7lO7Wbh2HN93uovUHgrECaO5ZrCXAU=
 github.com/goccy/go-json v0.10.2/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=
@@ -306,6 +314,8 @@ github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7a
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
+github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 h1:DACJavvAHhabrF08vX0COfcOBJRhZ8lUbR+ZWIs0Y5g=
+github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -766,6 +776,8 @@ github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXl
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
+github.com/tetratelabs/wazero v1.8.1 h1:NrcgVbWfkWvVc4UtT4LRLDf91PsOzDzefMdwhLfA550=
+github.com/tetratelabs/wazero v1.8.1/go.mod h1:yAI0XTsMBhREkM/YDAK/zNou3GoiAce1P6+rp/wQhjs=
 github.com/thlib/go-timezone-local v0.0.0-20210907160436-ef149e42d28e h1:BuzhfgfWQbX0dWzYzT1zsORLnHRv3bcRcsaUk0VmXA8=
 github.com/thlib/go-timezone-local v0.0.0-20210907160436-ef149e42d28e/go.mod h1:/Tnicc6m/lsJE0irFMA0LfIwTBo4QP7A8IfyIv4zZKI=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
@@ -878,6 +890,9 @@ golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 h1:2dVuKD2vS7b0QIHQbpyTISPd0
 golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56/go.mod h1:M4RDyNAINzryxdtnbRXRL/OHtkFuWGRjvuhBJpk2IlY=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
+golang.org/x/image v0.0.0-20191009234506-e7c1f5e7dbb8/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
+golang.org/x/image v0.21.0 h1:c5qV36ajHpdj4Qi0GnE0jUc/yuo33OLFaa0d+crTD5s=
+golang.org/x/image v0.21.0/go.mod h1:vUbsLavqK/W303ZroQQVKQ+Af3Yl6Uz1Ppu5J/cLz78=
 golang.org/x/lint v0.0.0-20180702182130-06c8688daad7/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=

--- a/cli/cli/helpers/graph_viz/visualize_instructions_graph.go
+++ b/cli/cli/helpers/graph_viz/visualize_instructions_graph.go
@@ -1,0 +1,123 @@
+package graph_viz
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/dependency_graph"
+	"github.com/kurtosis-tech/stacktrace"
+)
+
+// OutputGraphVisual generates a Graphviz DOT format graph and saves it to the specified path
+func OutputGraphVisual(instructions []dependency_graph.InstructionWithDependencies, path string) error {
+	if len(instructions) == 0 {
+		return stacktrace.NewError("No instructions provided to generate graph")
+	}
+
+	var dotGraph strings.Builder
+
+	// Start the DOT graph
+	dotGraph.WriteString("digraph KurtosisInstructions {\n")
+	dotGraph.WriteString("  rankdir=TB;\n")
+	dotGraph.WriteString("  node [shape=box, style=rounded];\n\n")
+
+	// Add nodes (skip print instructions)
+	for _, instruction := range instructions {
+		if instruction.IsPrintInstruction {
+			continue
+		}
+		nodeLabel := escapeLabel(instruction.ShortDescriptor)
+		dotGraph.WriteString(fmt.Sprintf("  \"%s\" [label=\"%s\"];\n",
+			instruction.InstructionUuid, nodeLabel))
+	}
+
+	dotGraph.WriteString("\n")
+
+	// Add edges (dependencies) - skip print instructions
+	for _, instruction := range instructions {
+		if instruction.IsPrintInstruction {
+			continue
+		}
+		for _, dependency := range instruction.Dependencies {
+			dotGraph.WriteString(fmt.Sprintf("  \"%s\" -> \"%s\";\n",
+				dependency, instruction.InstructionUuid))
+		}
+	}
+
+	dotGraph.WriteString("}\n")
+
+	// Write to file
+	err := os.WriteFile(path, []byte(dotGraph.String()), 0644)
+	if err != nil {
+		return stacktrace.Propagate(err, "Failed to write DOT graph to file '%s'", path)
+	}
+
+	return nil
+}
+
+// OutputMermaidGraph generates a Mermaid format graph and saves it to the specified path
+func OutputMermaidGraph(instructions []dependency_graph.InstructionWithDependencies, path string) error {
+	if len(instructions) == 0 {
+		return stacktrace.NewError("No instructions provided to generate mermaid graph")
+	}
+
+	var mermaidGraph strings.Builder
+
+	// Start the Mermaid graph
+	mermaidGraph.WriteString("```mermaid\n")
+	mermaidGraph.WriteString("graph TD\n")
+
+	// Add nodes with labels (skip print instructions)
+	for _, instruction := range instructions {
+		if instruction.IsPrintInstruction {
+			continue
+		}
+		nodeLabel := escapeLabel(instruction.ShortDescriptor)
+		nodeId := sanitizeNodeId(string(instruction.InstructionUuid))
+		mermaidGraph.WriteString(fmt.Sprintf("  %s[\"%s\"]\n", nodeId, nodeLabel))
+	}
+
+	mermaidGraph.WriteString("\n")
+
+	// Add edges (dependencies) - skip print instructions
+	for _, instruction := range instructions {
+		if instruction.IsPrintInstruction {
+			continue
+		}
+		targetNodeId := sanitizeNodeId(string(instruction.InstructionUuid))
+		for _, dependency := range instruction.Dependencies {
+			sourceNodeId := sanitizeNodeId(string(dependency))
+			mermaidGraph.WriteString(fmt.Sprintf("  %s --> %s\n", sourceNodeId, targetNodeId))
+		}
+	}
+
+	mermaidGraph.WriteString("```\n")
+
+	// Write to file
+	err := os.WriteFile(path, []byte(mermaidGraph.String()), 0644)
+	if err != nil {
+		return stacktrace.Propagate(err, "Failed to write Mermaid graph to file '%s'", path)
+	}
+
+	return nil
+}
+
+// escapeLabel escapes special characters in labels for graph formats
+func escapeLabel(label string) string {
+	// Replace quotes with escaped quotes
+	label = strings.ReplaceAll(label, "\"", "\\\"")
+	// Replace newlines with spaces
+	label = strings.ReplaceAll(label, "\n", " ")
+	return label
+}
+
+// sanitizeNodeId converts a UUID or identifier to a valid Mermaid node ID
+// Mermaid node IDs should not contain hyphens or special characters
+func sanitizeNodeId(id string) string {
+	// Replace hyphens and other special characters with underscores
+	id = strings.ReplaceAll(id, "-", "_")
+	id = strings.ReplaceAll(id, ".", "_")
+	id = strings.ReplaceAll(id, ":", "_")
+	return id
+}

--- a/cli/cli/helpers/graph_viz/visualize_instructions_graph.go
+++ b/cli/cli/helpers/graph_viz/visualize_instructions_graph.go
@@ -41,7 +41,7 @@ func OutputGraphVisual(instructions []dependency_graph.InstructionWithDependenci
 
 	dotGraph.WriteString("\n")
 
-	// Add edges (dependencies) - skip print instructions
+	// Add edges (dependencies) while skipping print instructions
 	for _, instruction := range instructions {
 		if instruction.IsPrintInstruction {
 			continue
@@ -58,19 +58,19 @@ func OutputGraphVisual(instructions []dependency_graph.InstructionWithDependenci
 	ctx := context.Background()
 	g, err := graphviz.New(ctx)
 	if err != nil {
-		return stacktrace.Propagate(err, "Failed to create graphviz instance")
+		return stacktrace.Propagate(err, "An error occurred creating graphviz instance.")
 	}
 	defer func() {
 		if err := g.Close(); err != nil {
 			// Log the error but don't fail the function
-			fmt.Fprintf(os.Stderr, "Warning: failed to close graphviz instance: %v\n", err)
+			fmt.Fprintf(os.Stderr, "Warning: an error occurred closing graphviz instance: %v\n", err)
 		}
 	}()
 
 	// Parse the DOT string
 	graph, err := graphviz.ParseBytes([]byte(dotGraph.String()))
 	if err != nil {
-		return stacktrace.Propagate(err, "Failed to parse DOT graph")
+		return stacktrace.Propagate(err, "An error occurred parsing the DOT graph.")
 	}
 	defer func() {
 		if err := graph.Close(); err != nil {
@@ -82,13 +82,13 @@ func OutputGraphVisual(instructions []dependency_graph.InstructionWithDependenci
 	// Render the graph to PNG format
 	var buf bytes.Buffer
 	if err := g.Render(ctx, graph, graphviz.PNG, &buf); err != nil {
-		return stacktrace.Propagate(err, "Failed to render graph to PNG")
+		return stacktrace.Propagate(err, "An error occurred rendering graph to PNG")
 	}
 
 	// Write the PNG to file
 	err = os.WriteFile(path, buf.Bytes(), graphFilePermissions)
 	if err != nil {
-		return stacktrace.Propagate(err, "Failed to write PNG graph to file '%s'", path)
+		return stacktrace.Propagate(err, "An error occurred writing graph image to file '%s'", path)
 	}
 
 	return nil
@@ -103,7 +103,6 @@ func OutputMermaidGraph(instructions []dependency_graph.InstructionWithDependenc
 	var mermaidGraph strings.Builder
 
 	// Start the Mermaid graph
-	mermaidGraph.WriteString("```mermaid\n")
 	mermaidGraph.WriteString("graph TD\n")
 
 	// Add nodes with labels (skip print instructions)
@@ -130,12 +129,10 @@ func OutputMermaidGraph(instructions []dependency_graph.InstructionWithDependenc
 		}
 	}
 
-	mermaidGraph.WriteString("```\n")
-
 	// Write to file
 	err := os.WriteFile(path, []byte(mermaidGraph.String()), graphFilePermissions)
 	if err != nil {
-		return stacktrace.Propagate(err, "Failed to write Mermaid graph to file '%s'", path)
+		return stacktrace.Propagate(err, "An error occurred writing Mermaid graph to file '%s'", path)
 	}
 
 	return nil

--- a/cli/cli/helpers/graph_viz/visualize_instructions_graph.go
+++ b/cli/cli/helpers/graph_viz/visualize_instructions_graph.go
@@ -12,6 +12,10 @@ import (
 	"github.com/kurtosis-tech/stacktrace"
 )
 
+const (
+	graphFilePermissions = 0644
+)
+
 // OutputGraphVisual generates a Graphviz DOT format graph and renders it as a PNG image
 func OutputGraphVisual(instructions []dependency_graph.InstructionWithDependencies, path string) error {
 	if len(instructions) == 0 {
@@ -82,7 +86,7 @@ func OutputGraphVisual(instructions []dependency_graph.InstructionWithDependenci
 	}
 
 	// Write the PNG to file
-	err = os.WriteFile(path, buf.Bytes(), 0644)
+	err = os.WriteFile(path, buf.Bytes(), graphFilePermissions)
 	if err != nil {
 		return stacktrace.Propagate(err, "Failed to write PNG graph to file '%s'", path)
 	}
@@ -129,7 +133,7 @@ func OutputMermaidGraph(instructions []dependency_graph.InstructionWithDependenc
 	mermaidGraph.WriteString("```\n")
 
 	// Write to file
-	err := os.WriteFile(path, []byte(mermaidGraph.String()), 0644)
+	err := os.WriteFile(path, []byte(mermaidGraph.String()), graphFilePermissions)
 	if err != nil {
 		return stacktrace.Propagate(err, "Failed to write Mermaid graph to file '%s'", path)
 	}

--- a/cli/cli/helpers/output_printers/parallel_kurtosis_instruction_printer.go
+++ b/cli/cli/helpers/output_printers/parallel_kurtosis_instruction_printer.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kurtosis-tech/kurtosis/cli/cli/command_args/run"
 	"github.com/kurtosis-tech/kurtosis/cli/cli/helpers/interactive_terminal_decider"
 	"github.com/kurtosis-tech/kurtosis/cli/cli/out"
+	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/builtins/print_builtin"
 	"github.com/kurtosis-tech/stacktrace"
 	"github.com/sirupsen/logrus"
 )
@@ -122,6 +123,10 @@ func (printer *ParallelExecutionPrinter) PrintKurtosisExecutionResponseLineToStd
 		return stacktrace.NewError("Cannot print with a non started printer")
 	}
 
+	if isPrintInstruction(responseLine) { // don't process print instructions
+		return nil
+	}
+
 	var msg tea.Msg
 	if responseLine.GetInstruction() != nil && verbosity != run.OutputOnly {
 		instruction := responseLine.GetInstruction()
@@ -203,4 +208,15 @@ func (printer *ParallelExecutionPrinter) PrintKurtosisExecutionResponseLineToStd
 	}
 
 	return nil
+}
+
+func isPrintInstruction(responseLine *kurtosis_core_rpc_api_bindings.StarlarkRunResponseLine) bool {
+	if responseLine.GetInstruction() != nil {
+		instruction := responseLine.GetInstruction()
+		return instruction.GetInstructionName() == print_builtin.PrintBuiltinName
+	} else if responseLine.GetInstructionResult() != nil {
+		instruction := responseLine.GetInstruction()
+		return instruction.GetInstructionName() == print_builtin.PrintBuiltinName
+	}
+	return false
 }

--- a/core/server/api_container/server/api_container_service.go
+++ b/core/server/api_container/server/api_container_service.go
@@ -722,7 +722,7 @@ func (apicService *ApiContainerService) GetStarlarkPackagePlanYaml(ctx context.C
 		interpretationError = startosis_errors.NewInterpretationError(apiInterpretationError.GetErrorMessage())
 		return nil, stacktrace.Propagate(interpretationError, "An interpretation error occurred interpreting package for retrieving plan yaml for package: %v", packageIdFromArgs)
 	}
-	planYamlStr, err := instructionsPlan.GenerateYaml(plan_yaml.CreateEmptyPlan(packageIdFromArgs))
+	planYamlStr, err := instructionsPlan.GenerateYamlWithInstructions(plan_yaml.CreateEmptyPlan(packageIdFromArgs))
 	if err != nil {
 		return nil, stacktrace.Propagate(err, "An error occurred generating plan yaml for package: %v", packageIdFromArgs)
 	}
@@ -757,7 +757,7 @@ func (apicService *ApiContainerService) GetStarlarkScriptPlanYaml(ctx context.Co
 	if apiInterpretationError != nil {
 		return nil, startosis_errors.NewInterpretationError(apiInterpretationError.GetErrorMessage())
 	}
-	planYamlStr, err := instructionsPlan.GenerateYaml(plan_yaml.CreateEmptyPlan(startosis_constants.PackageIdPlaceholderForStandaloneScript))
+	planYamlStr, err := instructionsPlan.GenerateYamlWithInstructions(plan_yaml.CreateEmptyPlan(startosis_constants.PackageIdPlaceholderForStandaloneScript))
 	if err != nil {
 		return nil, err
 	}

--- a/core/server/api_container/server/startosis_engine/dependency_graph/instruction_dependency_graph.go
+++ b/core/server/api_container/server/startosis_engine/dependency_graph/instruction_dependency_graph.go
@@ -34,7 +34,7 @@ type InstructionWithDependencies struct {
 	InstructionUuid    types.ScheduledInstructionUuid   `yaml:"instructionUuid"`
 	ShortDescriptor    string                           `yaml:"shortDescriptor"`
 	Dependencies       []types.ScheduledInstructionUuid `yaml:"dependencies"`
-	isPrintInstruction bool                             `yaml:"isPrintInstruction"`
+	IsPrintInstruction bool                             `yaml:"isPrintInstruction"`
 }
 
 func NewInstructionDependencyGraph(instructionsSequence []types.ScheduledInstructionUuid) *InstructionDependencyGraph {
@@ -155,7 +155,7 @@ func (graph *InstructionDependencyGraph) GenerateInstructionsWithDependencies() 
 		instructionsWithDependencies = append(instructionsWithDependencies, InstructionWithDependencies{
 			InstructionUuid:    instruction,
 			ShortDescriptor:    graph.instructionShortDescriptors[instruction],
-			isPrintInstruction: graph.printInstructionUuids[instruction],
+			IsPrintInstruction: graph.printInstructionUuids[instruction],
 			Dependencies:       dependencies,
 		})
 	}

--- a/core/server/api_container/server/startosis_engine/dependency_graph/instruction_dependency_graph.go
+++ b/core/server/api_container/server/startosis_engine/dependency_graph/instruction_dependency_graph.go
@@ -22,11 +22,19 @@ type InstructionDependencyGraph struct {
 
 	instructionsDependencies map[types.ScheduledInstructionUuid]map[types.ScheduledInstructionUuid]bool
 
+	instructionShortDescriptors map[types.ScheduledInstructionUuid]string
+	printInstructionUuids       map[types.ScheduledInstructionUuid]bool
+
 	// Right now, Services, Files Artifacts, and Runtime Values are all represented as strings for simplicity
 	// In the future, we may add types to represent each output but not needed for now
 	outputsToInstructionMap map[string]types.ScheduledInstructionUuid
+}
 
-	shortDescriptors map[types.ScheduledInstructionUuid]string
+type InstructionWithDependencies struct {
+	InstructionUuid    types.ScheduledInstructionUuid   `yaml:"instructionUuid"`
+	ShortDescriptor    string                           `yaml:"shortDescriptor"`
+	Dependencies       []types.ScheduledInstructionUuid `yaml:"dependencies"`
+	isPrintInstruction bool                             `yaml:"isPrintInstruction"`
 }
 
 func NewInstructionDependencyGraph(instructionsSequence []types.ScheduledInstructionUuid) *InstructionDependencyGraph {
@@ -35,11 +43,22 @@ func NewInstructionDependencyGraph(instructionsSequence []types.ScheduledInstruc
 		instructionsDependencies[instruction] = make(map[types.ScheduledInstructionUuid]bool)
 	}
 
+	printInstructionUuids := make(map[types.ScheduledInstructionUuid]bool)
+	for _, instruction := range instructionsSequence {
+		printInstructionUuids[instruction] = false
+	}
+
+	instructionShortDescriptors := make(map[types.ScheduledInstructionUuid]string)
+	for _, instruction := range instructionsSequence {
+		instructionShortDescriptors[instruction] = string(instruction) // initialize instruction descriptors to their uuid, but will be updated later
+	}
+
 	return &InstructionDependencyGraph{
-		instructionsDependencies: instructionsDependencies,
-		outputsToInstructionMap:  map[string]types.ScheduledInstructionUuid{},
-		instructionsSequence:     instructionsSequence,
-		shortDescriptors:         map[types.ScheduledInstructionUuid]string{},
+		instructionsDependencies:    instructionsDependencies,
+		outputsToInstructionMap:     map[string]types.ScheduledInstructionUuid{},
+		instructionsSequence:        instructionsSequence,
+		instructionShortDescriptors: instructionShortDescriptors,
+		printInstructionUuids:       printInstructionUuids,
 	}
 }
 
@@ -92,6 +111,7 @@ func (graph *InstructionDependencyGraph) consumesRuntimeValue(instruction types.
 
 // AddPrintInstruction manually adds a dependency between a print and the instruction that comes right before it in the instructions sequence.
 func (graph *InstructionDependencyGraph) AddPrintInstruction(instruction types.ScheduledInstructionUuid) {
+	graph.printInstructionUuids[instruction] = true
 	for i := 1; i < len(graph.instructionsSequence); i++ {
 		if graph.instructionsSequence[i] == instruction {
 			dependency := graph.instructionsSequence[i-1]
@@ -99,6 +119,10 @@ func (graph *InstructionDependencyGraph) AddPrintInstruction(instruction types.S
 			return
 		}
 	}
+}
+
+func (graph *InstructionDependencyGraph) UpdateInstructionShortDescriptor(instruction types.ScheduledInstructionUuid, shortDescriptor string) {
+	graph.instructionShortDescriptors[instruction] = shortDescriptor
 }
 
 func (graph *InstructionDependencyGraph) addDependency(instruction types.ScheduledInstructionUuid, dependency types.ScheduledInstructionUuid) {
@@ -119,4 +143,21 @@ func (graph *InstructionDependencyGraph) GenerateDependencyGraph() map[types.Sch
 		dependencyGraph[instruction] = instructionDependencies
 	}
 	return dependencyGraph
+}
+
+func (graph *InstructionDependencyGraph) GenerateInstructionsWithDependencies() []InstructionWithDependencies {
+	instructionsWithDependencies := []InstructionWithDependencies{}
+	for _, instruction := range graph.instructionsSequence {
+		dependencies := []types.ScheduledInstructionUuid{}
+		for dependency := range graph.instructionsDependencies[instruction] {
+			dependencies = append(dependencies, dependency)
+		}
+		instructionsWithDependencies = append(instructionsWithDependencies, InstructionWithDependencies{
+			InstructionUuid:    instruction,
+			ShortDescriptor:    graph.instructionShortDescriptors[instruction],
+			isPrintInstruction: graph.printInstructionUuids[instruction],
+			Dependencies:       dependencies,
+		})
+	}
+	return instructionsWithDependencies
 }

--- a/core/server/api_container/server/startosis_engine/kurtosis_instruction/add_service/add_service.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_instruction/add_service/add_service.go
@@ -330,6 +330,9 @@ func (builtin *AddServiceCapabilities) Description() string {
 
 // UpdateDependencyGraph updates the dependency graph with the effects of running this instruction
 func (builtin *AddServiceCapabilities) UpdateDependencyGraph(instructionsUuid types.ScheduledInstructionUuid, dependencyGraph *dependency_graph.InstructionDependencyGraph) error {
+	shortDescriptor := fmt.Sprintf("add_service(%s)", builtin.serviceName)
+	dependencyGraph.UpdateInstructionShortDescriptor(instructionsUuid, shortDescriptor)
+
 	err := addServiceToDependencyGraph(instructionsUuid, dependencyGraph, string(builtin.serviceName), builtin.returnValue, builtin.serviceConfig)
 	if err != nil {
 		return stacktrace.Propagate(err, "An error occurred updating the dependency graph with service '%s'", builtin.serviceName)

--- a/core/server/api_container/server/startosis_engine/kurtosis_instruction/add_service/add_service_shared.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_instruction/add_service/add_service_shared.go
@@ -340,5 +340,4 @@ func addServiceToDependencyGraph(
 	}
 	dependencyGraph.ProducesRuntimeValue(instructionUuid, hostname)
 	return nil
-
 }

--- a/core/server/api_container/server/startosis_engine/kurtosis_instruction/add_service/add_services.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_instruction/add_service/add_services.go
@@ -384,6 +384,7 @@ func (builtin *AddServicesCapabilities) UpdatePlan(plan *plan_yaml.PlanYamlGener
 }
 
 func (builtin *AddServicesCapabilities) UpdateDependencyGraph(instructionUuid types.ScheduledInstructionUuid, dependencyGraph *dependency_graph.InstructionDependencyGraph) error {
+	serviceNames := []string{}
 	for _, serviceTuple := range builtin.returnValue.Items() {
 		serviceNameVal := serviceTuple.Index(0)
 		serviceNameStarlarkStr, ok := serviceNameVal.(starlark.String)
@@ -391,6 +392,7 @@ func (builtin *AddServicesCapabilities) UpdateDependencyGraph(instructionUuid ty
 			return stacktrace.NewError("Expected to find a string in the return value for service '%s', but none was found; this is a bug in Kurtosis", serviceNameStarlarkStr.String())
 		}
 		serviceNameStr := serviceNameStarlarkStr.GoString()
+		serviceNames = append(serviceNames, serviceNameStr)
 
 		serviceStarlarkVal := serviceTuple.Index(1)
 		serviceObj, ok := serviceStarlarkVal.(*kurtosis_types.Service)
@@ -405,6 +407,10 @@ func (builtin *AddServicesCapabilities) UpdateDependencyGraph(instructionUuid ty
 			return stacktrace.Propagate(err, "An error occurred updating the dependency graph with service '%s'", serviceNameStr)
 		}
 	}
+
+	serviceNamesStr := strings.Join(serviceNames, ", ")
+	shortDescriptor := fmt.Sprintf("add_services(%d services: %s)", len(builtin.serviceConfigs), serviceNamesStr)
+	dependencyGraph.UpdateInstructionShortDescriptor(instructionUuid, shortDescriptor)
 	return nil
 }
 

--- a/core/server/api_container/server/startosis_engine/kurtosis_instruction/exec/exec.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_instruction/exec/exec.go
@@ -252,6 +252,9 @@ func formatErrorMessage(errorMessage string, errorFromExec string) string {
 
 // UpdateDependencyGraph updates the dependency graph with the effects of running this instruction.
 func (builtin *ExecCapabilities) UpdateDependencyGraph(instructionUuid types.ScheduledInstructionUuid, dependencyGraph *dependency_graph.InstructionDependencyGraph) error { // store outputs
+	shortDescriptor := fmt.Sprintf("exec(%s %s)", builtin.serviceName, builtin.description)
+	dependencyGraph.UpdateInstructionShortDescriptor(instructionUuid, shortDescriptor)
+
 	dependencyGraph.ConsumesService(instructionUuid, string(builtin.serviceName))
 	dependencyGraph.ConsumesAnyRuntimeValuesInList(instructionUuid, builtin.cmdList)
 

--- a/core/server/api_container/server/startosis_engine/kurtosis_instruction/get_cluster_type/get_cluster_type.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_instruction/get_cluster_type/get_cluster_type.go
@@ -76,7 +76,7 @@ func (builtin *GetClusterTypeCapabilities) UpdatePlan(planYaml *plan_yaml.PlanYa
 }
 
 func (builtin *GetClusterTypeCapabilities) UpdateDependencyGraph(instructionUuid types.ScheduledInstructionUuid, dependencyGraph *dependency_graph.InstructionDependencyGraph) error {
-	// has no effecto no dependencies
+	// has no effect no dependencies
 	return nil
 }
 

--- a/core/server/api_container/server/startosis_engine/kurtosis_instruction/get_cluster_type/get_cluster_type.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_instruction/get_cluster_type/get_cluster_type.go
@@ -76,7 +76,8 @@ func (builtin *GetClusterTypeCapabilities) UpdatePlan(planYaml *plan_yaml.PlanYa
 }
 
 func (builtin *GetClusterTypeCapabilities) UpdateDependencyGraph(instructionUuid types.ScheduledInstructionUuid, dependencyGraph *dependency_graph.InstructionDependencyGraph) error {
-	// has no effect no dependencies
+	shortDescriptor := fmt.Sprintf("get_cluster_type(%s)", builtin.description)
+	dependencyGraph.UpdateInstructionShortDescriptor(instructionUuid, shortDescriptor)
 	return nil
 }
 

--- a/core/server/api_container/server/startosis_engine/kurtosis_instruction/get_files_artifact/get_files_artifact.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_instruction/get_files_artifact/get_files_artifact.go
@@ -107,6 +107,9 @@ func (builtin *GetFilesArtifactCapabilities) Description() string {
 
 // UpdateDependencyGraph updates the dependency graph with the effects of running this instruction.
 func (builtin *GetFilesArtifactCapabilities) UpdateDependencyGraph(instructionUuid types.ScheduledInstructionUuid, dependencyGraph *dependency_graph.InstructionDependencyGraph) error {
+	shortDescriptor := fmt.Sprintf("get_files_artifact(%s)", builtin.artifactName)
+	dependencyGraph.UpdateInstructionShortDescriptor(instructionUuid, shortDescriptor)
+
 	dependencyGraph.ConsumesFilesArtifact(instructionUuid, string(builtin.artifactName))
 	dependencyGraph.ProducesFilesArtifact(instructionUuid, string(builtin.artifactName))
 	return nil

--- a/core/server/api_container/server/startosis_engine/kurtosis_instruction/get_service/get_service.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_instruction/get_service/get_service.go
@@ -117,6 +117,9 @@ func (builtin *GetServiceCapabilities) Description() string {
 
 // UpdateDependencyGraph updates the dependency graph with the effects of running this instruction.
 func (builtin *GetServiceCapabilities) UpdateDependencyGraph(instructionUuid types.ScheduledInstructionUuid, dependencyGraph *dependency_graph.InstructionDependencyGraph) error {
+	shortDescriptor := fmt.Sprintf("get_service(%s)", builtin.serviceName)
+	dependencyGraph.UpdateInstructionShortDescriptor(instructionUuid, shortDescriptor)
+
 	dependencyGraph.ConsumesService(instructionUuid, string(builtin.serviceName))
 	dependencyGraph.ProducesService(instructionUuid, string(builtin.serviceName))
 	return nil

--- a/core/server/api_container/server/startosis_engine/kurtosis_instruction/get_services/get_services.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_instruction/get_services/get_services.go
@@ -2,6 +2,7 @@ package get_services
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/service"
 	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/dependency_graph"
@@ -106,6 +107,9 @@ func (builtin *GetServicesCapabilities) Description() string {
 
 // UpdateDependencyGraph updates the dependency graph with the effects of running this instruction.
 func (builtin *GetServicesCapabilities) UpdateDependencyGraph(instructionUuid types.ScheduledInstructionUuid, dependencyGraph *dependency_graph.InstructionDependencyGraph) error {
+	shortDescriptor := fmt.Sprintf("get_services(%d services)", len(builtin.serviceNames))
+	dependencyGraph.UpdateInstructionShortDescriptor(instructionUuid, shortDescriptor)
+
 	for _, serviceName := range builtin.serviceNames {
 		dependencyGraph.ProducesService(instructionUuid, string(serviceName))
 	}

--- a/core/server/api_container/server/startosis_engine/kurtosis_instruction/kurtosis_print/kurtosis_print.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_instruction/kurtosis_print/kurtosis_print.go
@@ -2,6 +2,7 @@ package kurtosis_print
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/service_network"
 	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/dependency_graph"
@@ -120,6 +121,9 @@ func (builtin *PrintCapabilities) Description() string {
 
 // UpdateDependencyGraph updates the dependency graph with the effects of running this instruction.
 func (builtin *PrintCapabilities) UpdateDependencyGraph(instructionUuid types.ScheduledInstructionUuid, dependencyGraph *dependency_graph.InstructionDependencyGraph) error {
+	shortDescriptor := fmt.Sprintf("print(%s)", builtin.msg.String())
+	dependencyGraph.UpdateInstructionShortDescriptor(instructionUuid, shortDescriptor)
+
 	dependencyGraph.AddPrintInstruction(instructionUuid)
 
 	dependencyGraph.ConsumesAnyRuntimeValuesInString(instructionUuid, builtin.msg.String())

--- a/core/server/api_container/server/startosis_engine/kurtosis_instruction/remove_service/remove_service.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_instruction/remove_service/remove_service.go
@@ -128,6 +128,9 @@ func (builtin *RemoveServiceCapabilities) Description() string {
 
 // UpdateDependencyGraph updates the dependency graph with the effects of running this instruction.
 func (builtin *RemoveServiceCapabilities) UpdateDependencyGraph(instructionUuid types.ScheduledInstructionUuid, dependencyGraph *dependency_graph.InstructionDependencyGraph) error {
+	shortDescriptor := fmt.Sprintf("remove_service(%s)", builtin.serviceName)
+	dependencyGraph.UpdateInstructionShortDescriptor(instructionUuid, shortDescriptor)
+
 	dependencyGraph.ConsumesService(instructionUuid, string(builtin.serviceName))
 	return nil
 }

--- a/core/server/api_container/server/startosis_engine/kurtosis_instruction/render_templates/render_templates.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_instruction/render_templates/render_templates.go
@@ -195,6 +195,9 @@ func (builtin *RenderTemplatesCapabilities) Description() string {
 
 // UpdateDependencyGraph updates the dependency graph with the effects of running this instruction.
 func (builtin *RenderTemplatesCapabilities) UpdateDependencyGraph(instructionUuid types.ScheduledInstructionUuid, dependencyGraph *dependency_graph.InstructionDependencyGraph) error {
+	shortDescriptor := fmt.Sprintf("render_templates(%s)", builtin.artifactName)
+	dependencyGraph.UpdateInstructionShortDescriptor(instructionUuid, shortDescriptor)
+
 	// Templates can be constructed with runtime values in them
 	for _, templateData := range builtin.templatesAndDataByDestRelFilepath {
 		dependencyGraph.ConsumesAnyRuntimeValuesInString(instructionUuid, templateData.GetDataAsSerializedJson())

--- a/core/server/api_container/server/startosis_engine/kurtosis_instruction/request/request.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_instruction/request/request.go
@@ -244,6 +244,9 @@ func (builtin *RequestCapabilities) isAcceptableCode(recipeResult map[string]sta
 
 // UpdateDependencyGraph updates the dependency graph with the effects of running this instruction.
 func (builtin *RequestCapabilities) UpdateDependencyGraph(instructionUuid types.ScheduledInstructionUuid, dependencyGraph *dependency_graph.InstructionDependencyGraph) error {
+	shortDescriptor := fmt.Sprintf("request(%s %s)", builtin.serviceName, builtin.description)
+	dependencyGraph.UpdateInstructionShortDescriptor(instructionUuid, shortDescriptor)
+
 	dependencyGraph.ConsumesService(instructionUuid, string(builtin.serviceName))
 
 	returnValueStrings, interpretationErr := builtin.httpRequestRecipe.GetStarlarkReturnValuesAsStringList(builtin.resultUuid)

--- a/core/server/api_container/server/startosis_engine/kurtosis_instruction/request/request.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_instruction/request/request.go
@@ -244,7 +244,7 @@ func (builtin *RequestCapabilities) isAcceptableCode(recipeResult map[string]sta
 
 // UpdateDependencyGraph updates the dependency graph with the effects of running this instruction.
 func (builtin *RequestCapabilities) UpdateDependencyGraph(instructionUuid types.ScheduledInstructionUuid, dependencyGraph *dependency_graph.InstructionDependencyGraph) error {
-	shortDescriptor := fmt.Sprintf("request(%s %s)", builtin.serviceName, builtin.description)
+	shortDescriptor := fmt.Sprintf("request(%s, %s)", builtin.serviceName, builtin.description)
 	dependencyGraph.UpdateInstructionShortDescriptor(instructionUuid, shortDescriptor)
 
 	dependencyGraph.ConsumesService(instructionUuid, string(builtin.serviceName))

--- a/core/server/api_container/server/startosis_engine/kurtosis_instruction/set_service/set_service.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_instruction/set_service/set_service.go
@@ -201,7 +201,9 @@ func (builtin *SetServiceCapabilities) Description() string {
 
 // UpdateDependencyGraph updates the dependency graph with the effects of running this instruction.
 func (builtin *SetServiceCapabilities) UpdateDependencyGraph(instructionUuid types.ScheduledInstructionUuid, dependencyGraph *dependency_graph.InstructionDependencyGraph) error {
-	// TODO: Implement dependency graph updates for set_service instruction
+	shortDescriptor := fmt.Sprintf("set_service(%s, %s)", builtin.serviceName, builtin.description)
+	dependencyGraph.UpdateInstructionShortDescriptor(instructionUuid, shortDescriptor)
+
 	return nil
 }
 

--- a/core/server/api_container/server/startosis_engine/kurtosis_instruction/start_service/start_service.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_instruction/start_service/start_service.go
@@ -121,6 +121,9 @@ func (builtin *StartServiceCapabilities) Description() string {
 
 // UpdateDependencyGraph updates the dependency graph with the effects of running this instruction.
 func (builtin *StartServiceCapabilities) UpdateDependencyGraph(instructionUuid types.ScheduledInstructionUuid, dependencyGraph *dependency_graph.InstructionDependencyGraph) error {
+	shortDescriptor := fmt.Sprintf("start_service(%s)", builtin.serviceName)
+	dependencyGraph.UpdateInstructionShortDescriptor(instructionUuid, shortDescriptor)
+
 	dependencyGraph.ConsumesService(instructionUuid, string(builtin.serviceName))
 	return nil
 }

--- a/core/server/api_container/server/startosis_engine/kurtosis_instruction/stop_service/stop_service.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_instruction/stop_service/stop_service.go
@@ -121,6 +121,9 @@ func (builtin *StopServiceCapabilities) Description() string {
 
 // UpdateDependencyGraph updates the dependency graph with the effects of running this instruction.
 func (builtin *StopServiceCapabilities) UpdateDependencyGraph(instructionUuid types.ScheduledInstructionUuid, dependencyGraph *dependency_graph.InstructionDependencyGraph) error {
+	shortDescriptor := fmt.Sprintf("stop_service(%s)", builtin.serviceName)
+	dependencyGraph.UpdateInstructionShortDescriptor(instructionUuid, shortDescriptor)
+
 	dependencyGraph.ConsumesService(instructionUuid, string(builtin.serviceName))
 	return nil
 }

--- a/core/server/api_container/server/startosis_engine/kurtosis_instruction/store_service_files/store_service_files.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_instruction/store_service_files/store_service_files.go
@@ -215,7 +215,7 @@ func (builtin *StoreServiceFilesCapabilities) Description() string {
 
 // UpdateDependencyGraph updates the dependency graph with the effects of running this instruction.
 func (builtin *StoreServiceFilesCapabilities) UpdateDependencyGraph(instructionUuid types.ScheduledInstructionUuid, dependencyGraph *dependency_graph.InstructionDependencyGraph) error {
-	shortDescriptor := fmt.Sprintf("store_service_files(%s %s)", builtin.serviceName, builtin.description)
+	shortDescriptor := fmt.Sprintf("store_service_files(%s, %s)", builtin.serviceName, builtin.description)
 	dependencyGraph.UpdateInstructionShortDescriptor(instructionUuid, shortDescriptor)
 
 	dependencyGraph.ConsumesService(instructionUuid, string(builtin.serviceName))

--- a/core/server/api_container/server/startosis_engine/kurtosis_instruction/store_service_files/store_service_files.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_instruction/store_service_files/store_service_files.go
@@ -215,6 +215,9 @@ func (builtin *StoreServiceFilesCapabilities) Description() string {
 
 // UpdateDependencyGraph updates the dependency graph with the effects of running this instruction.
 func (builtin *StoreServiceFilesCapabilities) UpdateDependencyGraph(instructionUuid types.ScheduledInstructionUuid, dependencyGraph *dependency_graph.InstructionDependencyGraph) error {
+	shortDescriptor := fmt.Sprintf("store_service_files(%s %s)", builtin.serviceName, builtin.description)
+	dependencyGraph.UpdateInstructionShortDescriptor(instructionUuid, shortDescriptor)
+
 	dependencyGraph.ConsumesService(instructionUuid, string(builtin.serviceName))
 	dependencyGraph.ConsumesAnyRuntimeValuesInString(instructionUuid, builtin.dependsOn)
 	dependencyGraph.ProducesFilesArtifact(instructionUuid, string(builtin.artifactName))

--- a/core/server/api_container/server/startosis_engine/kurtosis_instruction/tasks/run_python.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_instruction/tasks/run_python.go
@@ -459,6 +459,9 @@ func (builtin *RunPythonCapabilities) UpdatePlan(plan *plan_yaml.PlanYamlGenerat
 }
 
 func (builtin *RunPythonCapabilities) UpdateDependencyGraph(instructionUuid types.ScheduledInstructionUuid, dependencyGraph *dependency_graph.InstructionDependencyGraph) error {
+	shortDescriptor := fmt.Sprintf("run_python(%s)", builtin.description)
+	dependencyGraph.UpdateInstructionShortDescriptor(instructionUuid, shortDescriptor)
+
 	if builtin.serviceConfig.GetFilesArtifactsExpansion() != nil {
 		for _, filesArtifactNames := range builtin.serviceConfig.GetFilesArtifactsExpansion().ServiceDirpathsToArtifactIdentifiers {
 			for _, filesArtifactName := range filesArtifactNames {

--- a/core/server/api_container/server/startosis_engine/kurtosis_instruction/tasks/run_sh.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_instruction/tasks/run_sh.go
@@ -412,6 +412,9 @@ func (builtin *RunShCapabilities) UpdatePlan(plan *plan_yaml.PlanYamlGenerator) 
 }
 
 func (builtin *RunShCapabilities) UpdateDependencyGraph(instructionUuid types.ScheduledInstructionUuid, dependencyGraph *dependency_graph.InstructionDependencyGraph) error {
+	shortDescriptor := fmt.Sprintf("run_sh(%s)", builtin.description)
+	dependencyGraph.UpdateInstructionShortDescriptor(instructionUuid, shortDescriptor)
+
 	if builtin.serviceConfig.GetFilesArtifactsExpansion() != nil {
 		for _, filesArtifactNames := range builtin.serviceConfig.GetFilesArtifactsExpansion().ServiceDirpathsToArtifactIdentifiers {
 			for _, filesArtifactName := range filesArtifactNames {

--- a/core/server/api_container/server/startosis_engine/kurtosis_instruction/upload_files/upload_files.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_instruction/upload_files/upload_files.go
@@ -236,7 +236,7 @@ func (builtin *UploadFilesCapabilities) Description() string {
 
 // UpdateDependencyGraph updates the dependency graph with the effects of running this instruction.
 func (builtin *UploadFilesCapabilities) UpdateDependencyGraph(instructionUuid types.ScheduledInstructionUuid, dependencyGraph *dependency_graph.InstructionDependencyGraph) error {
-	shortDescriptor := fmt.Sprintf("upload_files(%s %s)", builtin.src, builtin.artifactName)
+	shortDescriptor := fmt.Sprintf("upload_files(%s, %s)", builtin.src, builtin.artifactName)
 	dependencyGraph.UpdateInstructionShortDescriptor(instructionUuid, shortDescriptor)
 
 	dependencyGraph.ProducesFilesArtifact(instructionUuid, string(builtin.artifactName))

--- a/core/server/api_container/server/startosis_engine/kurtosis_instruction/upload_files/upload_files.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_instruction/upload_files/upload_files.go
@@ -236,6 +236,9 @@ func (builtin *UploadFilesCapabilities) Description() string {
 
 // UpdateDependencyGraph updates the dependency graph with the effects of running this instruction.
 func (builtin *UploadFilesCapabilities) UpdateDependencyGraph(instructionUuid types.ScheduledInstructionUuid, dependencyGraph *dependency_graph.InstructionDependencyGraph) error {
+	shortDescriptor := fmt.Sprintf("upload_files(%s %s)", builtin.src, builtin.artifactName)
+	dependencyGraph.UpdateInstructionShortDescriptor(instructionUuid, shortDescriptor)
+
 	dependencyGraph.ProducesFilesArtifact(instructionUuid, string(builtin.artifactName))
 	return nil
 }

--- a/core/server/api_container/server/startosis_engine/kurtosis_instruction/verify/verify.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_instruction/verify/verify.go
@@ -175,6 +175,9 @@ func (builtin *VerifyCapabilities) Description() string {
 
 // UpdateDependencyGraph updates the dependency graph with the effects of running this instruction.
 func (builtin *VerifyCapabilities) UpdateDependencyGraph(instructionUuid types.ScheduledInstructionUuid, dependencyGraph *dependency_graph.InstructionDependencyGraph) error {
+	shortDescriptor := fmt.Sprintf("verify(%s)", builtin.description)
+	dependencyGraph.UpdateInstructionShortDescriptor(instructionUuid, shortDescriptor)
+
 	dependencyGraph.ConsumesAnyRuntimeValuesInString(instructionUuid, builtin.runtimeValue)
 	return nil
 }

--- a/core/server/api_container/server/startosis_engine/kurtosis_instruction/wait/wait.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_instruction/wait/wait.go
@@ -317,6 +317,9 @@ func (builtin *WaitCapabilities) Description() string {
 
 // UpdateDependencyGraph updates the dependency graph with the effects of running this instruction.
 func (builtin *WaitCapabilities) UpdateDependencyGraph(instructionUuid types.ScheduledInstructionUuid, dependencyGraph *dependency_graph.InstructionDependencyGraph) error {
+	shortDescriptor := fmt.Sprintf("wait(%s %s)", builtin.serviceName, builtin.description)
+	dependencyGraph.UpdateInstructionShortDescriptor(instructionUuid, shortDescriptor)
+
 	dependencyGraph.ConsumesService(instructionUuid, string(builtin.serviceName))
 
 	returnValueStrings, interpretationErr := builtin.recipe.GetStarlarkReturnValuesAsStringList(builtin.resultUuid)

--- a/core/server/api_container/server/startosis_engine/kurtosis_instruction/wait/wait.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_instruction/wait/wait.go
@@ -317,7 +317,7 @@ func (builtin *WaitCapabilities) Description() string {
 
 // UpdateDependencyGraph updates the dependency graph with the effects of running this instruction.
 func (builtin *WaitCapabilities) UpdateDependencyGraph(instructionUuid types.ScheduledInstructionUuid, dependencyGraph *dependency_graph.InstructionDependencyGraph) error {
-	shortDescriptor := fmt.Sprintf("wait(%s %s)", builtin.serviceName, builtin.description)
+	shortDescriptor := fmt.Sprintf("wait(%s, %s)", builtin.serviceName, builtin.description)
 	dependencyGraph.UpdateInstructionShortDescriptor(instructionUuid, shortDescriptor)
 
 	dependencyGraph.ConsumesService(instructionUuid, string(builtin.serviceName))

--- a/core/server/api_container/server/startosis_engine/plan_yaml/plan_yaml.go
+++ b/core/server/api_container/server/startosis_engine/plan_yaml/plan_yaml.go
@@ -1,6 +1,10 @@
 package plan_yaml
 
-import "sort"
+import (
+	"sort"
+
+	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/dependency_graph"
+)
 
 const (
 	shell  TaskType = "sh"
@@ -8,13 +12,18 @@ const (
 	exec   TaskType = "exec"
 )
 
+// PlanYaml contains information about the effect of an InstructionsPlan or sequence of instructions on the state of the Enclave.
+// It also includes useful metadata about the plan, such as the package dependencies and the instructions with their dependencies.
 type PlanYaml struct {
-	PackageId           string           `yaml:"packageId,omitempty"`
-	Services            []*Service       `yaml:"services,omitempty"`
-	FilesArtifacts      []*FilesArtifact `yaml:"filesArtifacts,omitempty"`
-	Tasks               []*Task          `yaml:"tasks,omitempty"`
-	Images              []string         `yaml:"images,omitempty"`
-	PackageDependencies []string         `yaml:"packageDependencies,omitempty"`
+	PackageId      string           `yaml:"packageId,omitempty"`
+	Services       []*Service       `yaml:"services,omitempty"`
+	FilesArtifacts []*FilesArtifact `yaml:"filesArtifacts,omitempty"`
+	Tasks          []*Task          `yaml:"tasks,omitempty"`
+
+	Images              []string `yaml:"images,omitempty"`
+	PackageDependencies []string `yaml:"packageDependencies,omitempty"`
+
+	Instructions []dependency_graph.InstructionWithDependencies `yaml:"instructions,omitempty"`
 }
 
 // Service represents a service in the system.

--- a/core/server/api_container/server/startosis_engine/plan_yaml/plan_yaml_generator.go
+++ b/core/server/api_container/server/startosis_engine/plan_yaml/plan_yaml_generator.go
@@ -2,17 +2,19 @@ package plan_yaml
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
+
 	"github.com/go-yaml/yaml"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/service"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/service_directory"
 	store_spec2 "github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/store_spec"
+	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/dependency_graph"
 	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/kurtosis_types"
 	"github.com/kurtosis-tech/stacktrace"
 	"go.starlark.net/starlark"
 	"go.starlark.net/starlarkstruct"
 	"golang.org/x/exp/slices"
-	"strconv"
-	"strings"
 )
 
 const (
@@ -399,6 +401,10 @@ func (planYaml *PlanYamlGenerator) AddImages() {
 		planYaml.privatePlanYaml.Images = append(planYaml.privatePlanYaml.Images, img)
 	}
 	slices.Sort(planYaml.privatePlanYaml.Images)
+}
+
+func (planYaml *PlanYamlGenerator) AddInstructions(instructionsWithDependencies []dependency_graph.InstructionWithDependencies) {
+	planYaml.privatePlanYaml.Instructions = append(planYaml.privatePlanYaml.Instructions, instructionsWithDependencies...)
 }
 
 // getFileMountsFromFilesArtifacts turns filesArtifactExpansions into FileMount's

--- a/core/server/api_container/server/startosis_engine/plan_yaml/plan_yaml_generator.go
+++ b/core/server/api_container/server/startosis_engine/plan_yaml/plan_yaml_generator.go
@@ -44,6 +44,7 @@ func CreateEmptyPlan(packageId string) *PlanYamlGenerator {
 			FilesArtifacts:      []*FilesArtifact{},
 			Images:              []string{},
 			PackageDependencies: []string{},
+			Instructions:        []dependency_graph.InstructionWithDependencies{},
 		},
 		imageSet:             map[string]bool{},
 		packageDependencySet: map[string]bool{},

--- a/go.work.sum
+++ b/go.work.sum
@@ -456,6 +456,7 @@ github.com/coreos/go-systemd v0.0.0-20181012123002-c6f51f82210d h1:t5Wuyh53qYyg9
 github.com/coreos/go-systemd/v22 v22.5.0 h1:RrqgGjYQKalulkV8NGVIfkXQf6YYmOyiJKk8iXXhfZs=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf h1:CAKfRE2YtTUIjjh1bkBtyYFaUT/WmOqsJjgtihT0vMI=
+github.com/corona10/goimagehash v1.1.0/go.mod h1:VkvE0mLn84L4aF8vCb6mafVajEb6QYMHl2ZJLn0mOGI=
 github.com/cpuguy83/go-md2man/v2 v2.0.3 h1:qMCsGGgs+MAzDFyp9LpAe1Lqy/fY/qCovCm0qnXZOBM=
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/denverdino/aliyungo v0.0.0-20190125010748-a747050bb1ba h1:p6poVbjHDkKa+wtC8frBMwQtT3BmqGYBjzMwJ63tuR4=
@@ -693,6 +694,7 @@ github.com/ncw/swift v1.0.47 h1:4DQRPj35Y41WogBxyhOXlrI37nzGlyEcsforeudyYPQ=
 github.com/ncw/swift v1.0.47/go.mod h1:23YIA4yWVnGwv2dQlN4bB7egfYX6YLn0Yo/S6zZO/ZM=
 github.com/neelance/astrewrite v0.0.0-20160511093645-99348263ae86 h1:D6paGObi5Wud7xg83MaEFyjxQB1W5bz5d0IFppr+ymk=
 github.com/neelance/sourcemap v0.0.0-20151028013722-8c68805598ab h1:eFXv9Nu1lGbrNbj619aWwZfVF5HBrm9Plte8aNptuTI=
+github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646/go.mod h1:jpp1/29i3P1S/RLdc7JQKbRpFeM1dOBd8T9ki5s+AY8=
 github.com/oklog/oklog v0.3.2 h1:wVfs8F+in6nTBMkA7CbRw+zZMIB7nNM825cM1wuzoTk=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=


### PR DESCRIPTION
## Description
Adds a `--output-graph` and `--with-mermaid` flag to allow visualizing instruction dependency graph of a kurtosis run.

```
kurtosis run github.com/ethpandaops/ethereum-package --args-file shadowforking.yml --output-graph --with-mermaid

kurtosis run github.com/ethpandaops/ethereum-package --args-file shadowforking.yml --output-graph --with-mermaid --output-graph-path ./graphs/
```

Outputs a GraphViz dot png image and a mermaid file that can put into a render such as `mermaid.live` for visualizing instruction dependencies. This can be useful when debugging `--parallel` runs, especially when needing to enforce dependencies between instructions.

<img width="834" height="510" alt="image" src="https://github.com/user-attachments/assets/24e6fd93-e6bd-4228-adf3-fce560d23586" />

## Is this change user facing?
YES
