### PR TITLE
fix(test): prevent panic in TestSearchLogs when logs are not yet persisted

### DIFF
--- a/internal_testsuites/golang/testsuite/search_logs_test/search_logs_test.go
+++ b/internal_testsuites/golang/testsuite/search_logs_test/search_logs_test.go
@@ -150,8 +150,12 @@ func TestSearchLogs(t *testing.T) {
 
 		require.NoError(t, testEvaluationErr)
 		for serviceUuid := range userServiceUuids {
-			for logNum, expectedLogLine := range expectedLogLinesByRequest[requestIndex] {
-				require.Contains(t, receivedLogLinesByService[serviceUuid][logNum], expectedLogLine)
+			receivedLogLines := receivedLogLinesByService[serviceUuid]
+			expectedLogLines := expectedLogLinesByRequest[requestIndex]
+			require.GreaterOrEqual(t, len(receivedLogLines), len(expectedLogLines),
+				"Expected at least %d log lines for service %s but got %d", len(expectedLogLines), serviceUuid, len(receivedLogLines))
+			for logNum, expectedLogLine := range expectedLogLines {
+				require.Contains(t, receivedLogLines[logNum], expectedLogLine)
 			}
 		}
 		require.Equal(t, expectedNonExistenceServiceUuids, receivedNotFoundServiceUuids)


### PR DESCRIPTION
The test accessed receivedLogLinesByService[serviceUuid][logNum] without checking the slice length, causing a panic instead of a proper test failure when the log streaming channel closed before logs were available. Now validates the received slice length with require.GreaterOrEqual before indexing.

Fixes this bug:
```sh
time="2026-02-23T13:17:56Z" level=error msg="An error occurred receiving user service logs stream for user services 'map[391b0a1304c843c3a86a729c5808d7d8:true]' in enclave 'acafef68bd454a199031b77a5f076a10'. Error:\nrpc error: code = Unknown desc = An error occurred streaming user service logs.\n --- at /home/runner/work/kurtosis/kurtosis/engine/server/engine/server/engine_connect_server_service.go:393 (EngineConnectServerService.GetServiceLogs) ---\nCaused by: No logs file paths for service '391b0a1304c843c3a86a729c5808d7d8' in enclave 'acafef68bd454a199031b77a5f076a10' were found. This means either:\n\t\t\t\t\t1) No logs for this service were detected/stored.\n\t\t\t\t\t2) Logs were manually removed.\n --- at /home/runner/work/kurtosis/kurtosis/engine/server/engine/centralized_logs/client_implementations/persistent_volume/stream_logs_strategy/per_week_stream_logs_strategy.go:63 (PerWeekStreamLogsStrategy.StreamLogs) ---"
--- FAIL: TestSearchLogs (13.62s)
panic: runtime error: index out of range [0] with length 0 [recovered]
	panic: runtime error: index out of range [0] with length 0

goroutine 19 [running]:
testing.tRunner.func1.2({0xa589c0, 0xc00032a228})
	/opt/hostedtoolcache/go/1.23.7/x64/src/testing/testing.go:1632 +0x230
testing.tRunner.func1()
	/opt/hostedtoolcache/go/1.23.7/x64/src/testing/testing.go:1635 +0x35e
panic({0xa589c0?, 0xc00032a228?})
	/opt/hostedtoolcache/go/1.23.7/x64/src/runtime/panic.go:791 +0x132
github.com/kurtosis-tech/kurtosis-cli/golang_internal_testsuite/testsuite/search_logs_test_test.TestSearchLogs(0xc000173d40)
	/home/runner/work/kurtosis/kurtosis/internal_testsuites/golang/testsuite/search_logs_test/search_logs_test.go:154 +0x873
testing.tRunner(0xc000173d40, 0xae1628)
	/opt/hostedtoolcache/go/1.23.7/x64/src/testing/testing.go:1690 +0xf4
created by testing.(*T).Run in goroutine 1
	/opt/hostedtoolcache/go/1.23.7/x64/src/testing/testing.go:1743 +0x390
FAIL	github.com/kurtosis-tech/kurtosis-cli/golang_internal_testsuite/testsuite/search_logs_test	13.626s
```