### PR TITLE
fix: replace netstat with /proc/net/tcp for port availability checks

### DIFF
--- a/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/shared_helpers/shared_helpers.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/shared_helpers/shared_helpers.go
@@ -382,10 +382,10 @@ func WaitForPortAvailabilityUsingNetstat(
 	maxRetries uint,
 	timeBetweenRetries time.Duration,
 ) error {
+	portHex := fmt.Sprintf("%04X", portSpec.GetNumber())
 	commandStr := fmt.Sprintf(
-		"[ -n \"$(netstat -anp %v | grep LISTEN | grep %v)\" ]",
-		strings.ToLower(portSpec.GetTransportProtocol().String()),
-		portSpec.GetNumber(),
+		"grep -i ':%s ' /proc/net/tcp /proc/net/tcp6 2>/dev/null | grep -qi ' 0A '",
+		portHex,
 	)
 	execCmd := []string{
 		"sh",
@@ -400,7 +400,7 @@ func WaitForPortAvailabilityUsingNetstat(
 				return nil
 			}
 			logrus.Debugf(
-				"Netstat availability-waiting command '%v' returned without a Docker error, but exited with non-%v exit code '%v' and logs:\n%v",
+				"Port availability command '%v' returned without a Docker error, but exited with non-%v exit code '%v' and logs:\n%v",
 				commandStr,
 				netstatSuccessExitCode,
 				exitCode,
@@ -408,7 +408,7 @@ func WaitForPortAvailabilityUsingNetstat(
 			)
 		} else {
 			logrus.Debugf(
-				"Netstat availability-waiting command '%v' experienced a Docker error:\n%v",
+				"Port availability command '%v' experienced a Docker error:\n%v",
 				commandStr,
 				err,
 			)

--- a/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/shared_helpers/shared_helpers.go
+++ b/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/shared_helpers/shared_helpers.go
@@ -675,10 +675,10 @@ func WaitForPortAvailabilityUsingNetstat(
 	maxRetries uint,
 	timeBetweenRetries time.Duration,
 ) error {
+	portHex := fmt.Sprintf("%04X", portSpec.GetNumber())
 	commandStr := fmt.Sprintf(
-		"[ -n \"$(netstat -anp %v | grep LISTEN | grep %v)\" ]",
-		strings.ToLower(portSpec.GetTransportProtocol().String()),
-		portSpec.GetNumber(),
+		"grep -i ':%s ' /proc/net/tcp /proc/net/tcp6 2>/dev/null | grep -qi ' 0A '",
+		portHex,
 	)
 	execCmd := []string{
 		"sh",
@@ -701,7 +701,7 @@ func WaitForPortAvailabilityUsingNetstat(
 				return nil
 			}
 			logrus.Debugf(
-				"Netstat availability-waiting command '%v' returned without a Kubernetes error, but exited with non-%v exit code '%v' and logs:\n%v",
+				"Port availability command '%v' returned without a Kubernetes error, but exited with non-%v exit code '%v' and logs:\n%v",
 				commandStr,
 				netstatSuccessExitCode,
 				exitCode,
@@ -709,7 +709,7 @@ func WaitForPortAvailabilityUsingNetstat(
 			)
 		} else {
 			logrus.Debugf(
-				"Netstat availability-waiting command '%v' experienced a Kubernetes error:\n%v",
+				"Port availability command '%v' experienced a Kubernetes error:\n%v",
 				commandStr,
 				err,
 			)


### PR DESCRIPTION
The fluent-bit debug container (distroless:debug) does not include netstat, causing the logs collector port check to always fail on k8s. Use /proc/net/tcp which works on any Linux container without tool deps.

When it broke: Commit be932f74a ("impl k8s fluentbit collector availability check", Feb 18, 2025), merged via PR #2653 at commit 05e38135c ("feat:
  fluent bit logs collector in k8s backend", Feb 22, 2025). This has been broken since day one of the k8s logs collector feature - it was never
  working.

  Root cause: The port availability check runs netstat -anp tcp | grep LISTEN | grep 9713 via kubectl exec inside the fluent/fluent-bit:4.0.0-debug
  container. That image is based on Google's distroless:debug, which has a minimal busybox that does not include netstat. The engine and API
  containers are Alpine-based and have busybox netstat, so their checks work fine.

  The fix: Replaced the netstat command with a /proc/net/tcp check in both the Kubernetes and Docker backends:
  grep -i ':25F1 ' /proc/net/tcp /proc/net/tcp6 2>/dev/null | grep -qi ' 0A '

  - Reads the Linux proc filesystem directly (always available, zero tool dependency)
  - 25F1 is the hex representation of the port number
  - 0A is the TCP LISTEN state in /proc/net/tcp