### PR TITLE
fix: add Release and Translation files to apt repository

### DIFF
--- a/.github/workflows/update-package-repo.yml
+++ b/.github/workflows/update-package-repo.yml
@@ -70,6 +70,13 @@ jobs:
           dpkg-scanpackages --multiversion . > Packages
           gzip -9c Packages > Packages.gz
 
+          # Generate Release file to suppress apt "Ign" warnings
+          apt-ftparchive release . > Release
+
+          # Create empty Translation file to prevent 404 on Translation-en
+          touch Translation-en
+          gzip -9c Translation-en > Translation-en.gz
+
       - name: Update rpm repository
         run: |
           set -euo pipefail


### PR DESCRIPTION
The apt repository hosted on GitHub Pages only contained Packages and Packages.gz, causing apt-get update to emit noisy "Ign" and "Err 404" warnings for the missing InRelease, Release, and Translation-en files.

While the install still succeeded (due to [trusted=yes] and Packages being present), these errors are confusing for users and make it look like something is broken.

Generate a proper Release file via apt-ftparchive and add an empty Translation-en to satisfy apt's metadata expectations.

## Description
<!-- Describe this change, how it works, and the motivation behind it. -->

## REMINDER: Tag Reviewers, so they get notified to review

## Is this change user facing?
YES/NO
<!-- If yes, please add the "user facing" label to the PR -->
<!-- If yes, don't forget to include docs changes where relevant -->

## References (if applicable)
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
<!-- You can auto-close issues by putting "Fixes #XXXX" here. -->
