### PR TITLE
fix(ci): build golangci-lint from source for Go 1.26

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -71,6 +71,7 @@ jobs:
         uses: golangci/golangci-lint-action@v9
         with:
           version: ${{ env.GOLINT_VERSION }}
+          install-mode: goinstall
           working-directory: ${{ matrix.directory }}
           args: --timeout=3m
           skip-cache: true

--- a/flake.nix
+++ b/flake.nix
@@ -31,7 +31,6 @@
               goreleaser
               go_1_23
               gopls
-              golangci-lint
               delve
               enumer
               go-mockery

--- a/flake.nix
+++ b/flake.nix
@@ -29,7 +29,7 @@
                 import ./nix-pkgs/grpc-tools-node.nix { inherit pkgs; };
             in [
               goreleaser
-              go_1_23
+              unstable_pkgs.go_1_26
               gopls
               delve
               enumer

--- a/scripts/go-lint-all.sh
+++ b/scripts/go-lint-all.sh
@@ -4,4 +4,6 @@ set -euo pipefail   # Bash "strict mode"
 script_dirpath="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 root_dirpath="$(dirname "${script_dirpath}")"
 
-find $root_dirpath -type f -name 'go.mod' -exec sh -c 'dir=$(dirname "{}") && cd "$dir" && echo "$dir" && golangci-lint run' \;
+GOLINT_VERSION="v2.11.3"
+
+find $root_dirpath -type f -name 'go.mod' -exec sh -c 'dir=$(dirname "{}") && cd "$dir" && echo "$dir" && go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@'"$GOLINT_VERSION"' run' \;

--- a/scripts/go-lint-all.sh
+++ b/scripts/go-lint-all.sh
@@ -6,4 +6,4 @@ root_dirpath="$(dirname "${script_dirpath}")"
 
 GOLINT_VERSION="v2.11.3"
 
-find $root_dirpath -type f -name 'go.mod' -exec sh -c 'dir=$(dirname "{}") && cd "$dir" && echo "$dir" && go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@'"$GOLINT_VERSION"' run' \;
+find $root_dirpath -type f -name 'go.mod' -exec sh -c 'dir=$(dirname "{}") && cd "$dir" && echo "$dir" && GOTOOLCHAIN=local go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@'"$GOLINT_VERSION"' run' \;


### PR DESCRIPTION
## Summary

Upgrading to go1.26 caused golangci binary to fail with:

```
Error: can't load config: the Go language version (go1.24) used to build golangci-lint is lower than the targeted Go version (1.26.0)
Failed executing command with error: can't load config: the Go language version (go1.24) used to build golangci-lint is lower than the targeted Go version (1.26.0)
```
This PR fixes that error by:
- Adds `install-mode: goinstall` to the golangci-lint GitHub Action so it compiles golangci-lint from source using the Go 1.26 toolchain
- The latest golangci-lint release (v2.11.4) is built with Go 1.24, which errors when linting Go 1.26 code
- Updates nix flake to go_1.26

## Test plan
- [ ] Verify the golangci-lint CI job passes on this PR with Go 1.26

🤖 Generated with [Claude Code](https://claude.com/claude-code)