### PR TITLE
fix: use pull_request_target for dependabot auto-merge

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,5 +1,5 @@
 name: Dependabot auto-approve
-on: pull_request
+on: pull_request_target
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
## Description

Allows auto merging of dependabot Prs.
