### PR TITLE
build: include build commits in release-please changelog

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,6 +5,19 @@
   "bump-patch-for-minor-pre-major": true,
   "include-v-in-tag": false,
   "include-component-in-tag": false,
+  "changelog-sections": [
+    {"type": "feat", "section": "Features"},
+    {"type": "fix", "section": "Bug Fixes"},
+    {"type": "build", "section": "Build System", "hidden": false},
+    {"type": "perf", "section": "Performance Improvements"},
+    {"type": "revert", "section": "Reverts"},
+    {"type": "docs", "section": "Documentation", "hidden": true},
+    {"type": "style", "section": "Styles", "hidden": true},
+    {"type": "chore", "section": "Miscellaneous Chores", "hidden": true},
+    {"type": "refactor", "section": "Code Refactoring", "hidden": true},
+    {"type": "test", "section": "Tests", "hidden": true},
+    {"type": "ci", "section": "Continuous Integration", "hidden": true}
+  ],
   "packages": {
     ".": {
       "package-name": "kurtosis"


### PR DESCRIPTION
## Summary
- Adds `changelog-sections` to `release-please-config.json` so that `build` type commits (e.g. dependency bumps from dependabot) are treated as user-facing and trigger release PRs
- Without this, `build(deps):` commits were silently skipped by release-please

## Test plan
- [x] After merge, verify release-please opens a new release PR that includes the recent `build(deps): Bump go.opentelemetry.io/otel/sdk` commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)