### PR TITLE
chore: group dependabot updates into single PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,52 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directories:
+      - "/api/golang"
+      - "/cli/cli"
+      - "/cloud/api/golang"
+      - "/connect-server"
+      - "/container-engine-lib"
+      - "/contexts-config-store"
+      - "/core/files_artifacts_expander"
+      - "/core/launcher"
+      - "/core/server"
+      - "/enclave-manager/api/golang"
+      - "/enclave-manager/server"
+      - "/engine/launcher"
+      - "/engine/server"
+      - "/grpc-file-transfer/golang"
+      - "/internal_testsuites/golang"
+      - "/kurtosis_version"
+      - "/metrics-library/golang"
+      - "/name_generator"
+      - "/path-compression"
+    schedule:
+      interval: "weekly"
+    groups:
+      all-go-deps:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "npm"
+    directories:
+      - "/api/typescript"
+      - "/docs"
+      - "/enclave-manager/web"
+      - "/engine/frontend"
+      - "/internal_testsuites/typescript"
+    schedule:
+      interval: "weekly"
+    groups:
+      all-npm-deps:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      all-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` with grouped update configuration
- All **Go module** updates across 19 directories → single PR (`all-go-deps` group)
- All **npm** updates across 5 directories → single PR (`all-npm-deps` group)
- All **GitHub Actions** updates → single PR (`all-actions` group)
- Weekly schedule for all ecosystems

This prevents dependabot from opening dozens of individual PRs for each package bump.

## Test plan
- [ ] Verify dependabot picks up the config after merge (next weekly run or manual trigger)

🤖 Generated with [Claude Code](https://claude.com/claude-code)