### PR TITLE
ci: verify NPM token before publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,27 +17,14 @@ jobs:
   # Verify Secrets
   # ============================================================================
   verify-npm-token:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
-        with:
-          node-version: ${{ env.API_NODE_VERSION }}
-          registry-url: 'https://registry.npmjs.org'
-
-      - name: Verify NPM Access Token
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPMJS_AUTH_TOKEN }}
-        run: |
-          if ! npm whoami --registry https://registry.npmjs.org 2>/dev/null; then
-            echo "::error::NPM access token is invalid or expired. Please update the NPMJS_AUTH_TOKEN secret."
-            exit 1
-          fi
-          echo "NPM token is valid (authenticated as $(npm whoami --registry https://registry.npmjs.org))"
+    uses: ./.github/workflows/verify-npm-token.yml
+    secrets: inherit
 
   # ============================================================================
   # Publish SDK/API Packages
   # ============================================================================
   publish-kurtosis-sdk-rust:
+    needs: verify-npm-token
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -104,6 +91,7 @@ jobs:
   # Publish Docker Images
   # ============================================================================
   publish-files-artifacts-expander-image:
+    needs: verify-npm-token
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -151,6 +139,7 @@ jobs:
           scripts/docker-image-builder.sh "${push_to_dockerhub}" "${dockerfile_filepath}" "${podman_mode}" "${image_name_with_version}" "${image_name_to_publish_semver}" "${image_name_to_publish_latest}"
 
   publish-api-container-server-image:
+    needs: verify-npm-token
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -203,6 +192,7 @@ jobs:
           scripts/docker-image-builder.sh "${push_to_dockerhub}" "${dockerfile_filepath}" "${podman_mode}" "${image_name_with_version}" "${image_name_to_publish_semver}" "${image_name_to_publish_latest}"
 
   build-enclave-manager-webapp:
+    needs: verify-npm-token
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -232,7 +222,9 @@ jobs:
 
   publish-engine-server-image:
     runs-on: ubuntu-latest
-    needs: build-enclave-manager-webapp
+    needs:
+      - verify-npm-token
+      - build-enclave-manager-webapp
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,27 @@ env:
 
 jobs:
   # ============================================================================
+  # Verify Secrets
+  # ============================================================================
+  verify-npm-token:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: ${{ env.API_NODE_VERSION }}
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Verify NPM Access Token
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPMJS_AUTH_TOKEN }}
+        run: |
+          if ! npm whoami --registry https://registry.npmjs.org 2>/dev/null; then
+            echo "::error::NPM access token is invalid or expired. Please update the NPMJS_AUTH_TOKEN secret."
+            exit 1
+          fi
+          echo "NPM token is valid (authenticated as $(npm whoami --registry https://registry.npmjs.org))"
+
+  # ============================================================================
   # Publish SDK/API Packages
   # ============================================================================
   publish-kurtosis-sdk-rust:
@@ -34,6 +55,7 @@ jobs:
           cargo publish
 
   publish-kurtosis-api-typescript:
+    needs: verify-npm-token
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -53,6 +75,7 @@ jobs:
         run: npm publish
 
   publish-kurtosis-ui-libs:
+    needs: verify-npm-token
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/verify-npm-token.yml
+++ b/.github/workflows/verify-npm-token.yml
@@ -1,6 +1,7 @@
 name: Verify NPM Token
 
 on:
+  workflow_call:
   pull_request:
     branches: [main]
     paths:
@@ -10,7 +11,7 @@ on:
 jobs:
   verify-npm-token:
     runs-on: ubuntu-latest
-    if: startsWith(github.head_ref, 'release-please--')
+    if: ${{ github.event_name == 'workflow_call' || startsWith(github.head_ref, 'release-please--') }}
     steps:
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:

--- a/.github/workflows/verify-npm-token.yml
+++ b/.github/workflows/verify-npm-token.yml
@@ -1,0 +1,28 @@
+name: Verify NPM Token
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'version.txt'
+      - '.release-please-manifest.json'
+
+jobs:
+  verify-npm-token:
+    runs-on: ubuntu-latest
+    if: startsWith(github.head_ref, 'release-please--')
+    steps:
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: '22.16.0'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Verify NPM Access Token
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPMJS_AUTH_TOKEN }}
+        run: |
+          if ! npm whoami --registry https://registry.npmjs.org 2>/dev/null; then
+            echo "::error::NPM access token is invalid or expired. Please update the NPMJS_AUTH_TOKEN secret."
+            exit 1
+          fi
+          echo "NPM token is valid (authenticated as $(npm whoami --registry https://registry.npmjs.org))"


### PR DESCRIPTION
## Summary
- Adds a `verify-npm-token` job to the publish workflow that validates `NPMJS_AUTH_TOKEN` using `npm whoami` before any publish jobs run
- Adds a new `verify-npm-token.yml` workflow that runs the same check on release PRs (branches matching `release-please--*` that modify `version.txt` or `.release-please-manifest.json`)
- All publish jobs (`publish-kurtosis-api-typescript`, `publish-kurtosis-ui-libs`, etc.) now depend on the verification job

## Test plan
- [ ] Verify the publish workflow still runs correctly on a tag push
- [ ] Verify the new workflow triggers on release-please PRs
- [ ] Confirm that an invalid token causes the verification step to fail with a clear error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)