### PR TITLE
fix: correct malformed markdown link in docs

### DIFF
--- a/docs/docs/guides/how-to-compose-your-own-testnet.md
+++ b/docs/docs/guides/how-to-compose-your-own-testnet.md
@@ -211,7 +211,7 @@ The ethereum-package supports hundreds of configurations, including:
 - Mocking gas prices and block times
 - Pre-funding specific wallet addresses
 
-Configuration is accomplished by modifying the `network_params.yaml` file. An extensive list of customization options can be found in the (ethereum-package documentation)[https://github.com/ethpandaops/ethereum-package/tree/main?tab=readme-ov-file#configuration].
+Configuration is accomplished by modifying the `network_params.yaml` file. An extensive list of customization options can be found in the [ethereum-package documentation](https://github.com/ethpandaops/ethereum-package/tree/main?tab=readme-ov-file#configuration).
 
 In addition, ready-to-go configuration files are available as [examples](https://github.com/ethpandaops/ethereum-package/tree/main/examples).
 


### PR DESCRIPTION
## Description

Fixes a malformed markdown link in the testnet composition guide that was causing the docs build to fail. The link used `(text)[url]` syntax instead of the correct `[text](url)`, which `remark-lint` flagged as an undefined reference.

## REMINDER: Tag Reviewers, so they get notified to review

## Is this change user facing?
NO

## References (if applicable)