### PR TITLE
fix(ci): fix verify-npm-token job being skipped during publish

### DIFF
--- a/.github/workflows/verify-npm-token.yml
+++ b/.github/workflows/verify-npm-token.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   verify-npm-token:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'workflow_call' || startsWith(github.head_ref, 'release-please--') }}
+    if: ${{ github.event_name != 'pull_request' || startsWith(github.head_ref, 'release-please--') }}
     steps:
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:


### PR DESCRIPTION
## Description

The `verify-npm-token` reusable workflow's `if` condition checked for `github.event_name == 'workflow_call'`, but when called as a reusable workflow from `publish.yml` (triggered by a tag push), the `github.event_name` is inherited from the caller as `push`, not `workflow_call`. This caused released job to be skipped.