### PR TITLE
fix(tests): guard against nil RunScript result in integration tests

### DIFF
--- a/internal_testsuites/golang/testsuite/startosis_add_service_test/startosis_add_service_with_ready_conditions_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_add_service_test/startosis_add_service_with_ready_conditions_test.go
@@ -55,6 +55,7 @@ func (suite *StartosisAddServiceTestSuite) TestStartosis_AddServiceWithReadyCond
 	runResult, _ := suite.RunScript(ctx, script)
 
 	t := suite.T()
+	require.NotNil(t, runResult, "RunScript returned nil result")
 	expectedLastAssertionErrorStr := fmt.Sprintf("Verification failed '%v' '==' '%v'", okStatusCode, serverErrorStatusCode)
 
 	require.Nil(t, runResult.InterpretationError, "Unexpected interpretation error")

--- a/internal_testsuites/golang/testsuite/startosis_add_service_test/startosis_add_services_with_ready_conditions_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_add_service_test/startosis_add_services_with_ready_conditions_test.go
@@ -65,6 +65,7 @@ func (suite *StartosisAddServiceTestSuite) TestStartosis_AddServicesWithReadyCon
 	runResult, _ := suite.RunScript(ctx, script)
 
 	t := suite.T()
+	require.NotNil(t, runResult, "RunScript returned nil result")
 
 	require.Nil(t, runResult.InterpretationError, "Unexpected interpretation error")
 	require.Empty(t, runResult.ValidationErrors, "Unexpected validation error")

--- a/internal_testsuites/golang/testsuite/startosis_ports_wait_test/startosis_ports_wait_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_ports_wait_test/startosis_ports_wait_test.go
@@ -58,6 +58,7 @@ func (suite *StartosisPortsWaitTestSuite) TestStartosis_AssertFailBecausePortIsN
 	runResult, _ := suite.RunScript(ctx, assertFailScript)
 
 	t := suite.T()
+	require.NotNil(t, runResult, "RunScript returned nil result")
 
 	require.Nil(t, runResult.InterpretationError, "Unexpected interpretation error")
 	require.Empty(t, runResult.ValidationErrors, "Unexpected validation error")
@@ -69,6 +70,7 @@ func (suite *StartosisPortsWaitTestSuite) TestStartosis_AssertFailBecauseEmptySt
 	runResult, _ := suite.RunScript(ctx, assertFailScript2)
 
 	t := suite.T()
+	require.NotNil(t, runResult, "RunScript returned nil result")
 
 	require.NotNil(t, runResult.InterpretationError, "Expected interpretation error coming from wait validation")
 	require.Empty(t, runResult.ValidationErrors, "Unexpected validation error")

--- a/internal_testsuites/golang/testsuite/startosis_request_wait_assert_test/starlark_validation_failure_invalid_port_id_request_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_request_wait_assert_test/starlark_validation_failure_invalid_port_id_request_test.go
@@ -32,6 +32,7 @@ func (suite *StartosisRequestWaitAssertTestSuite) TestStarlark_InvalidPortIdRequ
 	runResult, _ := suite.RunScript(ctx, requestInvalidPortIDFailScript)
 
 	t := suite.T()
+	require.NotNil(t, runResult, "RunScript returned nil result")
 	require.Nil(t, runResult.InterpretationError, "Unexpected interpretation error")
 	require.NotEmpty(t, runResult.ValidationErrors, "Expected validation errors")
 	require.Len(t, runResult.ValidationErrors, 1)

--- a/internal_testsuites/golang/testsuite/startosis_request_wait_assert_test/starlark_validation_failure_invalid_port_id_wait_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_request_wait_assert_test/starlark_validation_failure_invalid_port_id_wait_test.go
@@ -32,6 +32,7 @@ func (suite *StartosisRequestWaitAssertTestSuite) TestStarlark_InvalidPortIdWait
 	runResult, _ := suite.RunScript(ctx, waitInvalidPortIDFailScript)
 
 	t := suite.T()
+	require.NotNil(t, runResult, "RunScript returned nil result")
 	require.Nil(t, runResult.InterpretationError, "Unexpected interpretation error")
 	require.NotEmpty(t, runResult.ValidationErrors, "Expected validation error")
 	require.Len(t, runResult.ValidationErrors, 1)

--- a/internal_testsuites/golang/testsuite/startosis_request_wait_assert_test/starlark_validation_failure_invalid_service_name_request_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_request_wait_assert_test/starlark_validation_failure_invalid_service_name_request_test.go
@@ -32,6 +32,7 @@ func (suite *StartosisRequestWaitAssertTestSuite) TestStarlark_InvalidServiceReq
 	runResult, _ := suite.RunScript(ctx, requestInvalidServiceNameScript)
 
 	t := suite.T()
