### PR TITLE
docs: add docusaurus-plugin-copy-page-button for AI-assisted workflows

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -23,6 +23,8 @@ const config = {
 		locales: ['en'],
 	},
 
+	plugins: ['docusaurus-plugin-copy-page-button'],
+
 	presets: [
 		[
 			'classic',

--- a/docs/package.json
+++ b/docs/package.json
@@ -20,6 +20,7 @@
     "@docusaurus/preset-classic": "^3.7.0",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.0.0",
+    "docusaurus-plugin-copy-page-button": "^0.4.2",
     "prism-react-renderer": "^2.3.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4"


### PR DESCRIPTION
## What this adds

A "Copy page" button in the docs sidebar that exports the current Kurtosis docs page as clean markdown, with one-click "Open in ChatGPT", "Open in Claude", and "Open in Gemini" actions.

## Why for Kurtosis

Kurtosis users hit AI tools constantly when authoring Starlark and YAML for distributed system test setups. A page like the [Starlark reference](https://docs.kurtosis.com/starlark-reference) or the CLI docs is exactly the kind of context devs paste into Claude or ChatGPT to get a working enclave config. This makes that handoff a single click instead of "select all → strip out the nav → paste."

The plugin is already shipping on a bunch of dev infra and L1 docs: Ethereum execution-apis, Sui (Mysten Labs), Walrus, Seal, SuiNS, Monad, Flare, Kaia, Nillion, and Chronicle. ~10k npm installs/month.

## Changes

- Adds `docusaurus-plugin-copy-page-button` to `docs/package.json` dependencies
- Adds the plugin to a new `plugins` array in `docs/docusaurus.config.js`

The button auto-injects into the table-of-contents sidebar. No further config required, theme-aware, mobile-friendly.

## Links

- Live demo: https://portdeveloper.github.io/copy-page-button-showcase/
- Plugin repo: https://github.com/portdeveloper/docusaurus-plugin-copy-page-button
- npm: https://www.npmjs.com/package/docusaurus-plugin-copy-page-button

Happy to revert or adjust if this doesn't fit the project's direction.