### PR TITLE
fix(ci): add -lresolv to static link flags for Linux CLI build

### DIFF
--- a/cli/cli/.goreleaser.yml
+++ b/cli/cli/.goreleaser.yml
@@ -34,8 +34,11 @@ builds:
           {{- end }}
         {{- end }}
     ldflags:
+      # -lresolv is needed because Go 1.26+ pulls in res_search via the cgo
+      # DNS resolver. Without it, static linking fails with
+      # "undefined reference to res_search".
       - >-
-        {{- if eq .Os "linux" }}-linkmode external -extldflags "-static"{{- end }}
+        {{- if eq .Os "linux" }}-linkmode external -extldflags "-static -lresolv"{{- end }}
     tags:
       - osusergo
 # In order for releasing-to-Github to work, we have to create these archives


### PR DESCRIPTION
## Description

Go 1.26.0 pulls in `res_search` via the cgo DNS resolver, causing the Linux static CLI build to fail with `undefined reference to res_search` when linking with g++. This adds `-lresolv` to the goreleaser `extldflags` for Linux builds to resolve the missing symbol.

## REMINDER: Tag Reviewers, so they get notified to review

## Is this change user facing?
NO

## References (if applicable)
Related to #2978 which upgraded Go to 1.26.0 in the CLI publish workflow.