### PR TITLE
fix: downstream instructions depend on any waits

### DIFF
--- a/core/server/api_container/server/startosis_engine/kurtosis_instruction/wait/wait.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_instruction/wait/wait.go
@@ -320,6 +320,7 @@ func (builtin *WaitCapabilities) UpdateDependencyGraph(instructionUuid types.Sch
 	shortDescriptor := fmt.Sprintf("wait(%s, %s)", builtin.serviceName, builtin.description)
 	dependencyGraph.UpdateInstructionShortDescriptor(instructionUuid, shortDescriptor)
 
+	dependencyGraph.AddWaitInstruction(instructionUuid) // every downstream instruction depends on this wait
 	dependencyGraph.ConsumesService(instructionUuid, string(builtin.serviceName))
 
 	returnValueStrings, interpretationErr := builtin.recipe.GetStarlarkReturnValuesAsStringList(builtin.resultUuid)


### PR DESCRIPTION
## Description
Ensures every instruction downstream of a `plan.wait` is dependent on that wait. The wait instruction is meant to ensure the system has reached a desired state, implying all downstream instructions should block until desired state is achieved.

## Is this change user facing?
YES

## References
