### PR TITLE
fix: use writeErr instead of readErr in stream forwarding

### DIFF
--- a/cli/cli/kurtosis_gateway/server/api_container_gateway/api_container_gateway_service_server.go
+++ b/cli/cli/kurtosis_gateway/server/api_container_gateway/api_container_gateway_service_server.go
@@ -430,7 +430,7 @@ func forwardDataChunkStream[T dataChunkStreamReceiver, U dataChunkStreamSender](
 			return stacktrace.Propagate(readErr, "Error reading Kurtosis execution lines from Kurtosis core stream")
 		}
 		if writeErr := streamToWriteTo.Send(dataChunk); writeErr != nil {
-			return stacktrace.Propagate(readErr, "Received a Kurtosis execution line but failed forwarding it back to the user")
+			return stacktrace.Propagate(writeErr, "Received a Kurtosis execution line but failed forwarding it back to the user")
 		}
 	}
 }

--- a/cli/cli/kurtosis_gateway/server/common/helpers.go
+++ b/cli/cli/kurtosis_gateway/server/common/helpers.go
@@ -21,7 +21,7 @@ func ForwardKurtosisExecutionStream[T any](streamToReadFrom grpc.ClientStream, s
 		}
 
 		if writeErr := streamToWriteTo.SendMsg(starlarkRunResponseLine); writeErr != nil {
-			return stacktrace.Propagate(readErr, "Received a Kurtosis execution line but failed forwarding it back to the user")
+			return stacktrace.Propagate(writeErr, "Received a Kurtosis execution line but failed forwarding it back to the user")
 		}
 	}
 }


### PR DESCRIPTION
## Description
Fix for: 
```sh
 panic: Propagate must be provided with a cause

  goroutine 646 [running]:
  github.com/kurtosis-tech/stacktrace.Propagate(...)
  /go/pkg/mod/github.com/kurtosis-tech/stacktrace@v0.0.0-20211028211901-1c67a77b5409/stacktrace.go:85
  github.com/kurtosis-tech/kurtosis/cli/cli/kurtosis_gateway/server/common.ForwardKurtosisExecutionStream[...]({0x7fdc64fa4508, 0xc0017f0cf0}, {0x7fdc64fa4550, 0xc0017f0c80})
  /root/project/cli/cli/kurtosis_gateway/server/common/helpers.go:24 +0x14f
  github.com/kurtosis-tech/kurtosis/cli/cli/kurtosis_gateway/server/engine_gateway.(*EngineGatewayServiceServer).GetServiceLogs(0x43c7090?, 0xc0000e8e00, {0x2d20530, 0xc0017f0c80})
  /root/project/cli/cli/kurtosis_gateway/server/engine_gateway/engine_gateway_service_server.go:270 +0x185
  github.com/kurtosis-tech/kurtosis/api/golang/engine/kurtosis_engine_rpc_api_bindings._EngineService_GetServiceLogs_Handler({0x2664c00, 0xc000d09680}, {0x2d1e140, 0xc000f723c0})
  /root/project/api/golang/engine/kurtosis_engine_rpc_api_bindings/engine_service_grpc.pb.go:396 +0x107
  google.golang.org/grpc.(*Server).processStreamingRPC(0xc000250780, {0x2d24000, 0xc000b6e1a0}, 0xc001906120, 0xc000c99140, 0x43da040, 0x0)
  /go/pkg/mod/google.golang.org/grpc@v1.57.1/server.go:1652 +0x12a6
  google.golang.org/grpc.(*Server).handleStream(0xc000250780, {0x2d24000, 0xc000b6e1a0}, 0xc001906120, 0x0)
  /go/pkg/mod/google.golang.org/grpc@v1.57.1/server.go:1739 +0x999
  google.golang.org/grpc.(*Server).serveStreams.func1.1()
  /go/pkg/mod/google.golang.org/grpc@v1.57.1/server.go:970 +0xaf
  created by google.golang.org/grpc.(*Server).serveStreams.func1 in goroutine 386
  /go/pkg/mod/google.golang.org/grpc@v1.57.1/server.go:981 +0x136

  Exited with code exit status 2
```

Panic appeared in the next [release](https://app.circleci.com/pipelines/github/kurtosis-tech/kurtosis/14646/workflows/b10da53c-88be-4462-b3ed-c68780cbd0d2/jobs/227840?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-checks-link&utm_content=summary) CI job. 

## REMINDER: Tag Reviewers, so they get notified to review

## Is this change user facing?
YES/NO
<!-- If yes, please add the "user facing" label to the PR -->
<!-- If yes, don't forget to include docs changes where relevant -->

## References (if applicable)
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
<!-- You can auto-close issues by putting "Fixes #XXXX" here. -->
