### PR TITLE
refactor(kubernetes): simplify cleanLogsCollector to skip if daemonset is not found

### DIFF
--- a/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/kubernetes_kurtosis_backend_enclave_functions.go
+++ b/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/kubernetes_kurtosis_backend_enclave_functions.go
@@ -334,13 +334,14 @@ func (backend *KubernetesKurtosisBackend) DestroyEnclaves(
 	}
 
 	// if destroy is deleting ALL enclaves, now's a good time to clean up log stuff
+	// these are best-effort: don't fail the entire destroy if cleanup has issues
 	if filters.Statuses[enclave.EnclaveStatus_Running] {
 		if err := logs_collector_functions.CleanLogsCollector(ctx, fluentbit.NewFluentbitLogsCollector(), backend.kubernetesManager); err != nil {
-			return nil, nil, stacktrace.Propagate(err, "An error cleaning logs collector daemon set.")
+			logrus.Warnf("Failed to clean logs collector daemon set (best-effort): %v", err)
 		}
 
 		if err := logs_aggregator_functions.CleanLogsAggregator(ctx, vector.NewVectorLogsAggregatorResourcesManager(), backend.kubernetesManager); err != nil {
-			return nil, nil, stacktrace.Propagate(err, "An error cleaning logs aggregator deployment.")
+			logrus.Warnf("Failed to clean logs aggregator deployment (best-effort): %v", err)
 		}
 	}
 

--- a/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_collector_functions/clean_logs_collector.go
+++ b/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_collector_functions/clean_logs_collector.go
@@ -10,9 +10,13 @@ func CleanLogsCollector(
 	ctx context.Context,
 	logsCollectorDaemonSet LogsCollectorDaemonSet,
 	kubernetesManager *kubernetes_manager.KubernetesManager) error {
-	_, k8sResources, err := getLogsCollectorObjAndResourcesForCluster(ctx, kubernetesManager)
+	k8sResources, err := getLogsCollectorKubernetesResourcesForCluster(ctx, kubernetesManager)
 	if err != nil {
-		return stacktrace.Propagate(err, "An error occurred getting logs collector object and resources for cluster.")
+		return stacktrace.Propagate(err, "An error occurred getting logs collector kubernetes resources for cluster.")
+	}
+
+	if k8sResources.daemonSet == nil {
+		return nil
 	}
 
 	if err := logsCollectorDaemonSet.Clean(ctx, k8sResources.daemonSet, kubernetesManager); err != nil {

--- a/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_collector_functions/shared_helpers.go
+++ b/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_collector_functions/shared_helpers.go
@@ -278,8 +278,8 @@ func getLogsCollectorStatus(ctx context.Context, kubernetesManager *kubernetes_m
 		return container.ContainerStatus_Stopped, stacktrace.Propagate(err, "An error occurred getting pods managed by logs collector daemon set '%v'.", logsCollectorDaemonSet.Name)
 	}
 	if len(logsCollectorPods) < 1 {
-		// if there are no pods associated with logs collector daemon set, assume something is wrong and err
-		return container.ContainerStatus_Stopped, stacktrace.NewError("No pods managed by logs collector daemon set were found. There should be at least one. This is likely a bug in Kurtosis.")
+		logrus.Warnf("No pods managed by logs collector daemon set '%v' were found; treating collector as stopped.", logsCollectorDaemonSet.Name)
+		return container.ContainerStatus_Stopped, nil
 	}
 
 	runningPods := 0

--- a/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_collector_functions/shared_helpers.go
+++ b/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_collector_functions/shared_helpers.go
@@ -139,7 +139,7 @@ func getLogsCollectorKubernetesResourcesForCluster(ctx context.Context, kubernet
 	logsCollectorConfigServiceAccounts, err := kubernetes_resource_collectors.CollectMatchingServiceAccounts(
 		ctx,
 		kubernetesManager,
-		namespace.Namespace,
+		namespace.Name,
 		logsCollectorDaemonSetSearchLabels,
 		resourceTypeLabelKeyStr,
 		map[string]bool{


### PR DESCRIPTION
PR Summary: Fix kurtosis clean -a hanging on k8s clusters with tainted/unhealthy nodes

  Problem

  kurtosis clean -a hangs indefinitely on Kubernetes clusters where some nodes have taints (e.g. DiskPressure, smc). The fluentbit logs collector
  Clean method creates remove-dir-pod cleanup pods targeted at each node, but nodes with taints won't schedule these pods. The waitForPodAvailability
   function then blocks for 15 minutes per unschedulable pod, and this happens sequentially per node.

  Changes (5 files, +46/-19)

  1. kubernetes_manager.go — waitForPodAvailability now:
    - Respects context cancellation (was ignoring ctx.Done())
    - Detects PodReasonUnschedulable and returns immediately instead of waiting 15 minutes
  2. fluentbit_logs_collector_daemonset.go — Clean method now:
    - Returns nil instead of error when zero pods found
    - Makes WaitForPodTermination best-effort (warn, don't fail)
    - Makes RemoveDirPathFromNode best-effort with 2-minute per-node timeout (skips tainted nodes)
    - Makes waitForAtLeastOneActivePodManagedByDaemonSet best-effort
  3. kubernetes_kurtosis_backend_enclave_functions.go — CleanLogsCollector and CleanLogsAggregator errors downgraded from fatal to best-effort
  warnings
  4. clean_logs_collector.go — Calls getLogsCollectorKubernetesResourcesForCluster directly, adds nil check for missing DaemonSet
  5. shared_helpers.go — Two fixes:
    - namespace.Namespace → namespace.Name (was always empty for k8s Namespace objects, causing cross-namespace service account lookups and "found 2"
   errors)
    - Zero pods case returns Stopped status with warning instead of error

  Result

  kurtosis clean -a completes in ~40 seconds even with tainted/unhealthy nodes, instead of hanging indefinitely.
