### PR TITLE
build(deps): bump dependabot/fetch-metadata from 3.0.0 to 3.1.0

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@ffa630c65fa7e0ecfa0625b5ceda64399aea1b36 # v3.0.0
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         with:
           github-token: "${{ secrets.RELEASER_TOKEN }}"
       - name: Approve a PR


### PR DESCRIPTION
## Summary

Bumps `dependabot/fetch-metadata` from v3.0.0 to v3.1.0 in `.github/workflows/dependabot.yml`. Pinned by commit SHA per repo convention.

Replaces orphaned dependabot PR #3062 — that PR predates the dependabot config refactor (#2957 / #2998) which renamed/regrouped update groups, leaving its group metadata invalid. Both `@dependabot rebase` and `@dependabot recreate` return "the 'unknown' group has been removed from your config" and there is no path to recover the PR.

Diff:

\`\`\`diff
-        uses: dependabot/fetch-metadata@ffa630c65fa7e0ecfa0625b5ceda64399aea1b36 # v3.0.0
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
\`\`\`

Upstream release: https://github.com/dependabot/fetch-metadata/releases/tag/v3.1.0

## Test plan

- [ ] CI passes
- [ ] On merge, close #3062