### PR TITLE
fix(ci): allow build workflow to run on fork PRs targeting main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,8 +2,6 @@ name: Build
 
 on:
   pull_request:
-    branches-ignore:
-      - main
   push:
     branches-ignore:
       - main


### PR DESCRIPTION
## Summary

- Removes `branches-ignore: main` from the `pull_request` trigger in `build.yml`
- The Build workflow was never running on fork PRs (like #2930) because `pull_request: branches-ignore: main` blocked all PRs targeting `main`
- Same-repo PRs weren't affected because the `push` event triggered builds instead, but fork PRs don't fire `push` events on the upstream repo
- The existing `concurrency` group handles deduplication for same-repo PRs that now trigger both `push` and `pull_request`

## Test plan

- [ ] Verify this PR's own build workflow triggers via `pull_request`
- [ ] Verify fork PR #2930 gets build checks after rebase/re-push

🤖 Generated with [Claude Code](https://claude.com/claude-code)