### PR TITLE
docs: expose raw markdown for every page (AI-friendly, no third-party deps)

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -23,6 +23,10 @@ const config = {
 		locales: ['en'],
 	},
 
+	plugins: [
+		require.resolve('./src/plugins/raw-markdown'),
+	],
+
 	presets: [
 		[
 			'classic',

--- a/docs/src/plugins/raw-markdown/index.js
+++ b/docs/src/plugins/raw-markdown/index.js
@@ -1,0 +1,52 @@
+const fs = require('fs');
+const path = require('path');
+
+const SOURCE_DOCS_DIR = 'docs';
+const SITE_URL = 'https://docs.kurtosis.com';
+
+function walkDocs(dir, baseDir, out) {
+  for (const entry of fs.readdirSync(dir, {withFileTypes: true})) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walkDocs(full, baseDir, out);
+    } else if (entry.isFile() && /\.(md|mdx)$/.test(entry.name)) {
+      const rel = path.relative(baseDir, full);
+      const urlPath = rel.replace(/\.(md|mdx)$/, '');
+      out.push({sourcePath: full, urlPath});
+    }
+  }
+}
+
+module.exports = function rawMarkdownPlugin(context) {
+  return {
+    name: 'raw-markdown-plugin',
+    async postBuild({outDir, siteConfig}) {
+      const siteDir = context.siteDir;
+      const docsDir = path.join(siteDir, SOURCE_DOCS_DIR);
+      if (!fs.existsSync(docsDir)) {
+        return;
+      }
+
+      const pages = [];
+      walkDocs(docsDir, docsDir, pages);
+
+      for (const {sourcePath, urlPath} of pages) {
+        const destPath = path.join(outDir, `${urlPath}.md`);
+        fs.mkdirSync(path.dirname(destPath), {recursive: true});
+        fs.copyFileSync(sourcePath, destPath);
+      }
+
+      const baseUrl = (siteConfig && siteConfig.url ? siteConfig.url : SITE_URL).replace(/\/$/, '');
+      const llmsLines = [
+        '# Kurtosis Docs',
+        '',
+        '> Raw markdown source of every page on docs.kurtosis.com. Append `.md` to any docs URL to fetch the source.',
+        '',
+      ];
+      for (const {urlPath} of pages.slice().sort((a, b) => a.urlPath.localeCompare(b.urlPath))) {
+        llmsLines.push(`- [${urlPath}](${baseUrl}/${urlPath}.md)`);
+      }
+      fs.writeFileSync(path.join(outDir, 'llms.txt'), llmsLines.join('\n') + '\n');
+    },
+  };
+};


### PR DESCRIPTION
## Summary

Adds a ~50-line local Docusaurus plugin that mirrors every doc page at the same URL with a \`.md\` suffix, plus emits a \`/llms.txt\` index. Closes #3072 by providing the same \"feed docs into an LLM\" use case without taking on the supply-chain risk of [\`docusaurus-plugin-copy-page-button\`](https://www.npmjs.com/package/docusaurus-plugin-copy-page-button) (single maintainer, no npm provenance — see review on #3072).

### What you get

| URL | Returns |
|---|---|
| \`https://docs.kurtosis.com/get-started/quickstart\` | rendered HTML (unchanged) |
| \`https://docs.kurtosis.com/get-started/quickstart.md\` | raw markdown source |
| \`https://docs.kurtosis.com/llms.txt\` | flat index of every page → its \`.md\` URL |

Users (and AI tools) can paste any docs URL into ChatGPT/Claude/Gemini and append \`.md\` to feed in the clean source. The \`llms.txt\` follows the [community convention](https://llmstxt.org/) so capable tools can ingest the whole site in one shot.

### Why not the third-party plugin (#3072)?

- \`docusaurus-plugin-copy-page-button\` has 1 maintainer, no npm provenance, 6 stars, 40 versions in 10 months. The PR was opened by the package owner himself.
- The plugin would run at build time on every docs deploy. A future compromised release could inject arbitrary JS into docs.kurtosis.com.
- We get ~90% of the value (LLM handoff) from raw .md URLs with zero supply chain.
- If you later want the in-browser copy/open-in-ChatGPT UX, the plugin source is ~1,100 lines of plain JS — easy to vendor into \`docs/src/plugins/\` if you decide it's worth maintaining.

### Implementation

Single file: \`docs/src/plugins/raw-markdown/index.js\`. Hooks the Docusaurus \`postBuild\` lifecycle, walks \`docs/docs/\`, copies each \`.md\`/\`.mdx\` to the build output keeping the URL path, then writes \`llms.txt\`. No npm deps, no install scripts, no client-side code.

### Verified locally

\`\`\`
$ yarn build
[SUCCESS] Generated static files in \"build\".
$ find build -name '*.md' | wc -l
125
$ diff -q docs/get-started/quickstart.md build/get-started/quickstart.md
# (matches)
\`\`\`

## Test plan

- [ ] Cloudflare Pages preview build succeeds
- [ ] Spot-check a few \`.md\` URLs on the preview return raw markdown
- [ ] \`/llms.txt\` resolves and lists ~125 pages