### PR TITLE
fix(ci): fix build triggers for merge queue and release-please

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches-ignore:
       - main
-      - release-please--branches--main--*
+      - gh-readonly-queue/**
   merge_group:
 
 concurrency:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -105,8 +105,8 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Build binaries (amd64)
         run: |
@@ -157,8 +157,8 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Build binaries (amd64)
         run: |
@@ -243,8 +243,8 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Build binaries (amd64)
         run: |


### PR DESCRIPTION
## Description
Fix build workflow triggers in `build.yml`:
- Removed `release-please--branches--main--*` from push `branches-ignore` so builds actually run on release-please PRs (previously no workflow would trigger, leaving required checks stuck as "waiting for status").
- Added `gh-readonly-queue/**` to push `branches-ignore` to prevent double-firing with the `merge_group` trigger, which was causing random cancellations in the merge queue.

## Is this change user facing?
NO