### PR TITLE
chore(publish): trigger publish on tag push instead of manual dispatch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches-ignore:
       - main
-      - release-please--branches--main--*
+      - gh-readonly-queue/**
   merge_group:
 
 concurrency:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,17 +1,9 @@
 name: Publish
 
-# Manual trigger only for now - enable tag trigger after validation
 on:
-  workflow_dispatch:
-    inputs:
-      version:
-        description: 'Version to publish (e.g., 1.14.0)'
-        required: true
-        type: string
-  # TODO: Uncomment after GitHub Actions is validated against CircleCI
-  # push:
-  #   tags:
-  #     - '[0-9]+.[0-9]+.[0-9]+'
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
 
 env:
   GO_VERSION: '1.23.7'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -105,8 +105,8 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Build binaries (amd64)
         run: |
@@ -157,8 +157,8 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Build binaries (amd64)
         run: |
@@ -243,8 +243,8 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Build binaries (amd64)
         run: |


### PR DESCRIPTION
## Description
Switch the publish workflow trigger from `workflow_dispatch` (manual) back to `push.tags` so releases are automatically published when a semver tag (e.g. `1.16.0`) is pushed. This restores the tag-based release flow that was used with CircleCI.

## Is this change user facing?
NO