### PR TITLE
fix(ci): use correct dtolnay/rust-toolchain action for Rust publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Rust
-        uses: dtolnay/rust-action@stable
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ env.RUST_VERSION }}
 


### PR DESCRIPTION
## Description

Fixed the publish workflow to use the correct GitHub Action for setting up Rust. The workflow was referencing `dtolnay/rust-action@stable`, which does not exist. The correct action is `dtolnay/rust-toolchain@stable`.

## Is this change user facing?

NO