### PR TITLE
feat: allow http(s) URLs in upload_files src

### DIFF
--- a/core/server/api_container/server/startosis_engine/kurtosis_instruction/upload_files/upload_files.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_instruction/upload_files/upload_files.go
@@ -20,6 +20,7 @@ import (
 	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/types"
 	path_compression "github.com/kurtosis-tech/kurtosis/path-compression"
 	"github.com/kurtosis-tech/stacktrace"
+	"github.com/sirupsen/logrus"
 	"go.starlark.net/starlark"
 )
 
@@ -117,27 +118,63 @@ func (builtin *UploadFilesCapabilities) Interpret(locatorOfModuleInWhichThisBuil
 	if err != nil {
 		return nil, startosis_errors.WrapWithInterpretationError(err, "Unable to extract value for '%s' argument", SrcArgName)
 	}
+	srcStr := src.GoString()
 
-	absoluteLocator, interpretationErr := builtin.packageContentProvider.GetAbsoluteLocator(builtin.packageId, locatorOfModuleInWhichThisBuiltInIsBeingCalled, src.GoString(), builtin.packageReplaceOptions)
-	if interpretationErr != nil {
-		return nil, startosis_errors.WrapWithInterpretationError(interpretationErr, "Tried to convert locator '%v' into absolute locator but failed", src.GoString())
-	}
-
-	pathOnDisk, interpretationErr := builtin.packageContentProvider.GetOnDiskAbsolutePath(absoluteLocator)
+	pathOnDisk, descriptionSrc, cleanup, interpretationErr := builtin.resolveSourcePathOnDisk(srcStr, locatorOfModuleInWhichThisBuiltInIsBeingCalled)
 	if interpretationErr != nil {
 		return nil, interpretationErr
 	}
+	defer cleanup()
 
 	compressedDataPath, _, compressedDataMd5, err := path_compression.CompressPathToFile(pathOnDisk, enforceMaxFileSizeLimit)
 	if err != nil {
 		return nil, startosis_errors.WrapWithInterpretationError(err, "An error occurred while compressing the files at '%s'", pathOnDisk)
 	}
 
-	builtin.src = src.GoString()
+	builtin.src = srcStr
 	builtin.archivePathOnDisk = compressedDataPath
 	builtin.filesArtifactMd5 = compressedDataMd5
-	builtin.description = builtin_argument.GetDescriptionOrFallBack(arguments, fmt.Sprintf(descriptionFormatStr, builtin.src, builtin.artifactName))
+	builtin.description = builtin_argument.GetDescriptionOrFallBack(arguments, fmt.Sprintf(descriptionFormatStr, descriptionSrc, builtin.artifactName))
 	return starlark.String(builtin.artifactName), nil
+}
+
+// resolveSourcePathOnDisk returns the local filesystem path that should be
+// compressed into the files artifact. When src is an absolute http(s) URL the
+// file is downloaded into a temporary directory and that path is returned;
+// otherwise the source is treated as a Kurtosis package locator and resolved
+// through the package content provider as before.
+//
+// The returned descriptionSrc is a sanitised representation of the source used
+// in user-facing messages; for URLs the query string and fragment are stripped
+// so descriptions stay readable and stable. The returned cleanup function must
+// be invoked once the caller has finished consuming the path (e.g. after
+// compression) and is safe to call even when no temp directory was created.
+func (builtin *UploadFilesCapabilities) resolveSourcePathOnDisk(src string, locatorOfModuleInWhichThisBuiltInIsBeingCalled string) (string, string, func(), *startosis_errors.InterpretationError) {
+	noopCleanup := func() {}
+
+	if isHTTPURL(src) {
+		downloadedFilePath, tempDir, err := downloadFileFromURL(context.Background(), src)
+		if err != nil {
+			return "", "", noopCleanup, startosis_errors.WrapWithInterpretationError(err, "An error occurred downloading file from URL '%s'", src)
+		}
+		cleanup := func() {
+			if removeErr := os.RemoveAll(tempDir); removeErr != nil {
+				logrus.Warnf("Failed to remove temporary directory '%s' used for URL download '%s': %v", tempDir, src, removeErr)
+			}
+		}
+		return downloadedFilePath, describeURLSource(src), cleanup, nil
+	}
+
+	absoluteLocator, interpretationErr := builtin.packageContentProvider.GetAbsoluteLocator(builtin.packageId, locatorOfModuleInWhichThisBuiltInIsBeingCalled, src, builtin.packageReplaceOptions)
+	if interpretationErr != nil {
+		return "", "", noopCleanup, startosis_errors.WrapWithInterpretationError(interpretationErr, "Tried to convert locator '%v' into absolute locator but failed", src)
+	}
+
+	pathOnDisk, interpretationErr := builtin.packageContentProvider.GetOnDiskAbsolutePath(absoluteLocator)
+	if interpretationErr != nil {
+		return "", "", noopCleanup, interpretationErr
+	}
+	return pathOnDisk, src, noopCleanup, nil
 }
 
 func (builtin *UploadFilesCapabilities) Validate(_ *builtin_argument.ArgumentValuesSet, validatorEnvironment *startosis_validator.ValidatorEnvironment) *startosis_errors.ValidationError {

--- a/core/server/api_container/server/startosis_engine/kurtosis_instruction/upload_files/url_download.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_instruction/upload_files/url_download.go
@@ -1,0 +1,119 @@
+package upload_files
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/kurtosis-tech/stacktrace"
+)
+
+const (
+	httpScheme  = "http"
+	httpsScheme = "https"
+
+	urlDownloadDirPattern = "kurtosis-upload-files-url-*"
+
+	urlDownloadHTTPTimeout = 5 * time.Minute
+
+	defaultDownloadedFileName = "download"
+)
+
+// isHTTPURL reports whether src is an absolute http or https URL.
+// Package locators such as `github.com/foo/bar` have no scheme and therefore
+// are not matched here; they continue to flow through the package content
+// provider as before.
+func isHTTPURL(src string) bool {
+	parsed, err := url.Parse(src)
+	if err != nil {
+		return false
+	}
+	scheme := strings.ToLower(parsed.Scheme)
+	if scheme != httpScheme && scheme != httpsScheme {
+		return false
+	}
+	return parsed.Host != ""
+}
+
+// downloadFileFromURL fetches src over HTTP(S) and writes its body to a file in
+// a freshly created temporary directory. The directory path is returned so the
+// caller can remove it once the contents have been compressed.
+//
+// The returned file path preserves the URL basename when one is present so the
+// resulting files artifact uses an intuitive filename (matching the behaviour
+// of upload_files for local sources).
+func downloadFileFromURL(ctx context.Context, src string) (downloadedFilePath string, tempDir string, err error) {
+	parsedURL, err := url.Parse(src)
+	if err != nil {
+		return "", "", stacktrace.Propagate(err, "Failed to parse '%s' as a URL", src)
+	}
+
+	tempDir, err = os.MkdirTemp("", urlDownloadDirPattern)
+	if err != nil {
+		return "", "", stacktrace.Propagate(err, "Failed to create temporary directory for URL download '%s'", src)
+	}
+	cleanupOnError := true
+	defer func() {
+		if cleanupOnError {
+			_ = os.RemoveAll(tempDir)
+		}
+	}()
+
+	fileName := path.Base(parsedURL.Path)
+	if fileName == "" || fileName == "." || fileName == "/" {
+		fileName = defaultDownloadedFileName
+	}
+	downloadedFilePath = filepath.Join(tempDir, fileName)
+
+	httpCtx, cancel := context.WithTimeout(ctx, urlDownloadHTTPTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(httpCtx, http.MethodGet, src, nil)
+	if err != nil {
+		return "", "", stacktrace.Propagate(err, "Failed to build HTTP request for '%s'", src)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", "", stacktrace.Propagate(err, "Failed to download '%s'", src)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", "", stacktrace.NewError("Downloading '%s' returned unexpected HTTP status '%s'", src, resp.Status)
+	}
+
+	out, err := os.Create(downloadedFilePath)
+	if err != nil {
+		return "", "", stacktrace.Propagate(err, "Failed to create temp file '%s' for URL download", downloadedFilePath)
+	}
+
+	if _, err := io.Copy(out, resp.Body); err != nil {
+		_ = out.Close()
+		return "", "", stacktrace.Propagate(err, "Failed to write response body for '%s' to '%s'", src, downloadedFilePath)
+	}
+	if err := out.Close(); err != nil {
+		return "", "", stacktrace.Propagate(err, "Failed to close downloaded file '%s'", downloadedFilePath)
+	}
+
+	cleanupOnError = false
+	return downloadedFilePath, tempDir, nil
+}
+
+// describeURLSource returns a short, deterministic string used as the artifact
+// description default and YAML-plan src field when the source is a URL. It
+// hides query strings and fragments to keep descriptions stable.
+func describeURLSource(src string) string {
+	parsed, err := url.Parse(src)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return src
+	}
+	return fmt.Sprintf("%s://%s%s", parsed.Scheme, parsed.Host, parsed.Path)
+}

