### PR TITLE
fix: join replace local path only when it is relative

### DIFF
--- a/api/golang/core/lib/enclaves/enclave_context.go
+++ b/api/golang/core/lib/enclaves/enclave_context.go
@@ -249,7 +249,10 @@ func getPackageNameAndReplaceOptions(packageRootPath string) (string, map[string
 func (enclaveCtx *EnclaveContext) uploadLocalStarlarkPackageDependencies(packageRootPath string, packageReplaceOptions map[string]string) error {
 	for dependencyPackageId, replaceOption := range packageReplaceOptions {
 		if isLocalDependencyReplace(replaceOption) {
-			localPackagePath := path.Join(packageRootPath, replaceOption)
+			localPackagePath := replaceOption
+			if !path.IsAbs(localPackagePath) {
+				localPackagePath = path.Join(packageRootPath, localPackagePath)
+			}
 			if err := enclaveCtx.uploadStarlarkPackage(dependencyPackageId, localPackagePath); err != nil {
 				return stacktrace.Propagate(err, "Error uploading package '%s' prior to executing it", replaceOption)
 			}


### PR DESCRIPTION
## Description

This PR fixes issue when an absolute local replacement path was joined with the package root, causing undesired behavior. Now replacement path only joined if it is relative. Absolute paths are remaining as they are.

## REMINDER: Tag Reviewers, so they get notified to review

## Is this change user facing?

YES

## References (if applicable)

Fixes #2857.
