### PR TITLE
fix: bump path-compression pin so api/golang builds for external consumers

### DIFF
--- a/api/golang/go.mod
+++ b/api/golang/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/kurtosis-tech/kurtosis/cloud/api/golang v0.0.0-20230803130419-099ee7a4e3dc
 	github.com/kurtosis-tech/kurtosis/contexts-config-store v0.0.0-20230818184218-f4e3e773463b
 	github.com/kurtosis-tech/kurtosis/grpc-file-transfer/golang v0.0.0-20230803130419-099ee7a4e3dc // needs to be pinned as the replace above won't work when importing the api standalone
-	github.com/kurtosis-tech/kurtosis/path-compression v0.0.0-20240307154559-64d2929cd265 // needs to be pinned as the replace above won't work when importing the api standalone
+	github.com/kurtosis-tech/kurtosis/path-compression v0.0.0-20260325155815-f36ae687d73d // needs to be pinned as the replace above won't work when importing the api standalone
 	github.com/kurtosis-tech/stacktrace v0.0.0-20211028211901-1c67a77b5409
 	github.com/labstack/echo/v4 v4.15.1
 	github.com/oapi-codegen/runtime v1.4.0


### PR DESCRIPTION
## Summary
- Fixes #3073 — `go build` of `github.com/kurtosis-tech/kurtosis/api/golang@v1.18.1` fails for external consumers with `undefined: path_compression.ComputeContentHash`
- Bumps the `path-compression` `require` pin from `v0.0.0-20240307154559-64d2929cd265` to `v0.0.0-20260325155815-f36ae687d73d` (latest `path-compression/` commit on `main`), which exports `ComputeContentHash`
- The local `replace` directive only applies inside the monorepo; downstream builds resolve the stale `require` and break

## Why this happened
`ComputeContentHash` was added in #2929 ("feat: cache compressed archives for package uploads") and is referenced from `core/lib/enclaves/enclave_context.go:762`. The monorepo-only `replace` directive in `api/golang/go.mod` papered over the missing API for internal builds, so the broken pin shipped in v1.18.1.

## Test plan
- [x] Monorepo: `cd api/golang && go build ./...` — passes
- [x] External-consumer simulation: copy `api/golang` to a temp dir, `go mod edit -dropreplace=...` for both `path-compression` and `grpc-file-transfer/golang`, then `go build ./...` — **passes** (this is the failure mode from #3073)
- [ ] Release-please will cut `api/golang/v1.18.2` on merge

## Follow-up suggestion (not in this PR)
Add a CI job that builds `api/golang` with `replace` directives stripped, so this class of breakage cannot ship again. Roughly:

```bash
cp -r api/golang /tmp/external-build
cd /tmp/external-build
go mod edit -dropreplace=github.com/kurtosis-tech/kurtosis/grpc-file-transfer/golang \
            -dropreplace=github.com/kurtosis-tech/kurtosis/path-compression
go build ./...
```

Happy to open a separate PR for that if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)