--- a/core/server/api_container/server/startosis_engine/kurtosis_instruction/upload_files/url_download_test.go
+++ b/core/server/api_container/server/startosis_engine/kurtosis_instruction/upload_files/url_download_test.go
@@ -1,0 +1,93 @@
+package upload_files
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsHTTPURL(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want bool
+	}{
+		{"https URL", "https://gist.githubusercontent.com/fjl/abc/raw/def/dashboard.json", true},
+		{"http URL", "http://example.com/file.txt", true},
+		{"github package locator (no scheme)", "github.com/foo/bar/file.star", false},
+		{"absolute path", "/etc/hosts", false},
+		{"relative path", "./dashboard.json", false},
+		{"empty string", "", false},
+		{"scheme but no host", "https://", false},
+		{"unsupported scheme", "ftp://example.com/file.txt", false},
+		{"file scheme", "file:///tmp/x.json", false},
+		{"uppercase scheme is fine", "HTTPS://example.com/file.txt", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, isHTTPURL(tt.src))
+		})
+	}
+}
+
+func TestDownloadFileFromURL_Success(t *testing.T) {
+	const body = "hello dashboard"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/raw/dashboard.json", r.URL.Path)
+		_, err := w.Write([]byte(body))
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	downloadedPath, tempDir, err := downloadFileFromURL(context.Background(), server.URL+"/raw/dashboard.json")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	require.Equal(t, "dashboard.json", filepath.Base(downloadedPath))
+
+	got, err := os.ReadFile(downloadedPath)
+	require.NoError(t, err)
+	require.Equal(t, body, string(got))
+}
+
+func TestDownloadFileFromURL_FallbackFilename(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("x"))
+	}))
+	defer server.Close()
+
+	// Trailing slash means path.Base returns "/", which should trigger the fallback name.
+	downloadedPath, tempDir, err := downloadFileFromURL(context.Background(), server.URL+"/")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	require.Equal(t, defaultDownloadedFileName, filepath.Base(downloadedPath))
+}
+
+func TestDownloadFileFromURL_NonSuccessStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "nope", http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	_, tempDir, err := downloadFileFromURL(context.Background(), server.URL+"/missing.json")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "404")
+	// On error the temp directory must not leak.
+	_, statErr := os.Stat(tempDir)
+	require.True(t, os.IsNotExist(statErr), "expected temp dir to be cleaned up on error, got stat err = %v", statErr)
+}
+
+func TestDescribeURLSource(t *testing.T) {
+	require.Equal(t,
+		"https://example.com/dashboard.json",
+		describeURLSource("https://example.com/dashboard.json?token=secret#frag"),
+	)
+	require.Equal(t, "not a url", describeURLSource("not a url"))
+}

