### PR TITLE
feat: Migrate install instructions from Gemfury to GitHub Pages

### DIFF
--- a/docs/docs/get-started/installing-the-cli.md
+++ b/docs/docs/get-started/installing-the-cli.md
@@ -15,6 +15,20 @@ import TabItem from '@theme/TabItem';
 
 The instructions in this guide will walk you through installing the latest version of Kurtosis.
 
+:::warning Migrating from Gemfury?
+The old Gemfury-hosted apt/yum repositories (`apt.fury.io/kurtosis-tech` and `yum.fury.io/kurtosis-tech`) are **no longer supported**. If you previously installed Kurtosis via Gemfury, switch to the new repository with a single command:
+
+**apt (Ubuntu/Debian):**
+```bash
+echo "deb [trusted=yes] https://sdk.kurtosis.com/kurtosis-cli-release-artifacts/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list && sudo apt update
+```
+
+**yum (RHEL/CentOS):**
+```bash
+sudo sed -i 's|https://yum.fury.io/kurtosis-tech/|https://sdk.kurtosis.com/kurtosis-cli-release-artifacts/rpm/|' /etc/yum.repos.d/kurtosis.repo && sudo yum makecache
+```
+:::
+
 I. Install & Start Docker
 -----------------
 
@@ -49,7 +63,7 @@ xcode-select --install
 <TabItem value="apt" label="apt (Ubuntu)">
 
 ```bash
-echo "deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
+echo "deb [trusted=yes] https://sdk.kurtosis.com/kurtosis-cli-release-artifacts/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
 sudo apt update
 sudo apt install kurtosis-cli
 ```
@@ -60,7 +74,7 @@ sudo apt install kurtosis-cli
 ```bash
 echo '[kurtosis]
 name=Kurtosis
-baseurl=https://yum.fury.io/kurtosis-tech/
+baseurl=https://sdk.kurtosis.com/kurtosis-cli-release-artifacts/rpm/
 enabled=1
 gpgcheck=0' | sudo tee /etc/yum.repos.d/kurtosis.repo
 sudo yum install kurtosis-cli

--- a/docs/docs/get-started/installing-the-cli.md
+++ b/docs/docs/get-started/installing-the-cli.md
@@ -27,6 +27,30 @@ echo "deb [trusted=yes] https://sdk.kurtosis.com/kurtosis-cli-release-artifacts/
 ```bash
 sudo sed -i 's|https://yum.fury.io/kurtosis-tech/|https://sdk.kurtosis.com/kurtosis-cli-release-artifacts/rpm/|' /etc/yum.repos.d/kurtosis.repo && sudo yum makecache
 ```
+
+**Note:** If you need to install a Kurtosis version for version `1.15.6` or earlier, you should still use the old Gemfury repositories:
+
+<details>
+<summary>Gemfury install instructions (version 1.15.6 or earlier)</summary>
+
+**apt (Ubuntu/Debian):**
+```bash
+echo "deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
+sudo apt update
+sudo apt install kurtosis-cli=<version>
+```
+
+**yum (RHEL/CentOS):**
+```bash
+echo '[kurtosis]
+name=Kurtosis
+baseurl=https://yum.fury.io/kurtosis-tech/
+enabled=1
+gpgcheck=0' | sudo tee /etc/yum.repos.d/kurtosis.repo
+sudo yum install kurtosis-cli-<version>
+```
+
+</details>
 :::
 
 I. Install & Start Docker

--- a/docs/docs/guides/installing-historical-versions.md
+++ b/docs/docs/guides/installing-historical-versions.md
@@ -46,7 +46,7 @@ sudo apt remove kurtosis-cli
 :::
 
 ```bash
-echo "deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
+echo "deb [trusted=yes] https://sdk.kurtosis.com/kurtosis-cli-release-artifacts/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
 sudo apt update
 sudo apt remove kurtosis-cli
 sudo apt install kurtosis-cli=<version> -V
@@ -68,7 +68,7 @@ sudo yum remove kurtosis-cli
 ```bash
 echo '[kurtosis]
 name=Kurtosis
-baseurl=https://yum.fury.io/kurtosis-tech/
+baseurl=https://sdk.kurtosis.com/kurtosis-cli-release-artifacts/rpm/
 enabled=1
 gpgcheck=0' | sudo tee /etc/yum.repos.d/kurtosis.repo
 sudo yum remove kurtosis-cli


### PR DESCRIPTION
## Summary
- Update all apt/yum repository URLs from Gemfury (`apt.fury.io/kurtosis-tech`, `yum.fury.io/kurtosis-tech`) to the new GitHub Pages hosted repo (`sdk.kurtosis.com/kurtosis-cli-release-artifacts`)
- Add a migration warning banner to the install page with one-liner commands for existing Gemfury users to switch over
- Update CI configs (CircleCI + GitHub Actions) to use the new repository URL

## Files changed
- `docs/docs/get-started/installing-the-cli.md` — new URLs + migration notice
- `docs/docs/guides/installing-historical-versions.md` — new URLs
- `.circleci/config.yml` — 4 apt source references updated
- `.github/workflows/build.yml` — 1 apt source reference updated

## Test plan
- [x] Verify `apt-get update && apt-get install kurtosis-cli` works with new URL
- [ ] Verify `yum install kurtosis-cli` works with new URL
- [ ] Verify docs render correctly with the migration warning banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)