### PR TITLE
docs: update upgrade guide with sdk.kurtosis.com repo URLs

### DIFF
--- a/cli/cli/commands/root.go
+++ b/cli/cli/commands/root.go
@@ -217,7 +217,15 @@ func checkCLIVersion(cmd *cobra.Command) {
 	}
 
 	if !isLatestVersion {
-		logrus.Warningf("You are running an old version of the Kurtosis CLI; we suggest you to update it to the latest version, '%v'. You can manually upgrade the CLI tool following these instructions: %v", latestVersion, user_support_constants.UpgradeCLIInstructionsPage)
+		upgradeMsg := fmt.Sprintf("You are running an old version of the Kurtosis CLI; we suggest you to update it to the latest version, '%v'. You can manually upgrade the CLI tool following these instructions: %v", latestVersion, user_support_constants.UpgradeCLIInstructionsPage)
+
+		gemfuryMaxVersion := semver.MustParse("1.15.6")
+		currentVersion, parseErr := semver.NewVersion(kurtosis_version.KurtosisVersion)
+		if parseErr == nil && !currentVersion.GreaterThan(gemfuryMaxVersion) {
+			upgradeMsg += " . If using apt/yum, ensure your repo points to sdk.kurtosis.com (the old Gemfury repo is no longer supported)."
+		}
+
+		logrus.Warning(upgradeMsg)
 	}
 }
 

--- a/cli/cli/commands/root.go
+++ b/cli/cli/commands/root.go
@@ -217,15 +217,7 @@ func checkCLIVersion(cmd *cobra.Command) {
 	}
 
 	if !isLatestVersion {
-		upgradeMsg := fmt.Sprintf("You are running an old version of the Kurtosis CLI; we suggest you to update it to the latest version, '%v'. You can manually upgrade the CLI tool following these instructions: %v", latestVersion, user_support_constants.UpgradeCLIInstructionsPage)
-
-		gemfuryMaxVersion := semver.MustParse("1.15.6")
-		currentVersion, parseErr := semver.NewVersion(kurtosis_version.KurtosisVersion)
-		if parseErr == nil && !currentVersion.GreaterThan(gemfuryMaxVersion) {
-			upgradeMsg += " . If using apt/yum, ensure your repo points to sdk.kurtosis.com (the old Gemfury repo is no longer supported)."
-		}
-
-		logrus.Warning(upgradeMsg)
+		logrus.Warningf("You are running an old version of the Kurtosis CLI; we suggest you to update it to the latest version, '%v'. You can manually upgrade the CLI tool following these instructions: %v", latestVersion, user_support_constants.UpgradeCLIInstructionsPage)
 	}
 }
 

--- a/docs/docs/guides/upgrading-the-cli.md
+++ b/docs/docs/guides/upgrading-the-cli.md
@@ -16,6 +16,20 @@ The instructions in this guide assume you already have Kurtosis installed, and w
 
 If you're looking to install Kurtosis, [see here][install-guide].
 
+:::warning Migrating from Gemfury?
+The old Gemfury-hosted apt/yum repositories (`apt.fury.io/kurtosis-tech` and `yum.fury.io/kurtosis-tech`) are **no longer supported**. If you previously installed Kurtosis via Gemfury, switch to the new repository before upgrading:
+
+**apt (Ubuntu/Debian):**
+```bash
+echo "deb [trusted=yes] https://sdk.kurtosis.com/kurtosis-cli-release-artifacts/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list && sudo apt update
+```
+
+**yum (RHEL/CentOS):**
+```bash
+sudo sed -i 's|https://yum.fury.io/kurtosis-tech/|https://sdk.kurtosis.com/kurtosis-cli-release-artifacts/rpm/|' /etc/yum.repos.d/kurtosis.repo && sudo yum makecache
+```
+:::
+
 I. Check breaking changes
 ---------------------------------
 You can check the version of the CLI you're running with `kurtosis version`. Before upgrading to the latest version, check [the changelog to see if there are any breaking changes][cli-changelog] before proceeding with the steps below to upgrade.
@@ -33,12 +47,6 @@ brew update && brew upgrade kurtosis-tech/tap/kurtosis-cli
 </TabItem>
 <TabItem value="apt" label="apt (Ubuntu)">
 
-First, ensure your apt source points to the current repository:
-```bash
-echo "deb [trusted=yes] https://sdk.kurtosis.com/kurtosis-cli-release-artifacts/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
-```
-
-Then upgrade:
 ```bash
 sudo apt update && sudo apt install --only-upgrade kurtosis-cli
 ```
@@ -46,16 +54,6 @@ sudo apt update && sudo apt install --only-upgrade kurtosis-cli
 </TabItem>
 <TabItem value="yum" label="yum (RHEL)">
 
-First, ensure your yum repo points to the current repository:
-```bash
-echo '[kurtosis]
-name=Kurtosis
-baseurl=https://sdk.kurtosis.com/kurtosis-cli-release-artifacts/rpm/
-enabled=1
-gpgcheck=0' | sudo tee /etc/yum.repos.d/kurtosis.repo
-```
-
-Then upgrade:
 ```bash
 sudo yum makecache && sudo yum upgrade kurtosis-cli
 ```

--- a/docs/docs/guides/upgrading-the-cli.md
+++ b/docs/docs/guides/upgrading-the-cli.md
@@ -33,15 +33,31 @@ brew update && brew upgrade kurtosis-tech/tap/kurtosis-cli
 </TabItem>
 <TabItem value="apt" label="apt (Ubuntu)">
 
+First, ensure your apt source points to the current repository:
 ```bash
-apt update && apt install --only-upgrade kurtosis-cli
+echo "deb [trusted=yes] https://sdk.kurtosis.com/kurtosis-cli-release-artifacts/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
+```
+
+Then upgrade:
+```bash
+sudo apt update && sudo apt install --only-upgrade kurtosis-cli
 ```
 
 </TabItem>
 <TabItem value="yum" label="yum (RHEL)">
 
+First, ensure your yum repo points to the current repository:
 ```bash
-yum update && upgrade kurtosis-cli
+echo '[kurtosis]
+name=Kurtosis
+baseurl=https://sdk.kurtosis.com/kurtosis-cli-release-artifacts/rpm/
+enabled=1
+gpgcheck=0' | sudo tee /etc/yum.repos.d/kurtosis.repo
+```
+
+Then upgrade:
+```bash
+sudo yum makecache && sudo yum upgrade kurtosis-cli
 ```
 
 </TabItem>


### PR DESCRIPTION
## Summary
- Updates the CLI upgrade guide (`/upgrade`) to include the current `sdk.kurtosis.com` repository URLs for apt and yum
- Users following the upgrade instructions (e.g. from the CLI warning pointing to https://docs.kurtosis.com/upgrade) now get the correct repo setup steps before running the upgrade commands
- Fixes the `yum` tab which had a broken command (`yum update && upgrade kurtosis-cli` → `sudo yum makecache && sudo yum upgrade kurtosis-cli`)

## Test plan
- [ ] Verify the docs build successfully
- [ ] Confirm apt and yum commands are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)