+	require.NotNil(t, runResult, "RunScript returned nil result")
 	require.Nil(t, runResult.InterpretationError, "Unexpected interpretation error")
 	require.NotEmpty(t, runResult.ValidationErrors, "Expected validation error")
 	require.Len(t, runResult.ValidationErrors, 1)

--- a/internal_testsuites/golang/testsuite/startosis_request_wait_assert_test/starlark_validation_failure_invalid_service_wait_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_request_wait_assert_test/starlark_validation_failure_invalid_service_wait_test.go
@@ -31,6 +31,7 @@ func (suite *StartosisRequestWaitAssertTestSuite) TestStarlark_InvalidServiceWai
 	ctx := context.Background()
 	t := suite.T()
 	runResult, _ := suite.RunScript(ctx, waitInvalidServiceTestScript)
+	require.NotNil(t, runResult, "RunScript returned nil result")
 
 	require.Nil(t, runResult.InterpretationError, "Unexpected interpretation error")
 	require.NotEmpty(t, runResult.ValidationErrors, "Expected validation error")

--- a/internal_testsuites/golang/testsuite/startosis_request_wait_assert_test/startosis_assert_fail_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_request_wait_assert_test/startosis_assert_fail_test.go
@@ -35,6 +35,7 @@ func (suite *StartosisRequestWaitAssertTestSuite) TestStartosis_AssertFail() {
 	ctx := context.Background()
 	t := suite.T()
 	runResult, _ := suite.RunScript(ctx, assertFailScript)
+	require.NotNil(t, runResult, "RunScript returned nil result")
 
 	require.Nil(t, runResult.InterpretationError, "Unexpected interpretation error")
 	require.Empty(t, runResult.ValidationErrors, "Unexpected validation error")

--- a/internal_testsuites/golang/testsuite/startosis_request_wait_assert_test/startosis_timeout_wait_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_request_wait_assert_test/startosis_timeout_wait_test.go
@@ -31,6 +31,7 @@ func (suite *StartosisRequestWaitAssertTestSuite) TestStartosis_TimeoutWait() {
 	ctx := context.Background()
 	t := suite.T()
 	runResult, _ := suite.RunScript(ctx, timeoutWaitStartosisScript)
+	require.NotNil(t, runResult, "RunScript returned nil result")
 
 	require.Nil(t, runResult.InterpretationError, "Unexpected interpretation error")
 	require.Empty(t, runResult.ValidationErrors, "Unexpected validation error")

--- a/internal_testsuites/golang/testsuite/startosis_run_sh_task_test/run_task_sh_task_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_run_sh_task_test/run_task_sh_task_test.go
@@ -60,6 +60,7 @@ func TestStarlark_RunshTaskFileArtifact(t *testing.T) {
 func TestStarlark_RunshTimesoutSuccess(t *testing.T) {
 	ctx := context.Background()
 	runResult, _ := test_helpers.SetupSimpleEnclaveAndRunScript(t, ctx, runshTest, runshStarlarkWithTimeout)
+	require.NotNil(t, runResult, "RunScript returned nil result")
 	expectedErrorMessage := "The exec request timed out after 5 seconds"
 	require.NotNil(t, runResult.ExecutionError)
 	require.Contains(t, runResult.ExecutionError.GetErrorMessage(), expectedErrorMessage)
@@ -68,6 +69,7 @@ func TestStarlark_RunshTimesoutSuccess(t *testing.T) {
 func TestStarlark_RunshAcceptableCodes(t *testing.T) {
 	ctx := context.Background()
 	runResult, _ := test_helpers.SetupSimpleEnclaveAndRunScript(t, ctx, runshTest, runStarlarkWithAcceptableCodes)
+	require.NotNil(t, runResult, "RunScript returned nil result")
 	expectedOutput := "Command returned with exit code '0' with no output\nCommand returned with exit code '1' with no output\nCommand returned with exit code '42' and the following output:\n--------------------\nHi\n\n--------------------\n"
 	require.Nil(t, runResult.ExecutionError)
 	require.Equal(t, expectedOutput, string(runResult.RunOutput))


### PR DESCRIPTION
## Summary
- When `RunScript`/`RunRemotePackage` returns `(nil, error)` due to gRPC failures (context cancelled, engine unreachable), tests that ignore the error with `runResult, _ := ...` and immediately access `runResult.InterpretationError` panic with a nil pointer dereference
- Added `require.NotNil(t, runResult, "RunScript returned nil result")` guards at 12 call sites across 10 test files to produce clean test failures instead of panics
- Two files (`startosis_add_service_invalid_name_test.go` and `startosis_remote_package_relative_import_test.go`) already had the guard and were left unchanged

## Test plan
- [x] `go vet ./...` passes in `internal_testsuites/golang/`
- [x] `go build ./...` passes in `internal_testsuites/golang/`
- [ ] Full integration test suite (requires running Kurtosis engine + k8s cluster, validated by CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)