### PR TITLE
docs: add Claude Code skills installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,97 @@ To see where we're going with the product, check out the roadmap [here](https://
 
 Got more questions? Drop them in our [Github Discussions](https://github.com/kurtosis-tech/kurtosis/discussions/new?category=q-a) where we, or other community members, can help answer.
 
+Claude Code Skills
+========================
+
+This repository includes [Claude Code](https://claude.ai/download) skills that teach Claude how to work with Kurtosis. Skills are structured prompts in the `skills/` directory that give Claude operational knowledge about building, debugging, deploying, and managing Kurtosis enclaves.
+
+### Available Skills
+
+| Skill | Description |
+|-------|-------------|
+| `clean` | Clean up enclaves and artifacts |
+| `cli-local-build` | Build the CLI from source |
+| `cluster-manage` | Manage Kurtosis clusters |
+| `context-manage` | Manage Kurtosis contexts |
+| `docker-debug` | Debug Docker-based enclaves |
+| `docker-local-build` | Build and load Docker images locally |
+| `dump` | Dump enclave state for debugging |
+| `enclave-inspect` | Inspect running enclaves |
+| `engine-manage` | Start, stop, and restart the engine |
+| `files-inspect` | Inspect files artifacts |
+| `gateway` | Manage the Kurtosis gateway |
+| `grafloki` | Query Grafana and Loki observability |
+| `import-compose` | Import Docker Compose files |
+| `k8s-clean-cluster` | Clean Kurtosis resources from K8s |
+| `k8s-debug-pods` | Debug pods on Kubernetes |
+| `k8s-dev-deploy` | Build and deploy dev images to K8s |
+| `lint` | Lint the codebase |
+| `port-forward` | Forward ports from enclaves |
+| `portal` | Manage the Kurtosis portal |
+| `run-package` | Run Starlark packages |
+| `service-manage` | Manage services within enclaves |
+| `starlark-dev` | Develop Starlark packages |
+
+### Installing Skills
+
+Skills are auto-discovered by Claude Code when present in a project's `skills/` directory. There are several ways to install them:
+
+#### Option 1: Clone the repository (contributors)
+
+If you're contributing to Kurtosis, skills are already included:
+
+```bash
+git clone https://github.com/kurtosis-tech/kurtosis.git
+cd kurtosis
+```
+
+Claude Code will automatically discover the skills when you open a conversation in this directory.
+
+#### Option 2: Copy skills into your project
+
+Copy the `skills/` directory into any project where you want Claude to have Kurtosis knowledge:
+
+```bash
+# From the kurtosis repo, copy skills into your project
+cp -r /path/to/kurtosis/skills /path/to/your-project/skills
+```
+
+#### Option 3: Symlink from another project
+
+If you want to keep skills in sync with the Kurtosis repo without copying:
+
+```bash
+# Symlink the entire skills directory
+ln -s /path/to/kurtosis/skills /path/to/your-project/skills
+
+# Or symlink individual skills
+mkdir -p /path/to/your-project/skills
+ln -s /path/to/kurtosis/skills/run-package /path/to/your-project/skills/run-package
+```
+
+#### Option 4: Install globally for all projects
+
+To make Kurtosis skills available across all your Claude Code projects, add them to your global Claude configuration:
+
+```bash
+# Copy skills to your global Claude config
+cp -r /path/to/kurtosis/skills ~/.claude/skills
+```
+
+### Using Skills
+
+Once installed, skills are invoked as slash commands in Claude Code:
+
+```
+/clean          # Clean up enclaves
+/run-package    # Run a Starlark package
+/docker-debug   # Debug Docker containers
+/k8s-debug-pods # Debug Kubernetes pods
+```
+
+You can also reference skills naturally in conversation — Claude will use the relevant skill context automatically when discussing Kurtosis topics.
+
 Contributing to Kurtosis
 ========================
 

--- a/docs/docs/guides/using-claude-code-skills.md
+++ b/docs/docs/guides/using-claude-code-skills.md
@@ -1,0 +1,152 @@
+---
+title: Using Claude Code Skills
+sidebar_label: Claude Code Skills
+slug: /claude-code-skills
+sidebar_position: 16
+---
+
+This repository ships with a set of [Claude Code](https://claude.ai/download) skills — structured prompts that teach Claude how to build, debug, deploy, and manage Kurtosis. When loaded, Claude gains operational knowledge about the Kurtosis CLI, Docker and Kubernetes backends, Starlark development, and more.
+
+## What are skills?
+
+Skills are Markdown files (`SKILL.md`) in the `skills/` directory of the Kurtosis repository. Each skill contains step-by-step instructions, common flags, troubleshooting tips, and best practices for a specific area of Kurtosis. Claude Code automatically discovers and indexes these files so it can reference them during conversations.
+
+## Available skills
+
+### Core operations
+
+| Skill | Description |
+|-------|-------------|
+| `clean` | Clean up enclaves and artifacts |
+| `engine-manage` | Start, stop, restart the engine and check health |
+| `cluster-manage` | Switch between Docker and Kubernetes backends |
+| `context-manage` | Manage contexts for multiple Kurtosis environments |
+| `run-package` | Run Starlark scripts and packages with all flags |
+
+### Enclave and service management
+
+| Skill | Description |
+|-------|-------------|
+| `enclave-inspect` | List enclaves, view services, ports, and file artifacts |
+| `service-manage` | Add, stop, start, remove services; view logs and shell in |
+| `files-inspect` | Inspect, download, upload, and debug file artifacts |
+| `port-forward` | View and manage port mappings for services |
+| `dump` | Export enclave state for offline debugging |
+
+### Development and building
+
+| Skill | Description |
+|-------|-------------|
+| `starlark-dev` | Write and debug Starlark packages from scratch |
+| `cli-local-build` | Build and test the CLI from source |
+| `docker-local-build` | Build all components and Docker images locally |
+| `lint` | Lint and format Starlark files |
+| `import-compose` | Convert Docker Compose files to Starlark packages |
+
+### Kubernetes
+
+| Skill | Description |
+|-------|-------------|
+| `k8s-dev-deploy` | Build, push, and deploy dev images to a K8s cluster |
+| `k8s-debug-pods` | Diagnose Pending, CrashLoopBackOff, and scheduling issues |
+| `k8s-clean-cluster` | Force-clean orphaned Kurtosis resources from a cluster |
+| `gateway` | Start the gateway for forwarding ports to K8s services |
+
+### Debugging and observability
+
+| Skill | Description |
+|-------|-------------|
+| `docker-debug` | Inspect engine, APIC, and service logs on Docker |
+| `grafloki` | Start Grafana and Loki for centralized log collection |
+| `portal` | Manage the Portal daemon for remote context access |
+
+## Installing skills
+
+Skills are auto-discovered by Claude Code when present in a project's `skills/` directory. There are several ways to set them up depending on your workflow.
+
+### Already cloning the repo (contributors)
+
+If you're working in the Kurtosis repository, skills are already available — no extra setup needed. Claude Code discovers them automatically when you open a conversation in the repo directory.
+
+### Copy skills into another project
+
+To give Claude Kurtosis knowledge inside a different project:
+
+```bash
+cp -r /path/to/kurtosis/skills /path/to/your-project/skills
+```
+
+### Symlink from another project
+
+Keep skills in sync with the Kurtosis repo without duplicating files:
+
+```bash
+# Symlink the entire directory
+ln -s /path/to/kurtosis/skills /path/to/your-project/skills
+
+# Or symlink only the skills you need
+mkdir -p /path/to/your-project/skills
+ln -s /path/to/kurtosis/skills/run-package /path/to/your-project/skills/run-package
+ln -s /path/to/kurtosis/skills/starlark-dev /path/to/your-project/skills/starlark-dev
+```
+
+### Install globally
+
+Make Kurtosis skills available in all Claude Code sessions regardless of which project you're in:
+
+```bash
+cp -r /path/to/kurtosis/skills ~/.claude/skills
+```
+
+## Using skills
+
+Once installed, invoke a skill as a slash command in Claude Code:
+
+```
+/clean              # Clean up enclaves
+/run-package        # Run a Starlark package
+/docker-debug       # Debug Docker containers
+/k8s-debug-pods     # Debug Kubernetes pods
+/starlark-dev       # Help writing Starlark packages
+```
+
+You can also reference skills naturally in conversation. For example, asking "help me debug why my pod is stuck in Pending" will cause Claude to pull in the relevant `k8s-debug-pods` skill context automatically.
+
+### Combining skills
+
+Skills compose well together. For example, a typical development workflow might use:
+
+1. `/starlark-dev` — write a new Starlark package
+2. `/run-package` — run and test the package
+3. `/enclave-inspect` — verify the enclave looks correct
+4. `/docker-debug` or `/k8s-debug-pods` — troubleshoot any issues
+5. `/clean` — tear everything down when done
+
+## Writing new skills
+
+To add a new skill, create a `SKILL.md` file in a new subdirectory under `skills/`:
+
+```
+skills/
+  my-new-skill/
+    SKILL.md
+```
+
+The file should include YAML frontmatter with at minimum a `name` and `description`:
+
+```yaml
+---
+name: my-new-skill
+description: Short description of what this skill helps with and when to use it.
+compatibility: Any prerequisites (e.g., "Requires kurtosis CLI with a running engine.")
+metadata:
+  author: your-name
+  version: "1.0"
+---
+
+# My New Skill
+
+Instructions, commands, and tips go here...
+```
+
+Keep skills focused on a single area. Prefer concrete commands and examples over abstract explanations.


### PR DESCRIPTION
## Summary
- Adds a new "Claude Code Skills" section to the README documenting all 22 available skills
- Provides four installation methods: clone, copy, symlink, and global install
- Includes a quick-start guide for using skills as slash commands

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Confirm skill names match the `skills/` directory contents

🤖 Generated with [Claude Code](https://claude.com/claude-code)