### PR TITLE
docs(cli-reference): add otel start/stop pages

### DIFF
--- a/docs/docs/cli-reference/otel-start.md
+++ b/docs/docs/cli-reference/otel-start.md
@@ -1,0 +1,40 @@
+---
+title: otel start
+sidebar_label: otel start
+slug: /otel-start
+---
+
+To start a local OpenTelemetry collector and ClickHouse instance in Docker, run:
+
+```bash
+kurtosis otel start
+```
+
+This command starts two engine-managed side containers — an [OpenTelemetry collector][otel-collector] and a single-node [ClickHouse][clickhouse] — and restarts the Kurtosis engine with an updated configuration. The new configuration adds a log sink that routes enclave logs to the collector over Loki's HTTP protocol; the collector then writes them to ClickHouse, where they can be queried alongside any OTLP traces and metrics you push to the collector from inside your enclaves.
+
+The side containers publish the following ports on the Docker host so they are reachable from inside every enclave as well as from tools on your machine:
+
+| Service               | Host port | Purpose                       |
+|-----------------------|-----------|-------------------------------|
+| OpenTelemetry — OTLP gRPC | `14317`   | OTLP gRPC ingest              |
+| OpenTelemetry — OTLP HTTP | `14318`   | OTLP HTTP ingest              |
+| ClickHouse — HTTP     | `18123`   | ClickHouse HTTP query/insert  |
+
+The host ports are deliberately non-default (e.g. `14317` instead of `4317`) so the side containers do not collide with a developer's own ClickHouse or OTLP collector already bound on the Docker host.
+
+Once the side containers are running, enclave logs are tagged with the enclave name (not just the enclave UUID), so logs and traces can be tenanted and queried by enclave name.
+
+`kurtosis otel start` is **Docker-only** — it returns an error on Kubernetes and Podman backends. It is also mutually exclusive with [grafloki start][grafloki-start]: running `kurtosis otel start` skips any configured Grafana/Loki setup, and the engine will only export logs to the OpenTelemetry collector while the otel side containers are running.
+
+There is currently no `kurtosis-config.yml` switch to enable the OpenTelemetry collector by default; the command must be invoked explicitly each time the engine is started.
+
+To stop the side containers and revert the engine to its default log sink, use [otel stop][otel-stop].
+
+Read more about sinks and how to [export logs][export-logs] from Kurtosis.
+
+<!-------------------- ONLY LINKS BELOW THIS POINT ----------------------->
+[otel-collector]: https://opentelemetry.io/docs/collector/
+[clickhouse]: https://clickhouse.com/
+[grafloki-start]: ./grafloki-start.md
+[otel-stop]: ./otel-stop.md
+[export-logs]: ../guides/exporting-logs.md

--- a/docs/docs/cli-reference/otel-start.md
+++ b/docs/docs/cli-reference/otel-start.md
@@ -26,7 +26,18 @@ Once the side containers are running, enclave logs are tagged with the enclave n
 
 `kurtosis otel start` is **Docker-only** — it returns an error on Kubernetes and Podman backends. It is also mutually exclusive with [grafloki start][grafloki-start]: running `kurtosis otel start` skips any configured Grafana/Loki setup, and the engine will only export logs to the OpenTelemetry collector while the otel side containers are running.
 
-There is currently no `kurtosis-config.yml` switch to enable the OpenTelemetry collector by default; the command must be invoked explicitly each time the engine is started.
+To make the OpenTelemetry collector the default for every engine start, set [`backend-log-collector: otel`][kurtosis-config] in `kurtosis-config.yml`:
+
+```yaml
+config-version: 9
+should-send-metrics: true
+kurtosis-clusters:
+  docker:
+    type: docker
+    backend-log-collector: otel
+```
+
+With that in place, `kurtosis engine start` and `kurtosis engine restart` auto-start the OpenTelemetry side containers and wire up the Loki sink — no need to invoke `kurtosis otel start` manually each time. This option is Docker-only and mutually exclusive with `grafana-loki.should-start-before-engine: true`.
 
 To stop the side containers and revert the engine to its default log sink, use [otel stop][otel-stop].
 
@@ -38,3 +49,4 @@ Read more about sinks and how to [export logs][export-logs] from Kurtosis.
 [grafloki-start]: ./grafloki-start.md
 [otel-stop]: ./otel-stop.md
 [export-logs]: ../guides/exporting-logs.md
+[kurtosis-config]: ../advanced-concepts/kurtosis-config.md

--- a/docs/docs/cli-reference/otel-stop.md
+++ b/docs/docs/cli-reference/otel-stop.md
@@ -1,0 +1,18 @@
+---
+title: otel stop
+sidebar_label: otel stop
+slug: /otel-stop
+---
+
+To stop the OpenTelemetry side containers that were started by [otel start][otel-start], run:
+
+```bash
+kurtosis otel stop
+```
+
+This restarts a running Kurtosis engine without the OpenTelemetry Loki sink — reverting to the default log sinks — and then stops the OpenTelemetry collector and ClickHouse side containers, if they exist. If the engine is not running, the engine restart step is skipped and only the side containers are stopped.
+
+Like [otel start][otel-start], this command is **Docker-only**.
+
+<!-------------------- ONLY LINKS BELOW THIS POINT ----------------------->
+[otel-start]: ./otel-start.md


### PR DESCRIPTION
> **⚠️ Depends on #3136 — merge that first.**
> After the second commit on this branch, `otel-start.md` now references the `backend-log-collector: otel` config option introduced in #3136. Merging this PR before #3136 would temporarily leave the docs describing a config field that doesn't exist on `main`.

## Summary
The `kurtosis otel` command was added in #3122 but its CLI reference docs were missed. This PR adds them, modeled on the existing `grafloki-start`/`grafloki-stop` pages.

Both new pages cover:
- The Docker-only constraint (errors on Kubernetes/Podman)
- The host-published ports (`14317` OTLP gRPC, `14318` OTLP HTTP, `18123` ClickHouse HTTP) and why they're deliberately non-default
- The enclave-name log stamping behaviour
- Mutual exclusion with `grafloki start`
- A pointer to the new `backend-log-collector: otel` config option from #3136 for enabling OTel by default at engine start

No sidebar wiring is needed — `docs/sidebars.js` uses `{type: 'autogenerated', dirName: 'cli-reference'}`, so the new pages get picked up automatically.

## Test plan
- [ ] Docs site builds locally (`cd docs && yarn build`) and the two pages render
- [ ] `otel start` / `otel stop` appear in the auto-generated CLI Reference sidebar
- [ ] Internal links (`grafloki-start`, `otel-stop`, `exporting-logs`, `kurtosis-config`) resolve