### PR TITLE
fix(ci): fix publish secrets and build workflow triggers

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -105,8 +105,8 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Build binaries (amd64)
         run: |
@@ -157,8 +157,8 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Build binaries (amd64)
         run: |
@@ -243,8 +243,8 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Build binaries (amd64)
         run: |


### PR DESCRIPTION
## Description
Two CI fixes for the GitHub Actions migration:

1. **Rename Docker Hub secrets** in `publish.yml` - Changed `DOCKER_USERNAME`/`DOCKER_PASSWORD` to `DOCKERHUB_USERNAME`/`DOCKERHUB_PASSWORD` to match existing GitHub Actions secret names.

2. **Fix build workflow triggers** in `build.yml`:
   - Removed `release-please--branches--main--*` from push `branches-ignore` so builds run on release-please PRs (previously no workflow would trigger, leaving required checks stuck as "waiting for status").
   - Added `gh-readonly-queue/**` to push `branches-ignore` to prevent double-firing with the `merge_group` trigger, which was causing random cancellations in the merge queue.

## Is this change user facing?
NO

## References
First release since migrating from CircleCI to GitHub Actions.