### PR TITLE
feat(packages): recurse git submodules when cloning packages

### DIFF
--- a/core/server/api_container/server/startosis_engine/startosis_packages/git_package_content_provider/git_package_content_provider.go
+++ b/core/server/api_container/server/startosis_engine/startosis_packages/git_package_content_provider/git_package_content_provider.go
@@ -437,7 +437,7 @@ func (provider *GitPackageContentProvider) cloneWithRetries(parsedURL *shared_ut
 			SingleBranch:      false,
 			NoCheckout:        false,
 			Depth:             depth,
-			RecurseSubmodules: 0,
+			RecurseSubmodules: git.DefaultSubmoduleRecursionDepth,
 			Progress:          io.Discard,
 			Tags:              0,
 			InsecureSkipTLS:   false,


### PR DESCRIPTION
## What

Set `RecurseSubmodules` to `git.DefaultSubmoduleRecursionDepth` (10) instead of `0` when Kurtosis clones a remote package via `git.PlainClone` in `cloneWithRetries`.

## Why

Today, package authors can't vendor dependencies via git submodules — Kurtosis clones the parent repo without populating submodule directories, so any local-path `replace:` directives pointing into submodule paths break for remote consumers.

Concrete use case: making [`ethpandaops/ethereum-package`](https://github.com/ethpandaops/ethereum-package) runnable fully offline. It depends on three external Kurtosis packages (`postgres-package`, `redis-package`, `prometheus-package`) via `import_module(...)`. With this change, those can be vendored as submodules and redirected via `replace:` in `kurtosis.yml`, working transparently for both local and remote consumers.

## Trade-offs

- Clones with submodules become slightly slower. Packages without submodules are unaffected (no `.gitmodules` → nothing to recurse).
- Submodule auth uses the same `githubAuth` already passed to `PlainClone`, so private submodules behave like the parent.
- Alternative: add an opt-in `recurse_submodules: true` field to `kurtosis.yml`. Happy to take this direction instead if preferred.

## Testing

`cloneWithRetries` isn't exercised in the existing unit test suite (would need a live git server). Verified manually by adding a submodule to a test package and confirming files present after `kurtosis run github.com/...`.