### PR TITLE
fix(engine): use heredoc instead of printf to write Docker config storage

### DIFF
--- a/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/engine_functions/docker_config_storage_creator/docker_config_storage_creator.go
+++ b/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/engine_functions/docker_config_storage_creator/docker_config_storage_creator.go
@@ -21,7 +21,11 @@ const (
 
 	shBinaryFilepath = "/bin/sh"
 	shCmdFlag        = "-c"
-	printfCmdName    = "printf"
+
+	// Delimiter for the heredoc that writes the config.json. The content
+	// (a JSON document) cannot contain this delimiter on a line by itself,
+	// so this is safe against arbitrary JSON payloads.
+	heredocDelimiter = "KURTOSIS_DOCKER_CONFIG_EOF"
 
 	creationSuccessExitCode = 0
 
@@ -132,12 +136,28 @@ func storeConfigInVolume(
 		return stacktrace.NewError("An error occurred marshalling the Docker config into JSON: %v", err)
 	}
 
-	// Write the config.json to the volume
+	// Write the config.json to the volume using a heredoc with a
+	// single-quoted delimiter so the JSON content is copied verbatim and
+	// never interpreted by the shell.
+	//
+	// Historically this used `printf '<JSON>' > <path>`, which broke when
+	// the host's Docker config contained URL-encoded characters — most
+	// notably a GCP Artifact Registry service-account login, whose
+	// _json_key password embeds a `client_x509_cert_url` field containing
+	// `%40` (URL-encoded `@`). busybox printf inside the alpine:3.17 helper
+	// parses `%40m` as a format directive with conversion character `m`
+	// (invalid) and exits non-zero, failing engine startup with a confusing
+	// "Docker config storage creation didn't return success" error.
+	//
+	// Using `cat` with a single-quoted heredoc delimiter avoids any format
+	// string or parameter expansion over the payload.
+	configFileFullPath := fmt.Sprintf("%s/%s", storageDirPath, configFilePath)
 	commandStr := fmt.Sprintf(
-		"%v '%v' > %v",
-		printfCmdName,
+		"cat > %s <<'%s'\n%s\n%s",
+		configFileFullPath,
+		heredocDelimiter,
 		string(cfgJsonStr),
-		fmt.Sprintf("%s/%s", storageDirPath, configFilePath),
+		heredocDelimiter,
 	)
 
 	execCmd := []string{


### PR DESCRIPTION
## Summary

`CreateDockerConfigStorage` writes the host's Docker registry credentials into a volume by running

```
sh -c 'printf "<JSON>" > /root/.docker/config.json'
```

inside an `alpine:3.17` helper. The JSON content is passed to `printf` **as a format string**, so any `%NN` sequence in the credentials is parsed as a printf format directive. If it isn't terminated by a valid conversion character, busybox printf exits non-zero with `invalid format`, and engine startup aborts with:

> `The Docker config storage creation didn't return success (as measured by the command 'printf '<JSON>' > /root/.docker//config.json') even after retrying 2 times with 200ms between retries`

## Impact

Anyone with a **GCP Artifact Registry login** in `~/.docker/config.json` (e.g. from `gcloud auth configure-docker <region>-docker.pkg.dev`) cannot start the engine.

GCP stores the service-account login as a `_json_key` auth whose decoded password embeds an entire JSON key document. That document includes a `client_x509_cert_url` field which **URL-encodes the service-account email** — `ethereum-storage@molten-verve-216720.iam.gserviceaccount.com` becomes `…ethereum-storage%40molten-verve-216720…`. `printf` sees `%40m` (next char is `m` in "molten"), parses `%40` as a width spec looking for a conversion char, hits `m` (not a valid printf conversion), and exits 1.

## Secondary concern — credential leak in error

The existing error message dumps `commandStr` verbatim, which means the full decoded JSON — **including the service-account private key** — gets written to user-facing stderr. With the heredoc fix, the content still appears in the error string, so a follow-up PR to redact or truncate that (or to use `docker exec` with stdin so the payload never goes through the shell command line) would be worthwhile. Happy to take that on separately.

## Fix

Switch from `printf` to `cat` with a **single-quoted heredoc delimiter**. Single quotes suppress parameter expansion and command substitution inside the body, and `cat` performs no format parsing — so the payload is copied verbatim regardless of what `%`, `$`, backticks, or backslashes it contains.

```diff
-	"%v '%v' > %v",
-	printfCmdName,
+	"cat > %s <<'%s'\n%s\n%s",
+	configFileFullPath,
+	heredocDelimiter,
 	string(cfgJsonStr),
-	fmt.Sprintf("%s/%s", storageDirPath, configFilePath),
+	heredocDelimiter,
```

`json.Marshal` never emits raw newlines (all control characters in string values are escaped as `\uNNNN`), so the delimiter `KURTOSIS_DOCKER_CONFIG_EOF` cannot appear on a line by itself inside a valid JSON payload.

## Reproduction

On a fresh host:

```sh
gcloud auth configure-docker us-central1-docker.pkg.dev
kurtosis engine start
```

Before this change → fails with the error above.
After this change → engine starts cleanly.

Verified with a literal `%40` payload against unpatched `alpine:3.17`:

```sh
$ docker run --rm alpine:3.17 sh -c \"printf '{\\\"url\\\":\\\"a%40b\\\"}' > /tmp/x; echo \$?\"
sh: %40b\"}: invalid format
1

$ docker run --rm alpine:3.17 sh -c \"cat > /tmp/x <<'KURTOSIS_DOCKER_CONFIG_EOF'
{\\\"url\\\":\\\"a%40b\\\"}
KURTOSIS_DOCKER_CONFIG_EOF
cat /tmp/x; echo \$?\"
{\"url\":\"a%40b\"}
0
```

## Test plan

- [x] `go build ./container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/engine_functions/docker_config_storage_creator/` succeeds
- [x] Heredoc correctly writes payloads containing `%NN`, unchanged by busybox sh's format parser
- [x] Manual end-to-end: `kurtosis engine start` on a host with a GCP Artifact Registry login (previously failed) now succeeds
- [ ] Maintainers to confirm no existing unit/integration tests need updating

Happy to iterate on naming, the delimiter constant, or to add a regression test for credentials containing `%NN`.