--- a/docs/docs/api-reference/starlark-reference/plan.md
+++ b/docs/docs/api-reference/starlark-reference/plan.md
@@ -852,12 +852,17 @@ The return value is a [future reference][future-references-reference] to the nam
 upload_files
 ------------
 
-The `upload_files` instruction packages the files specified by the [locator][locators-reference] into a [files artifact][files-artifacts-reference] that gets stored inside the enclave. This is particularly useful when a static file needs to be loaded to a service container. 
+The `upload_files` instruction packages the files specified by `src` into a [files artifact][files-artifacts-reference] that gets stored inside the enclave. This is particularly useful when a static file needs to be loaded to a service container.
+
+`src` accepts either:
+
+- a Kurtosis [locator][locators-reference] (a path within the current package, or a `github.com/...` path — without the `/blob/main` part), or
+- an absolute `http://` or `https://` URL pointing to a single file (for example a gist raw URL, an S3 object, or a Grafana dashboard JSON hosted on a CDN). The file is fetched at interpretation time and packaged as the files artifact.
 
 ```python
 artifact_name = plan.upload_files(
-    # The file to upload into a files artifact
-    # Must be any GitHub URL without the '/blob/main' part.
+    # The file to upload into a files artifact. Accepts a GitHub locator,
+    # a path within the current package, or an absolute http(s) URL.
     # MANDATORY
     src = "github.com/foo/bar/static/example.txt",
 
@@ -869,6 +874,12 @@ artifact_name = plan.upload_files(
     # A human friendly description for the end user of the package
     # OPTIONAL (Default: Uploading file 'PATH' to files artifact 'ARTIFACT_NAME')
     description = "uploading file"
+)
+
+# Example: upload a single file from an arbitrary URL
+dashboard = plan.upload_files(
+    src = "https://gist.githubusercontent.com/fjl/abc/raw/def/dashboard.json",
+    name = "grafana-dashboard",
 )
 ```
 


