### PR TITLE
fix: kurtosis dump fails with permission denied on restrictive file artifacts

### DIFF
--- a/path-compression/go.mod
+++ b/path-compression/go.mod
@@ -3,7 +3,6 @@ module github.com/kurtosis-tech/kurtosis/path-compression
 go 1.26.0
 
 require (
-	github.com/jm33-m0/arc/v2 v2.0.1
 	github.com/kurtosis-tech/stacktrace v0.0.0-20211028211901-1c67a77b5409
 	github.com/mholt/archives v0.1.5
 	github.com/sirupsen/logrus v1.9.4

--- a/path-compression/go.sum
+++ b/path-compression/go.sum
@@ -74,8 +74,6 @@ github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
-github.com/jm33-m0/arc/v2 v2.0.1 h1:vEFs1706MRpQ430O78qS9h+wYzp9oSjlM6c70X9l+Ug=
-github.com/jm33-m0/arc/v2 v2.0.1/go.mod h1:Dzf3wxVdcaFZla5y3aZwdNUkE6Im2H+ubCGSRP45Obs=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=

--- a/path-compression/path_compression.go
+++ b/path-compression/path_compression.go
@@ -3,13 +3,13 @@ package path_compression
 import (
 	"context"
 	"crypto/md5"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
 
-	"github.com/jm33-m0/arc/v2"
 	"github.com/kurtosis-tech/stacktrace"
 	"github.com/mholt/archives"
 
@@ -17,6 +17,7 @@ import (
 )
 
 const (
+	extractDirPermissions     = 0755
 	kurtosisDataTransferLimit = 2000 * 1024 * 1024 // ~2 GB
 	tempCompressionDirPattern = "upload-compression-cache-"
 	compressionExtension      = ".tgz"
@@ -243,10 +244,73 @@ func mapFilePathOnDiskToRelativePathInArchive(pathToCompress string, filesToUplo
 	return filenameMappings
 }
 
-// Unarchive is a drop in replacement for mholt/archiver.Unarchive
-// mholt/archiver was updated to mholt/archives in Kurtosis due to https://nvd.nist.gov/vuln/detail/CVE-2025-3445
-// The successor to mholt/archiver is mholt/archives but because it doesn't have an Unarchive function, we reimplement it here
-// Implementation is from: https://github.com/jm33-m0/arc
+// Unarchive extracts an archive to a destination directory.
+// Unlike the previous arc.Unarchive implementation, directories are always
+// created with 0755 permissions (matching the old mholt/archiver behavior).
+// This prevents "permission denied" errors when archives contain directories
+// with restrictive permissions (e.g. validator secrets with 0500).
 func Unarchive(source, destination string) error {
-	return arc.Unarchive(source, destination)
+	archiveFile, err := os.Open(source)
+	if err != nil {
+		return fmt.Errorf("open archive %s: %w", source, err)
+	}
+	defer archiveFile.Close()
+
+	format, input, err := archives.Identify(context.Background(), source, archiveFile)
+	if err != nil {
+		return fmt.Errorf("identify format: %w", err)
+	}
+
+	extractor, ok := format.(archives.Extractor)
+	if !ok {
+		return fmt.Errorf("unsupported format for extraction")
+	}
+
+	if err := os.MkdirAll(destination, extractDirPermissions); err != nil {
+		return fmt.Errorf("creating destination directory: %w", err)
+	}
+
+	handler := func(ctx context.Context, f archives.FileInfo) error {
+		clean := filepath.Clean("/" + f.NameInArchive)
+		relative := strings.TrimPrefix(clean, string(os.PathSeparator))
+		dstPath := filepath.Join(destination, relative)
+
+		if !strings.HasPrefix(filepath.Clean(dstPath)+string(os.PathSeparator), filepath.Clean(destination)+string(os.PathSeparator)) {
+			return fmt.Errorf("illegal file path: %s", dstPath)
+		}
+
+		if f.IsDir() {
+			return os.MkdirAll(dstPath, extractDirPermissions)
+		}
+
+		if f.LinkTarget != "" {
+			return nil
+		}
+
+		if err := os.MkdirAll(filepath.Dir(dstPath), extractDirPermissions); err != nil {
+			return fmt.Errorf("mkdir: %w", err)
+		}
+
+		reader, err := f.Open()
+		if err != nil {
+			return fmt.Errorf("open file: %w", err)
+		}
+		defer reader.Close()
+
+		out, err := os.OpenFile(dstPath, os.O_CREATE|os.O_WRONLY, f.Mode())
+		if err != nil {
+			return fmt.Errorf("create file: %w", err)
+		}
+		defer out.Close()
+
+		if _, err := io.Copy(out, reader); err != nil {
+			return fmt.Errorf("copy: %w", err)
+		}
+		return nil
+	}
+
+	if err := extractor.Extract(context.Background(), input, handler); err != nil {
+		return fmt.Errorf("extracting files: %w", err)
+	}
+	return nil
 }


### PR DESCRIPTION
## Summary
- Fixes `kurtosis dump` failing with "permission denied" when extracting file artifacts that contain directories with restrictive permissions (e.g. validator secrets with `0500`)
- Replaces `jm33-m0/arc.Unarchive` with a custom implementation that always creates directories with `0755`, matching the old `mholt/archiver` behavior
- The `arc` library preserved original directory permissions from the archive, which meant directories like `secrets/` were created with read-only perms, then subsequent file writes into them failed
- Removes the `jm33-m0/arc` dependency entirely

## Regression
Introduced in #2947 (replace deprecated mholt/archiver with mholt/archives). The old `mholt/archiver` always used `os.MkdirAll(path, 0755)` for directories, while the replacement `arc` library used `f.Mode()` from the archive.

## Test plan
- [x] `go test ./...` passes in path-compression
- [x] CI passes
- [x] `kurtosis dump` works on an enclave with validator secrets (ethereum-package k8s test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)