### PR TITLE
chore: publish deb/rpm artifacts to GitHub Pages

### DIFF
--- a/.github/workflows/update-package-repo.yml
+++ b/.github/workflows/update-package-repo.yml
@@ -88,5 +88,5 @@ jobs:
           publish_dir: ./repo
           keep_files: true
           user_name: kurtosisbot
-          user_email: kurtosisbot@users.noreply.github.com
+          user_email: kurtosisbot@kurtosistech.com
           commit_message: "Update package repo for ${{ steps.version.outputs.version }}"

--- a/.github/workflows/update-package-repo.yml
+++ b/.github/workflows/update-package-repo.yml
@@ -1,0 +1,92 @@
+name: Update Package Repository
+
+on:
+  # Run automatically after a successful publish
+  workflow_run:
+    workflows: ["Publish"]
+    types: [completed]
+
+  # Allow manual trigger
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version to publish (e.g. 1.16.4)'
+        required: true
+
+jobs:
+  update-package-repo:
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: Determine version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "version=${{ github.event.inputs.version }}" >> "$GITHUB_OUTPUT"
+          else
+            # Get the tag from the workflow run that triggered us
+            echo "version=${{ github.event.workflow_run.head_branch }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install repo tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y dpkg-dev createrepo-c
+
+      - name: Checkout existing GitHub Pages
+        uses: actions/checkout@v4
+        with:
+          repository: kurtosis-tech/kurtosis-cli-release-artifacts
+          ref: gh-pages
+          token: ${{ secrets.KURTOSISBOT_GITHUB_TOKEN }}
+          path: repo
+
+      - name: Download deb/rpm from release
+        env:
+          GH_TOKEN: ${{ secrets.KURTOSISBOT_GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          version="${{ steps.version.outputs.version }}"
+
+          mkdir -p downloads
+          gh release download "${version}" \
+            --repo kurtosis-tech/kurtosis-cli-release-artifacts \
+            --pattern '*.deb' \
+            --pattern '*.rpm' \
+            --dir downloads
+
+          echo "Downloaded artifacts:"
+          ls -la downloads/
+
+      - name: Update apt repository
+        run: |
+          set -euo pipefail
+          cd repo
+
+          # Flat repo layout: debs and Packages file at the root (like Gemfury)
+          cp ../downloads/*.deb .
+
+          # Generate Packages index for all deb files in the root
+          dpkg-scanpackages --multiversion . > Packages
+          gzip -9c Packages > Packages.gz
+
+      - name: Update rpm repository
+        run: |
+          set -euo pipefail
+          cd repo
+
+          mkdir -p rpm/packages
+          cp ../downloads/*.rpm rpm/packages/
+
+          createrepo_c --update rpm/
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          personal_token: ${{ secrets.KURTOSISBOT_GITHUB_TOKEN }}
+          external_repository: kurtosis-tech/kurtosis-cli-release-artifacts
+          publish_dir: ./repo
+          keep_files: true
+          user_name: kurtosisbot
+          user_email: kurtosisbot@users.noreply.github.com
+          commit_message: "Update package repo for ${{ steps.version.outputs.version }}"

--- a/cli/cli/.goreleaser.yml
+++ b/cli/cli/.goreleaser.yml
@@ -52,7 +52,6 @@ archives:
       - scripts/completions/scripts/*
     name_template: kurtosis-cli_{{ .Version }}_{{ .Os }}_{{ .Arch }}
 
-# Gemfury accepts deb & rpm packages but not APK, so we build these two separately
 nfpms:
   - id: deb-and-rpm-packages
     package_name: kurtosis-cli
@@ -84,10 +83,10 @@ release:
 
   name_template: "{{ .Version }}"
 
-  # NOTE: these are the archive IDs, not the build/binary IDs
   ids:
     - cli
     - cli-linux-packages
+    - deb-and-rpm-packages
 
 brews:
   # creates a brew formula representing the latest version
@@ -141,15 +140,13 @@ brews:
       The kurtosis CLI is installed with tab completion support. For more details visit https://docs.kurtosis.com/.
 
 publishers:
-  # Inspired by https://netdevops.me/2021/building-and-publishing-deb/rpm-packages-with-goreleaser-and-fury.io/
   - name: fury.io
     ids:
     - deb-and-rpm-packages
     dir: "{{ dir .ArtifactPath }}"
     env:
-      # This will get set by CI; see the CI config for how
       - 'FURY_TOKEN={{ .Env.FURY_TOKEN }}'
-    cmd: "curl -F package=@{{ .ArtifactName }} https://{{ .Env.FURY_TOKEN }}@push.fury.io/kurtosis-tech/"
+    cmd: "curl --fail -F package=@{{ .ArtifactName }} https://{{ .Env.FURY_TOKEN }}@push.fury.io/kurtosis-tech/"
 
 source:
   # Kurt Core is a private project, and we definitely don't want to release source code


### PR DESCRIPTION
## Summary
This P adds adds apt/rpm package distribution with a self-hosted repository on GitHub Pages using the existing `kurtosis-cli-release-artifacts` repo.

**Key Changes:**
- Add new workflow job to generate apt/rpm repository metadata on GitHub Pages
- Fix goreleaser release IDs to properly upload deb/rpm files to GitHub Releases

**New Repository URL:**
```
https://kurtosis-tech.github.io/kurtosis-cli-release-artifacts/
```

## User Facing
YES - Updated installation instructions for users

🤖 Generated with [Claude Code](https://claude.com/claude-code)