### PR TITLE
fix: revert don't publish udp ports (#2818)

### DIFF
--- a/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/shared_helpers/shared_helpers.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/shared_helpers/shared_helpers.go
@@ -140,6 +140,7 @@ func GetPublicPortBindingFromPrivatePortSpec(privatePortSpec *port_spec.PortSpec
 	resultPublicPortSpec *port_spec.PortSpec,
 	resultErr error,
 ) {
+
 	dockerPrivatePort, err := GetDockerPortFromPortSpec(privatePortSpec)
 	if err != nil {
 		return nil, nil, stacktrace.Propagate(
@@ -252,7 +253,9 @@ func GetIpAndPortInfoFromContainer(
 
 	privatePortSpecs, err := docker_port_spec_serializer.DeserializePortSpecs(serializedPortSpecs)
 	if err != nil {
-		return nil, nil, nil, nil, stacktrace.Propagate(err, "Couldn't deserialize port spec string '%v'", serializedPortSpecs)
+		if err != nil {
+			return nil, nil, nil, nil, stacktrace.Propagate(err, "Couldn't deserialize port spec string '%v'", serializedPortSpecs)
+		}
 	}
 
 	var containerPublicIp net.IP
@@ -261,16 +264,7 @@ func GetIpAndPortInfoFromContainer(
 		return privateIp, privatePortSpecs, containerPublicIp, publicPortSpecs, nil
 	}
 
-	publishedPrivateSpecs := map[string]*port_spec.PortSpec{}
 	for portId, privatePortSpec := range privatePortSpecs {
-		// filter out the UDP private port specs (as they don't get published) so we don't attempt to retrieve a public port that doesn't exist
-		if privatePortSpec.GetTransportProtocol() == port_spec.TransportProtocol_UDP {
-			continue
-		}
-		publishedPrivateSpecs[portId] = privatePortSpec
-	}
-
-	for portId, privatePortSpec := range publishedPrivateSpecs {
 		portPublicIp, publicPortSpec, err := GetPublicPortBindingFromPrivatePortSpec(privatePortSpec, hostMachinePortBindings)
 		if err != nil {
 			return nil, nil, nil, nil, stacktrace.Propagate(

--- a/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/user_services_functions/start_user_services.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/user_services_functions/start_user_services.go
@@ -672,11 +672,7 @@ func createStartServiceOperation(
 				return nil, stacktrace.Propagate(err, "An error occurred converting private port spec '%v' to a Docker port", portId)
 			}
 			//TODO this is a huge hack to temporarily enable static ports for NEAR until we have a more productized solution
-			if privatePortSpec.GetTransportProtocol() == port_spec.TransportProtocol_UDP {
-				// After Docker Desktop 4.41.2 https://github.com/docker/for-mac/issues/7754, Docker Desktop doesn't properly publish UDP ports to the host machine
-				// To avoid errors downstream checking for published UDP ports, we only expose them
-				dockerUsedPorts[dockerPort] = docker_manager.NewNoPublishingSpec()
-			} else if portShouldBeManuallyPublished(portId, publicPorts) {
+			if portShouldBeManuallyPublished(portId, publicPorts) {
 				publicPortSpec, found := publicPorts[portId]
 				if !found {
 					return nil, stacktrace.NewError("Expected to receive public port with ID '%v' bound to private port number '%v', but it was not found", portId, privatePortSpec.GetNumber())


### PR DESCRIPTION
This reverts commit f87a91ead5306196818ff3c39d2bcfbacc0826cd. or PR [2818](https://github.com/kurtosis-tech/kurtosis/pull/2818). 

This revert was needed as we were unable to stay peered on a public network due to lack of UDP communication using the ethereum package. 

I can advise to everyone that has issues with docker desktop to switch away from it, to something like orbstack.