### PR TITLE
fix: replace deprecated goreleaser changelog.skip

### DIFF
--- a/cli/cli/.goreleaser.yml
+++ b/cli/cli/.goreleaser.yml
@@ -157,4 +157,4 @@ snapshot:
   name_template: "{{ .Env.VERSION }}"
 changelog:
   # We manage our own changelog
-  skip: true
+  disable: true


### PR DESCRIPTION
## Summary
- Replaces `changelog.skip: true` with `changelog.disable: true` in goreleaser config
- Fixes deprecation warning: `DEPRECATED: changelog.skip should not be used anymore`

## Test plan
- [x] CI passes without deprecation warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)