### PR TITLE
fix: join replace local path only when it is relative

### DIFF
--- a/api/golang/core/lib/enclaves/enclave_context.go
+++ b/api/golang/core/lib/enclaves/enclave_context.go
@@ -249,7 +249,10 @@ func getPackageNameAndReplaceOptions(packageRootPath string) (string, map[string
 func (enclaveCtx *EnclaveContext) uploadLocalStarlarkPackageDependencies(packageRootPath string, packageReplaceOptions map[string]string) error {
 	for dependencyPackageId, replaceOption := range packageReplaceOptions {
 		if isLocalDependencyReplace(replaceOption) {
-			localPackagePath := path.Join(packageRootPath, replaceOption)
+			localPackagePath := replaceOption
+			if !path.IsAbs(localPackagePath) {
+				localPackagePath = path.Join(packageRootPath, localPackagePath)
+			}
 			if err := enclaveCtx.uploadStarlarkPackage(dependencyPackageId, localPackagePath); err != nil {
 				return stacktrace.Propagate(err, "Error uploading package '%s' prior to executing it", replaceOption)
 			}

--- a/api/golang/core/lib/enclaves/enclave_context_test.go
+++ b/api/golang/core/lib/enclaves/enclave_context_test.go
@@ -1,0 +1,107 @@
+/*
+ *    Copyright 2021 Kurtosis Technologies Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ */
+
+package enclaves
+
+import (
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsLocalDependencyReplace(t *testing.T) {
+	tests := []struct {
+		name     string
+		replace  string
+		expected bool
+	}{
+		{
+			name:     "absolute path",
+			replace:  "/tmp/my-package",
+			expected: true,
+		},
+		{
+			name:     "relative path with dot prefix",
+			replace:  "./my-package",
+			expected: true,
+		},
+		{
+			name:     "relative path with double dot prefix",
+			replace:  "../my-package",
+			expected: true,
+		},
+		{
+			name:     "remote github package",
+			replace:  "github.com/kurtosis-tech/postgres-package",
+			expected: false,
+		},
+		{
+			name:     "empty string",
+			replace:  "",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isLocalDependencyReplace(tt.replace)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestLocalPackagePathResolution(t *testing.T) {
+	packageRootPath := "/tmp/pkg2"
+
+	tests := []struct {
+		name          string
+		replaceOption string
+		expectedPath  string
+	}{
+		{
+			name:          "absolute path is not joined with package root",
+			replaceOption: "/tmp/pkg1",
+			expectedPath:  "/tmp/pkg1",
+		},
+		{
+			name:          "relative path is joined with package root",
+			replaceOption: "../pkg1",
+			expectedPath:  "/tmp/pkg1",
+		},
+		{
+			name:          "relative dot path is joined with package root",
+			replaceOption: "./nested/pkg1",
+			expectedPath:  "/tmp/pkg2/nested/pkg1",
+		},
+		{
+			name:          "deeply nested absolute path is preserved",
+			replaceOption: "/home/user/projects/my-package",
+			expectedPath:  "/home/user/projects/my-package",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			localPackagePath := tt.replaceOption
+			if !path.IsAbs(localPackagePath) {
+				localPackagePath = path.Join(packageRootPath, localPackagePath)
+			}
+			require.Equal(t, tt.expectedPath, localPackagePath)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Fixes absolute paths in the `replace` key of `kurtosis.yml` being incorrectly joined with the package root path
- `path.Join(packageRootPath, "/tmp/pkg1")` strips the leading `/`, producing `/tmp/pkg2/tmp/pkg1` instead of `/tmp/pkg1`
- Now only relative replace paths are joined; absolute paths are used as-is

Closes #2857.
Supersedes #2858 (taking over from @aleasims who wrote the original fix — thank you!).

## Test plan

- [ ] Run `kurtosis run` on a package that uses an absolute path in the `replace` key and verify it resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)