### PR TITLE
ci: skip release-token verify jobs on dependabot PRs

### DIFF
--- a/.github/workflows/verify-release-tokens.yml
+++ b/.github/workflows/verify-release-tokens.yml
@@ -9,13 +9,14 @@ on:
 permissions:
   contents: read
 
-# Fork PRs don't have access to secrets. Skip the secret-dependent jobs there;
-# GitHub will still show them as "skipped" rather than failing contributor PRs.
+# Fork PRs and dependabot PRs don't have access to release secrets. Skip the
+# secret-dependent jobs there; GitHub will show them as "skipped" rather than
+# failing contributor / dependabot PRs.
 jobs:
   verify-kurtosisbot-github-token:
     name: KURTOSISBOT_GITHUB_TOKEN
     runs-on: ubuntu-latest
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+    if: ${{ github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]') }}
     env:
       TOKEN: ${{ secrets.KURTOSISBOT_GITHUB_TOKEN }}
     steps:
@@ -72,7 +73,7 @@ jobs:
   verify-releaser-token:
     name: RELEASER_TOKEN
     runs-on: ubuntu-latest
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+    if: ${{ github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]') }}
     env:
       TOKEN: ${{ secrets.RELEASER_TOKEN }}
     steps:
@@ -111,7 +112,7 @@ jobs:
   verify-dockerhub-credentials:
     name: DOCKERHUB_USERNAME / DOCKERHUB_PASSWORD
     runs-on: ubuntu-latest
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+    if: ${{ github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]') }}
     env:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
@@ -134,6 +135,6 @@ jobs:
 
   verify-npm-token:
     name: NPMJS_AUTH_TOKEN
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+    if: ${{ github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]') }}
     uses: ./.github/workflows/verify-npm-token.yml
     secrets: inherit


### PR DESCRIPTION
## Summary

- Dependabot PRs cannot access release secrets (`KURTOSISBOT_GITHUB_TOKEN`, `RELEASER_TOKEN`, `DOCKERHUB_USERNAME/PASSWORD`, `NPMJS_AUTH_TOKEN`), so the four Verify Release Tokens jobs always fail on them and make every dependabot PR look red.
- Extend the existing fork-PR guard on each job in `.github/workflows/verify-release-tokens.yml` to also skip when `github.actor == 'dependabot[bot]'`. GitHub renders these as "skipped" instead of failed, matching the contributor-fork behaviour.
- No effect on `push` to `main`, manual dispatch, or human-authored PRs — the secrets are still verified there.

## Test plan

- [ ] After merge, re-run a dependabot PR (e.g. #3080) and confirm the four `Verify Release Tokens` checks come back as skipped/neutral instead of failing.
- [ ] Run the workflow manually via `workflow_dispatch` and confirm all four secret-verify jobs still execute.