### PR TITLE
fix(test): increase log flush wait times in TestStreamLogs

### DIFF
--- a/internal_testsuites/golang/testsuite/consts/consts.go
+++ b/internal_testsuites/golang/testsuite/consts/consts.go
@@ -3,5 +3,5 @@ package consts
 import "time"
 
 const (
-	FluentbitRefreshInterval = 10 * time.Second
+	FluentbitRefreshInterval = 30 * time.Second
 )

--- a/internal_testsuites/golang/testsuite/search_logs_test/search_logs_test.go
+++ b/internal_testsuites/golang/testsuite/search_logs_test/search_logs_test.go
@@ -150,8 +150,12 @@ func TestSearchLogs(t *testing.T) {
 
 		require.NoError(t, testEvaluationErr)
 		for serviceUuid := range userServiceUuids {
-			for logNum, expectedLogLine := range expectedLogLinesByRequest[requestIndex] {
-				require.Contains(t, receivedLogLinesByService[serviceUuid][logNum], expectedLogLine)
+			receivedLogLines := receivedLogLinesByService[serviceUuid]
+			expectedLogLines := expectedLogLinesByRequest[requestIndex]
+			require.GreaterOrEqual(t, len(receivedLogLines), len(expectedLogLines),
+				"Expected at least %d log lines for service %s but got %d", len(expectedLogLines), serviceUuid, len(receivedLogLines))
+			for logNum, expectedLogLine := range expectedLogLines {
+				require.Contains(t, receivedLogLines[logNum], expectedLogLine)
 			}
 		}
 		require.Equal(t, expectedNonExistenceServiceUuids, receivedNotFoundServiceUuids)

--- a/internal_testsuites/golang/testsuite/stream_logs_test/stream_logs_test.go
+++ b/internal_testsuites/golang/testsuite/stream_logs_test/stream_logs_test.go
@@ -29,9 +29,10 @@ const (
 	lastLogLine   = "successfully"
 
 	// Retry configuration for log retrieval
-	// Logs may not be immediately available due to Fluentbit/Vector flush timing
-	maxLogRetrievalRetries    = 5
-	logRetrievalRetryInterval = 5 * time.Second
+	// Logs may not be immediately available due to Fluentbit/Vector flush timing;
+	// in CI the flush can take well over 30 seconds so we allow up to ~100 s of retries.
+	maxLogRetrievalRetries    = 10
+	logRetrievalRetryInterval = 10 * time.Second
 )
 
 var (


### PR DESCRIPTION
In CI, Fluentbit/Vector can take well over 30s to flush logs to the persistent volume. The previous 10s initial sleep + 5 retries at 5s intervals (~35s total) was insufficient. Increase:
- FluentbitRefreshInterval: 10s -> 30s (affects all log tests)
- maxLogRetrievalRetries: 5 -> 10
- logRetrievalRetryInterval: 5s -> 10s

This gives ~130s total wait budget before failing.

Fixing this bug:
```sh
time="2026-02-23T15:08:32Z" level=warning msg="We expected the running engine version to match format X.Y.Z, but instead got '34d685'; this means that we can't verify the API library and engine versions match so you may encounter runtime errors"
time="2026-02-23T15:08:41Z" level=warning msg="We expected the running engine version to match format X.Y.Z, but instead got '34d685'; this means that we can't verify the API library and engine versions match so you may encounter runtime errors"
time="2026-02-23T15:08:54Z" level=error msg="An error occurred receiving user service logs stream for user services 'map[fca2879ccede4871a4e6482ae24e608b:true]' in enclave 'ca1c2c8309bf46f595a319683c22639b'. Error:\nrpc error: code = Unknown desc = Error forwarding stream from Kurtosis engine back to the user\n --- at /__w/kurtosis/kurtosis/cli/cli/kurtosis_gateway/server/engine_gateway/engine_gateway_service_server.go:271 (EngineGatewayServiceServer.GetServiceLogs) ---\nCaused by: Error reading Kurtosis execution lines from Kurtosis core stream\n --- at /__w/kurtosis/kurtosis/cli/cli/kurtosis_gateway/server/common/helpers.go:20 (ForwardKurtosisExecutionStream[...]) ---\nCaused by: rpc error: code = Unknown desc = An error occurred streaming user service logs.\n --- at /home/runner/work/kurtosis/kurtosis/engine/server/engine/server/engine_connect_server_service.go:393 (EngineConnectServerService.GetServiceLogs) ---\nCaused by: No logs file paths for service 'fca2879ccede4871a4e6482ae24e608b' in enclave 'ca1c2c8309bf46f595a319683c22639b' were found. This means either:\n\t\t\t\t\t1) No logs for this service were detected/stored.\n\t\t\t\t\t2) Logs were manually removed.\n --- at /home/runner/work/kurtosis/kurtosis/engine/server/engine/centralized_logs/client_implementations/persistent_volume/stream_logs_strategy/per_week_stream_logs_strategy.go:63 (PerWeekStreamLogsStrategy.StreamLogs) ---"
time="2026-02-23T15:09:00Z" level=error msg="An error occurred receiving user service logs stream for user services 'map[fca2879ccede4871a4e6482ae24e608b:true]' in enclave 'ca1c2c8309bf46f595a319683c22639b'. Error:\nrpc error: code = Unknown desc = Error forwarding stream from Kurtosis engine back to the user\n --- at /__w/kurtosis/kurtosis/cli/cli/kurtosis_gateway/server/engine_gateway/engine_gateway_service_server.go:271 (EngineGatewayServiceServer.GetServiceLogs) ---\nCaused by: Error reading Kurtosis execution lines from Kurtosis core stream\n --- at /__w/kurtosis/kurtosis/cli/cli/kurtosis_gateway/server/common/helpers.go:20 (ForwardKurtosisExecutionStream[...]) ---\nCaused by: rpc error: code = Unknown desc = An error occurred streaming user service logs.\n --- at /home/runner/work/kurtosis/kurtosis/engine/server/engine/server/engine_connect_server_service.go:393 (EngineConnectServerService.GetServiceLogs) ---\nCaused by: No logs file paths for service 'fca2879ccede4871a4e6482ae24e608b' in enclave 'ca1c2c8309bf46f595a319683c22639b' were found. This means either:\n\t\t\t\t\t1) No logs for this service were detected/stored.\n\t\t\t\t\t2) Logs were manually removed.\n --- at /home/runner/work/kurtosis/kurtosis/engine/server/engine/centralized_logs/client_implementations/persistent_volume/stream_logs_strategy/per_week_stream_logs_strategy.go:63 (PerWeekStreamLogsStrategy.StreamLogs) ---"
time="2026-02-23T15:09:06Z" level=error msg="An error occurred receiving user service logs stream for user services 'map[fca2879ccede4871a4e6482ae24e608b:true]' in enclave 'ca1c2c8309bf46f595a319683c22639b'. Error:\nrpc error: code = Unknown desc = Error forwarding stream from Kurtosis engine back to the user\n --- at /__w/kurtosis/kurtosis/cli/cli/kurtosis_gateway/server/engine_gateway/engine_gateway_service_server.go:271 (EngineGatewayServiceServer.GetServiceLogs) ---\nCaused by: Error reading Kurtosis execution lines from Kurtosis core stream\n --- at /__w/kurtosis/kurtosis/cli/cli/kurtosis_gateway/server/common/helpers.go:20 (ForwardKurtosisExecutionStream[...]) ---\nCaused by: rpc error: code = Unknown desc = An error occurred streaming user service logs.\n --- at /home/runner/work/kurtosis/kurtosis/engine/server/engine/server/engine_connect_server_service.go:393 (EngineConnectServerService.GetServiceLogs) ---\nCaused by: No logs file paths for service 'fca2879ccede4871a4e6482ae24e608b' in enclave 'ca1c2c8309bf46f595a319683c22639b' were found. This means either:\n\t\t\t\t\t1) No logs for this service were detected/stored.\n\t\t\t\t\t2) Logs were manually removed.\n --- at /home/runner/work/kurtosis/kurtosis/engine/server/engine/centralized_logs/client_implementations/persistent_volume/stream_logs_strategy/per_week_stream_logs_strategy.go:63 (PerWeekStreamLogsStrategy.StreamLogs) ---"
time="2026-02-23T15:09:19Z" level=error msg="An error occurred receiving user service logs stream for user services 'map[fca2879ccede4871a4e6482ae24e608b:true]' in enclave 'ca1c2c8309bf46f595a319683c22639b'. Error:\nrpc error: code = Unknown desc = Error forwarding stream from Kurtosis engine back to the user\n --- at /__w/kurtosis/kurtosis/cli/cli/kurtosis_gateway/server/engine_gateway/engine_gateway_service_server.go:271 (EngineGatewayServiceServer.GetServiceLogs) ---\nCaused by: Error reading Kurtosis execution lines from Kurtosis core stream\n --- at /__w/kurtosis/kurtosis/cli/cli/kurtosis_gateway/server/common/helpers.go:20 (ForwardKurtosisExecutionStream[...]) ---\nCaused by: rpc error: code = Unknown desc = An error occurred streaming user service logs.\n --- at /home/runner/work/kurtosis/kurtosis/engine/server/engine/server/engine_connect_server_service.go:393 (EngineConnectServerService.GetServiceLogs) ---\nCaused by: No logs file paths for service 'fca2879ccede4871a4e6482ae24e608b' in enclave 'ca1c2c8309bf46f595a319683c22639b' were found. This means either:\n\t\t\t\t\t1) No logs for this service were detected/stored.\n\t\t\t\t\t2) Logs were manually removed.\n --- at /home/runner/work/kurtosis/kurtosis/engine/server/engine/centralized_logs/client_implementations/persistent_volume/stream_logs_strategy/per_week_stream_logs_strategy.go:63 (PerWeekStreamLogsStrategy.StreamLogs) ---"
time="2026-02-23T15:09:25Z" level=error msg="An error occurred receiving user service logs stream for user services 'map[fca2879ccede4871a4e6482ae24e608b:true]' in enclave 'ca1c2c8309bf46f595a319683c22639b'. Error:\nrpc error: code = Unknown desc = Error forwarding stream from Kurtosis engine back to the user\n --- at /__w/kurtosis/kurtosis/cli/cli/kurtosis_gateway/server/engine_gateway/engine_gateway_service_server.go:271 (EngineGatewayServiceServer.GetServiceLogs) ---\nCaused by: Error reading Kurtosis execution lines from Kurtosis core stream\n --- at /__w/kurtosis/kurtosis/cli/cli/kurtosis_gateway/server/common/helpers.go:20 (ForwardKurtosisExecutionStream[...]) ---\nCaused by: rpc error: code = Unknown desc = An error occurred streaming user service logs.\n --- at /home/runner/work/kurtosis/kurtosis/engine/server/engine/server/engine_connect_server_service.go:393 (EngineConnectServerService.GetServiceLogs) ---\nCaused by: No logs file paths for service 'fca2879ccede4871a4e6482ae24e608b' in enclave 'ca1c2c8309bf46f595a319683c22639b' were found. This means either:\n\t\t\t\t\t1) No logs for this service were detected/stored.\n\t\t\t\t\t2) Logs were manually removed.\n --- at /home/runner/work/kurtosis/kurtosis/engine/server/engine/centralized_logs/client_implementations/persistent_volume/stream_logs_strategy/per_week_stream_logs_strategy.go:63 (PerWeekStreamLogsStrategy.StreamLogs) ---"
--- FAIL: TestStreamLogs (65.72s)
    stream_logs_test.go:145: Attempt 1: expected 1 log lines for service fca2879ccede4871a4e6482ae24e608b, got 0. Retrying...
    stream_logs_test.go:145: Attempt 2: expected 1 log lines for service fca2879ccede4871a4e6482ae24e608b, got 0. Retrying...
    stream_logs_test.go:145: Attempt 3: expected 1 log lines for service fca2879ccede4871a4e6482ae24e608b, got 0. Retrying...
    stream_logs_test.go:145: Attempt 4: expected 1 log lines for service fca2879ccede4871a4e6482ae24e608b, got 0. Retrying...
    stream_logs_test.go:145: Attempt 5: expected 1 log lines for service fca2879ccede4871a4e6482ae24e608b, got 0. Retrying...
    stream_logs_test.go:157: 
        	Error Trace:	/home/runner/work/kurtosis/kurtosis/internal_testsuites/golang/testsuite/stream_logs_test/stream_logs_test.go:157
        	Error:      	Should be true
        	Test:       	TestStreamLogs
        	Messages:   	Failed to retrieve expected logs after 5 attempts
FAIL
FAIL	github.com/kurtosis-tech/kurtosis-cli/golang_internal_testsuite/testsuite/stream_logs_test	65.723s
ok  	github.com/kurtosis-tech/kurtosis-cli/golang_internal_testsuite/testsuite/upload_download_files_test	28.552s
FAIL
Error: Process completed with exit code 1.
```