### PR DESCRIPTION
## Summary
- `plan.upload_files(src=...)` now accepts an absolute `http://` / `https://` URL in addition to package locators. The file is fetched at interpretation time, packaged into a files artifact, and the temp staging directory is cleaned up afterwards.
- Package locators (`github.com/owner/repo/...`) and local paths inside a package continue to go through the existing package content provider unchanged.
- Docs updated in `docs/docs/api-reference/starlark-reference/plan.md` with a gist-raw-URL example.

## Motivation
Today `upload_files` rejects anything other than a `github.com/...` locator because it reuses `GetAbsoluteLocator` → `ParseGitURL`, which is intentionally GitHub-only for the package system. That makes sense for `import_module` (versioned packages, relative imports, GH auth) but is a leaky abstraction for `upload_files` — there is no reason a single-file fetch should be gated on the package-system constraint.

Real cases this unblocks (today they need a `run_sh` + `curl` workaround service):
- Pulling enode lists from `https://raw.githubusercontent.com/eth-clients/<network>/refs/heads/main/metadata/enodes.yaml` (see `mempool_bridge_launcher.star` in `ethereum-package`).
- Fetching a Grafana dashboard JSON from a gist raw URL.
- Pulling a config blob from an S3 / GCS object URL or a CDN.

## Implementation notes
- Carve-out is local to the `upload_files` package: new `url_download.go` adds `isHTTPURL`, `downloadFileFromURL`, and `describeURLSource`. Nothing in the package locator / git provider code changes.
- 5-minute HTTP timeout via `context.WithTimeout`. Non-2xx responses are surfaced as interpretation errors. The temp directory is removed on error and after the artifact has been compressed.
- A scheme-bearing URL is unambiguously a URL — package locators are scheme-less, so detection has zero overlap with the existing locator path.

## Test plan
- [x] `go test -race ./core/server/api_container/server/startosis_engine/...` passes locally.
- [x] New unit tests in `url_download_test.go` cover URL detection, successful download, fallback filename, non-2xx errors (incl. temp-dir cleanup), and `describeURLSource` sanitisation.
- [x] **Enclave smoke test (docker backend, locally built images)** — `plan.upload_files(src="https://raw.githubusercontent.com/eth-clients/mainnet/refs/heads/main/metadata/enodes.yaml", name="mainnet-enodes")` produced artifact `mainnet-enodes`, was mounted into a verifier service, and `head -n 3 /data/enodes.yaml` returned the real eth-clients/mainnet enode contents with exit 0 (`plan.verify` succeeded).