### PR TITLE
fix: pass node selectors and tolerations to availability-check-pod

### DIFF
--- a/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_aggregator_functions/create_logs_aggregator.go
+++ b/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_aggregator_functions/create_logs_aggregator.go
@@ -75,7 +75,7 @@ func CreateLogsAggregator(
 	logrus.Debugf("Checking for logs aggregator availability in namespace '%v'...", kubernetesResources.namespace.Name)
 
 	healthCheckEndpoint, healthCheckPortNum := logsAggregatorResourcesManager.GetHTTPHealthCheckEndpointAndPort()
-	if err = waitForLogsAggregatorAvailability(ctx, healthCheckEndpoint, healthCheckPortNum, kubernetesResources, kubernetesManager); err != nil {
+	if err = waitForLogsAggregatorAvailability(ctx, healthCheckEndpoint, healthCheckPortNum, kubernetesResources, kubernetesManager, nodeSelector, tolerations); err != nil {
 		return nil, removeLogsAggregatorFunc, stacktrace.Propagate(err, "An error occurred while waiting for the logs aggregator deployment to become available")
 	}
 	logrus.Debugf("...logs aggregator is available in namepsace '%v'", kubernetesResources.namespace.Name)

--- a/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_aggregator_functions/shared_helpers.go
+++ b/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_kurtosis_backend/logs_aggregator_functions/shared_helpers.go
@@ -247,6 +247,8 @@ func waitForLogsAggregatorAvailability(
 	healthCheckPortNum uint16,
 	k8sResources *logsAggregatorKubernetesResources,
 	kubernetesManager *kubernetes_manager.KubernetesManager,
+	nodeSelectors map[string]string,
+	tolerations []apiv1.Toleration,
 ) error {
 	availabilityCheckerNamespace := k8sResources.namespace.Name
 	aggregatorHost := k8sResources.service.Spec.ClusterIP
@@ -294,7 +296,7 @@ func waitForLogsAggregatorAvailability(
 				StdinOnce:                false,
 				TTY:                      false,
 			},
-		}, nil, "", apiv1.RestartPolicyNever, nil, nil)
+		}, nil, "", apiv1.RestartPolicyNever, tolerations, nodeSelectors)
 	if err != nil {
 		return stacktrace.Propagate(err, "An error occurred creating pod '%v' in namespace '%v'.", availabilityCheckPodName, availabilityCheckerNamespace)
 	}


### PR DESCRIPTION
## Summary
- The `availability-check-pod` created during logs aggregator health checks was missing `nodeSelectors` and `tolerations`, causing it to be scheduled on arbitrary nodes
- On clusters with unhealthy nodes (e.g. broken kubelet proxy), this causes `engine start` to fail with health check timeouts even though the logs aggregator itself is healthy
- Now passes the same `nodeSelectors` and `tolerations` from the kurtosis config to the availability-check-pod's `CreatePod` call

## Test plan
- [x] Built and deployed to k8s cluster with `node-selectors` and `tolerations` configured
- [x] Verified `engine start` succeeds with the fix (previously failed due to pod landing on unhealthy node)
- [x] Ran `ethereum-package` end-to-end on k8s successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)