### PR TITLE
fix(ci): use CIRCLE_TAG instead of git describe for tag detection

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -434,8 +434,7 @@ jobs:
 
       - run: |
           # If the current commit is not a tag and if there is no change (compared to main) of anything but docs, then skip this
-          git fetch origin --tags 
-          if (! git describe --exact-match) && git --no-pager diff --exit-code origin/main...HEAD -- . ':!docs' ':!*.md' ; then
+          if [ -z "${CIRCLE_TAG:-}" ] && git --no-pager diff --exit-code origin/main...HEAD -- . ':!docs' ':!*.md' ; then
             circleci-agent step halt
           fi
 


### PR DESCRIPTION
## Description
<!-- Describe this change, how it works, and the motivation behind it. -->

## REMINDER: Tag Reviewers, so they get notified to review

## Is this change user facing?
YES/NO
<!-- If yes, please add the "user facing" label to the PR -->
<!-- If yes, don't forget to include docs changes where relevant -->

## References (if applicable)
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
<!-- You can auto-close issues by putting "Fixes #XXXX" here. -->
