### PR TITLE
feat(cli): add backend-log-collector config to auto-start OTel stack

### DIFF
--- a/cli/cli/commands/grafloki/start/start.go
+++ b/cli/cli/commands/grafloki/start/start.go
@@ -62,6 +62,9 @@ func run(
 	if err != nil {
 		return stacktrace.Propagate(err, "An error occurred creating an engine manager.")
 	}
+	// User explicitly chose grafloki for this engine; suppress the config-driven OpenTelemetry auto-start
+	// so the engine restart below doesn't also bring up the otel side containers.
+	engineManager.SetSkipConfiguredOtel(true)
 	_, engineClientCloseFunc, err := engineManager.RestartEngineIdempotently(
 		ctx,
 		defaults.DefaultEngineLogLevel,

--- a/cli/cli/commands/loki/start/start.go
+++ b/cli/cli/commands/loki/start/start.go
@@ -53,6 +53,7 @@ func run(
 		return stacktrace.Propagate(err, "An error occurred creating an engine manager.")
 	}
 	engineManager.SetSkipConfiguredGrafloki(true)
+	engineManager.SetSkipConfiguredOtel(true)
 	_, engineClientCloseFunc, err := engineManager.RestartEngineIdempotently(
 		ctx,
 		defaults.DefaultEngineLogLevel,

--- a/cli/cli/commands/otel/start/start.go
+++ b/cli/cli/commands/otel/start/start.go
@@ -55,6 +55,9 @@ func run(
 		return stacktrace.Propagate(err, "An error occurred creating an engine manager.")
 	}
 	engineManager.SetSkipConfiguredGrafloki(true)
+	// `otel start` already started the side containers above; suppress the config-driven auto-start
+	// path so RestartEngineIdempotently below doesn't try to start them a second time.
+	engineManager.SetSkipConfiguredOtel(true)
 	_, engineClientCloseFunc, err := engineManager.RestartEngineIdempotently(
 		ctx,
 		defaults.DefaultEngineLogLevel,

--- a/cli/cli/helpers/engine_manager/engine_manager.go
+++ b/cli/cli/helpers/engine_manager/engine_manager.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kurtosis-tech/kurtosis/cli/cli/command_str_consts"
 	"github.com/kurtosis-tech/kurtosis/cli/cli/helpers/grafloki"
 	"github.com/kurtosis-tech/kurtosis/cli/cli/helpers/kurtosis_config_getter"
+	"github.com/kurtosis-tech/kurtosis/cli/cli/helpers/otel"
 	"github.com/kurtosis-tech/kurtosis/cli/cli/helpers/portal_manager"
 	"github.com/kurtosis-tech/kurtosis/cli/cli/kurtosis_cluster_setting"
 	"github.com/kurtosis-tech/kurtosis/cli/cli/kurtosis_config"
@@ -48,6 +49,7 @@ type EngineManager struct {
 	enclaveEnvVars                            string
 	allowedCORSOrigins                        *[]string
 	skipConfiguredGrafloki                    bool
+	skipConfiguredOtel                        bool
 	// Make engine IP, port, and protocol configurable in the future
 }
 
@@ -109,6 +111,7 @@ func NewEngineManager(ctx context.Context) (*EngineManager, error) {
 		enclaveEnvVars:         enclaveEnvVars,
 		allowedCORSOrigins:     nil,
 		skipConfiguredGrafloki: false,
+		skipConfiguredOtel:     false,
 	}, nil
 }
 
@@ -122,6 +125,10 @@ func (manager *EngineManager) GetKurtosisBackend() backend_interface.KurtosisBac
 
 func (manager *EngineManager) SetSkipConfiguredGrafloki(skip bool) {
 	manager.skipConfiguredGrafloki = skip
+}
+
+func (manager *EngineManager) SetSkipConfiguredOtel(skip bool) {
+	manager.skipConfiguredOtel = skip
 }
 
 // GetEngineStatus Returns:
@@ -217,6 +224,16 @@ func (manager *EngineManager) StartEngineIdempotentlyWithDefaultVersion(
 	}
 	additionalSinks = combineSinks(additionalSinks, lokiSink)
 
+	if !manager.skipConfiguredOtel && manager.clusterConfig.GetBackendLogCollector() == resolved_config.BackendLogCollectorOtel {
+		otelEndpoints, otelStartErr := otel.StartOtel(ctx, clusterType)
+		if otelStartErr != nil {
+			return nil, nil, stacktrace.Propagate(otelStartErr, "An error occurred starting the OpenTelemetry side containers before the engine; backend-log-collector is set to '%v'.", resolved_config.BackendLogCollectorOtel)
+		}
+		logrus.Infof("otel ClickHouse running at %v (native: %v)", otelEndpoints.ClickHouseHTTPURL, otelEndpoints.ClickHouseNativeAddress)
+		logrus.Infof("otel collector running at %v (http: %v)", otelEndpoints.CollectorOTLPGRPCURL, otelEndpoints.CollectorOTLPHTTPURL)
+		additionalSinks = combineSinks(additionalSinks, otel.NewLokiSink(otelEndpoints.CollectorLokiURL))
+	}
+
 	engineGuarantor := newEngineExistenceGuarantorWithDefaultVersion(
 		ctx,
 		maybeHostMachinePortBinding,
@@ -283,6 +300,16 @@ func (manager *EngineManager) StartEngineIdempotentlyWithCustomVersion(ctx conte
 		logrus.Infof("Grafana running at %v", grafanaUrl)
 	}
 	additionalSinks = combineSinks(additionalSinks, lokiSink)
+
+	if !manager.skipConfiguredOtel && manager.clusterConfig.GetBackendLogCollector() == resolved_config.BackendLogCollectorOtel {
+		otelEndpoints, otelStartErr := otel.StartOtel(ctx, clusterType)
+		if otelStartErr != nil {
+			return nil, nil, stacktrace.Propagate(otelStartErr, "An error occurred starting the OpenTelemetry side containers before the engine; backend-log-collector is set to '%v'.", resolved_config.BackendLogCollectorOtel)
+		}
+		logrus.Infof("otel ClickHouse running at %v (native: %v)", otelEndpoints.ClickHouseHTTPURL, otelEndpoints.ClickHouseNativeAddress)
+		logrus.Infof("otel collector running at %v (http: %v)", otelEndpoints.CollectorOTLPGRPCURL, otelEndpoints.CollectorOTLPHTTPURL)
+		additionalSinks = combineSinks(additionalSinks, otel.NewLokiSink(otelEndpoints.CollectorLokiURL))
+	}
 
 	engineGuarantor := newEngineExistenceGuarantorWithCustomVersion(
 		ctx,

--- a/cli/cli/kurtosis_config/config_version/config_version.go
+++ b/cli/cli/kurtosis_config/config_version/config_version.go
@@ -14,4 +14,5 @@ const (
 	ConfigVersion_v6 // adds logs collector config
 	ConfigVersion_v7 // adds node-selectors and tolerations to KubernetesClusterConfig
 	ConfigVersion_v8 // adds allow-privileged-mode to KurtosisClusterConfig
+	ConfigVersion_v9 // adds backend-log-collector to KurtosisClusterConfig
 )

--- a/cli/cli/kurtosis_config/config_version/configversion_enumer.go
+++ b/cli/cli/kurtosis_config/config_version/configversion_enumer.go
@@ -7,11 +7,11 @@ import (
 	"strings"
 )
 
-const _ConfigVersionName = "ConfigVersion_v0ConfigVersion_v1ConfigVersion_v2ConfigVersion_v3ConfigVersion_v4ConfigVersion_v5ConfigVersion_v6ConfigVersion_v7ConfigVersion_v8"
+const _ConfigVersionName = "ConfigVersion_v0ConfigVersion_v1ConfigVersion_v2ConfigVersion_v3ConfigVersion_v4ConfigVersion_v5ConfigVersion_v6ConfigVersion_v7ConfigVersion_v8ConfigVersion_v9"
 
-var _ConfigVersionIndex = [...]uint8{0, 16, 32, 48, 64, 80, 96, 112, 128, 144}
+var _ConfigVersionIndex = [...]uint8{0, 16, 32, 48, 64, 80, 96, 112, 128, 144, 160}
 
-const _ConfigVersionLowerName = "configversion_v0configversion_v1configversion_v2configversion_v3configversion_v4configversion_v5configversion_v6configversion_v7configversion_v8"
+const _ConfigVersionLowerName = "configversion_v0configversion_v1configversion_v2configversion_v3configversion_v4configversion_v5configversion_v6configversion_v7configversion_v8configversion_v9"
 
 func (i ConfigVersion) String() string {
 	if i >= ConfigVersion(len(_ConfigVersionIndex)-1) {
@@ -33,9 +33,10 @@ func _ConfigVersionNoOp() {
 	_ = x[ConfigVersion_v6-(6)]
 	_ = x[ConfigVersion_v7-(7)]
 	_ = x[ConfigVersion_v8-(8)]
+	_ = x[ConfigVersion_v9-(9)]
 }
 
-var _ConfigVersionValues = []ConfigVersion{ConfigVersion_v0, ConfigVersion_v1, ConfigVersion_v2, ConfigVersion_v3, ConfigVersion_v4, ConfigVersion_v5, ConfigVersion_v6, ConfigVersion_v7, ConfigVersion_v8}
+var _ConfigVersionValues = []ConfigVersion{ConfigVersion_v0, ConfigVersion_v1, ConfigVersion_v2, ConfigVersion_v3, ConfigVersion_v4, ConfigVersion_v5, ConfigVersion_v6, ConfigVersion_v7, ConfigVersion_v8, ConfigVersion_v9}
 
 var _ConfigVersionNameToValueMap = map[string]ConfigVersion{
 	_ConfigVersionName[0:16]:         ConfigVersion_v0,
@@ -56,6 +57,8 @@ var _ConfigVersionNameToValueMap = map[string]ConfigVersion{
 	_ConfigVersionLowerName[112:128]: ConfigVersion_v7,
 	_ConfigVersionName[128:144]:      ConfigVersion_v8,
 	_ConfigVersionLowerName[128:144]: ConfigVersion_v8,
+	_ConfigVersionName[144:160]:      ConfigVersion_v9,
+	_ConfigVersionLowerName[144:160]: ConfigVersion_v9,
 }
 
 var _ConfigVersionNames = []string{
@@ -68,6 +71,7 @@ var _ConfigVersionNames = []string{
 	_ConfigVersionName[96:112],
 	_ConfigVersionName[112:128],
 	_ConfigVersionName[128:144],
+	_ConfigVersionName[144:160],
 }
 
 // ConfigVersionString retrieves an enum value from the enum constants string name.

--- a/cli/cli/kurtosis_config/overrides_deserializers/config_overrides_deserializers.go
+++ b/cli/cli/kurtosis_config/overrides_deserializers/config_overrides_deserializers.go
@@ -12,6 +12,7 @@ import (
 	v6 "github.com/kurtosis-tech/kurtosis/cli/cli/kurtosis_config/overrides_objects/v6"
 	v7 "github.com/kurtosis-tech/kurtosis/cli/cli/kurtosis_config/overrides_objects/v7"
 	v8 "github.com/kurtosis-tech/kurtosis/cli/cli/kurtosis_config/overrides_objects/v8"
+	v9 "github.com/kurtosis-tech/kurtosis/cli/cli/kurtosis_config/overrides_objects/v9"
 	"github.com/kurtosis-tech/stacktrace"
 )
 
@@ -26,6 +27,18 @@ type configOverridesDeserializer func(configFileBytes []byte) (interface{}, erro
 // We keep these sorted in REVERSE chronological order so you don't need to scroll to the bottom each time
 // >>>>>>>>>>>>>>>>>>>>>>>>>>>>> INSTRUCTIONS <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 var AllConfigOverridesDeserializers = map[config_version.ConfigVersion]configOverridesDeserializer{
+	config_version.ConfigVersion_v9: func(configFileBytes []byte) (interface{}, error) {
+		overrides := &v9.KurtosisConfigV9{
+			ConfigVersion:     0,
+			ShouldSendMetrics: nil,
+			KurtosisClusters:  nil,
+			CloudConfig:       nil,
+		}
+		if err := yaml.Unmarshal(configFileBytes, overrides); err != nil {
+			return nil, stacktrace.Propagate(err, "An error occurred unmarshalling Kurtosis config YAML file content '%v'", string(configFileBytes))
+		}
+		return overrides, nil
+	},
 	config_version.ConfigVersion_v8: func(configFileBytes []byte) (interface{}, error) {
 		overrides := &v8.KurtosisConfigV8{
 			ConfigVersion:     0,

--- a/cli/cli/kurtosis_config/overrides_migrators/config_overrides_migrators.go
+++ b/cli/cli/kurtosis_config/overrides_migrators/config_overrides_migrators.go
@@ -11,6 +11,7 @@ import (
 	v6 "github.com/kurtosis-tech/kurtosis/cli/cli/kurtosis_config/overrides_objects/v6"
 	v7 "github.com/kurtosis-tech/kurtosis/cli/cli/kurtosis_config/overrides_objects/v7"
 	v8 "github.com/kurtosis-tech/kurtosis/cli/cli/kurtosis_config/overrides_objects/v8"
+	v9 "github.com/kurtosis-tech/kurtosis/cli/cli/kurtosis_config/overrides_objects/v9"
 	"github.com/kurtosis-tech/stacktrace"
 )
 
@@ -30,6 +31,7 @@ type configOverridesMigrator = func(uncastedOldConfig interface{}) (interface{},
 // to the bottom each time
 // >>>>>>>>>>>>>>>>>>>>>>>>>>>>> INSTRUCTIONS <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 var AllConfigOverridesMigrators = map[config_version.ConfigVersion]configOverridesMigrator{
+	config_version.ConfigVersion_v8: migrateFromV8,
 	config_version.ConfigVersion_v7: migrateFromV7,
 	config_version.ConfigVersion_v6: migrateFromV6,
 	config_version.ConfigVersion_v5: migrateFromV5,
@@ -41,6 +43,115 @@ var AllConfigOverridesMigrators = map[config_version.ConfigVersion]configOverrid
 }
 
 // vvvvvvvvvvvvvvvvvvvvvvv REVERSE chronological order so you don't have to scroll forever vvvvvvvvvvvvvvvvvvvv
+func migrateFromV8(uncastedConfig interface{}) (interface{}, error) {
+	castedOldConfig, ok := uncastedConfig.(*v8.KurtosisConfigV8)
+	if !ok {
+		return nil, stacktrace.NewError(
+			"Failed to cast old configuration '%+v' to expected configuration struct",
+			uncastedConfig,
+		)
+	}
+
+	var newClusters map[string]*v9.KurtosisClusterConfigV9
+	if castedOldConfig.KurtosisClusters != nil {
+		newClusters = make(map[string]*v9.KurtosisClusterConfigV9, len(castedOldConfig.KurtosisClusters))
+		for oldClusterName, oldClusterConfig := range castedOldConfig.KurtosisClusters {
+			oldKubernetesConfig := oldClusterConfig.Config
+			oldLogsAggregatorConfig := oldClusterConfig.LogsAggregator
+			oldLogsCollectorConfig := oldClusterConfig.LogsCollector
+			oldGraflokiConfig := oldClusterConfig.GrafanaLokiConfig
+
+			var newKubernetesConfig *v9.KubernetesClusterConfigV9
+			if oldKubernetesConfig != nil {
+				newKubernetesConfig = &v9.KubernetesClusterConfigV9{
+					KubernetesClusterName:  oldKubernetesConfig.KubernetesClusterName,
+					StorageClass:           oldKubernetesConfig.StorageClass,
+					EnclaveSizeInMegabytes: oldKubernetesConfig.EnclaveSizeInMegabytes,
+					EngineNodeName:         oldKubernetesConfig.EngineNodeName,
+					NodeSelectors:          oldKubernetesConfig.NodeSelectors,
+					Tolerations:            migrateKubernetesTolerationsFromV8(oldKubernetesConfig.Tolerations),
+				}
+			}
+
+			var newLogsAggregatorConfig *v9.LogsAggregatorConfigV9
+			if oldLogsAggregatorConfig != nil {
+				newLogsAggregatorConfig = &v9.LogsAggregatorConfigV9{
+					Sinks: oldLogsAggregatorConfig.Sinks,
+				}
+			}
+
+			var newLogsCollectorConfig *v9.LogsCollectorConfigV9
+			if oldLogsCollectorConfig != nil {
+				newLogsCollectorConfig = &v9.LogsCollectorConfigV9{
+					Parsers: oldLogsCollectorConfig.Parsers,
+					Filters: oldLogsCollectorConfig.Filters,
+				}
+			}
+
+			var newGraflokiConfig *v9.GrafanaLokiConfigV9
+			if oldGraflokiConfig != nil {
+				newGraflokiConfig = &v9.GrafanaLokiConfigV9{
+					ShouldStartBeforeEngine: oldGraflokiConfig.ShouldStartBeforeEngine,
+					GrafanaImage:            oldGraflokiConfig.GrafanaImage,
+					LokiImage:               oldGraflokiConfig.LokiImage,
+				}
+			}
+
+			newClusterConfig := &v9.KurtosisClusterConfigV9{
+				Type:                        oldClusterConfig.Type,
+				Config:                      newKubernetesConfig,
+				LogsAggregator:              newLogsAggregatorConfig,
+				LogsCollector:               newLogsCollectorConfig,
+				GrafanaLokiConfig:           newGraflokiConfig,
+				ShouldEnableDefaultLogsSink: oldClusterConfig.ShouldEnableDefaultLogsSink,
+				AllowPrivilegedMode:         oldClusterConfig.AllowPrivilegedMode,
+				BackendLogCollector:         nil,
+			}
+
+			newClusters[oldClusterName] = newClusterConfig
+		}
+	}
+
+	var newCloudConfig *v9.KurtosisCloudConfigV9
+	if castedOldConfig.CloudConfig != nil {
+		newCloudConfig = &v9.KurtosisCloudConfigV9{
+			ApiUrl:           castedOldConfig.CloudConfig.ApiUrl,
+			Port:             castedOldConfig.CloudConfig.Port,
+			CertificateChain: castedOldConfig.CloudConfig.CertificateChain,
+		}
+	}
+
+	newConfig := &v9.KurtosisConfigV9{
+		ConfigVersion:     config_version.ConfigVersion_v9,
+		ShouldSendMetrics: castedOldConfig.ShouldSendMetrics,
+		KurtosisClusters:  newClusters,
+		CloudConfig:       newCloudConfig,
+	}
+
+	return newConfig, nil
+}
+
+func migrateKubernetesTolerationsFromV8(oldTolerations []*v8.KubernetesTolerationV8) []*v9.KubernetesTolerationV9 {
+	if oldTolerations == nil {
+		return nil
+	}
+	newTolerations := make([]*v9.KubernetesTolerationV9, 0, len(oldTolerations))
+	for _, oldToleration := range oldTolerations {
+		if oldToleration == nil {
+			newTolerations = append(newTolerations, nil)
+			continue
+		}
+		newTolerations = append(newTolerations, &v9.KubernetesTolerationV9{
+			Key:               oldToleration.Key,
+			Operator:          oldToleration.Operator,
+			Value:             oldToleration.Value,
+			Effect:            oldToleration.Effect,
+			TolerationSeconds: oldToleration.TolerationSeconds,
+		})
+	}
+	return newTolerations
+}
+
 func migrateFromV7(uncastedConfig interface{}) (interface{}, error) {
 	castedOldConfig, ok := uncastedConfig.(*v7.KurtosisConfigV7)
 	if !ok {

--- a/cli/cli/kurtosis_config/overrides_objects/config_version_emptystructs.go
+++ b/cli/cli/kurtosis_config/overrides_objects/config_version_emptystructs.go
@@ -11,6 +11,7 @@ import (
 	v6 "github.com/kurtosis-tech/kurtosis/cli/cli/kurtosis_config/overrides_objects/v6"
 	v7 "github.com/kurtosis-tech/kurtosis/cli/cli/kurtosis_config/overrides_objects/v7"
 	v8 "github.com/kurtosis-tech/kurtosis/cli/cli/kurtosis_config/overrides_objects/v8"
+	v9 "github.com/kurtosis-tech/kurtosis/cli/cli/kurtosis_config/overrides_objects/v9"
 )
 
 /*
@@ -23,6 +24,12 @@ For an explanation, see the docs on TestKurtosisConfigIsUsingLatestConfigStruct.
 */
 
 var AllConfigVersionEmptyStructs = map[config_version.ConfigVersion]interface{}{
+	config_version.ConfigVersion_v9: &v9.KurtosisConfigV9{
+		ConfigVersion:     0,
+		ShouldSendMetrics: nil,
+		KurtosisClusters:  nil,
+		CloudConfig:       nil,
+	},
 	config_version.ConfigVersion_v8: &v8.KurtosisConfigV8{
 		ConfigVersion:     0,
 		ShouldSendMetrics: nil,

--- a/cli/cli/kurtosis_config/overrides_objects/v9/grafana_loki_config_v9.go
+++ b/cli/cli/kurtosis_config/overrides_objects/v9/grafana_loki_config_v9.go
@@ -1,0 +1,19 @@
+package v9
+
+/*
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! WARNING !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+                           DO NOT CHANGE THIS FILE!
+  If you change this file, it will break config for users who have instantiated an
+           overrides file with this version of config overrides!
+    Instead, to make changes, you will need to add a new version of the config
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! WARNING !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+*/
+
+type GrafanaLokiConfigV9 struct {
+	// ShouldStartBeforeEngine starts Grafana and Loki before the engine, if true.
+	// Equivalent to running `grafloki start` before `engine start`.
+	// Useful for treating Grafana and Loki as default logging setup in Kurtosis.
+	ShouldStartBeforeEngine bool   `yaml:"should-start-before-engine,omitempty"`
+	GrafanaImage            string `yaml:"grafana-image,omitempty"`
+	LokiImage               string `yaml:"loki-image,omitempty"`
+}

--- a/cli/cli/kurtosis_config/overrides_objects/v9/kubernetes_cluster_config_v9.go
+++ b/cli/cli/kurtosis_config/overrides_objects/v9/kubernetes_cluster_config_v9.go
@@ -1,0 +1,19 @@
+package v9
+
+/*
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! WARNING !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+                           DO NOT CHANGE THIS FILE!
+  If you change this file, it will break config for users who have instantiated an
+           overrides file with this version of config overrides!
+    Instead, to make changes, you will need to add a new version of the config
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! WARNING !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+*/
+
+type KubernetesClusterConfigV9 struct {
+	KubernetesClusterName  *string                   `yaml:"kubernetes-cluster-name,omitempty"`
+	StorageClass           *string                   `yaml:"storage-class,omitempty"`
+	EnclaveSizeInMegabytes *uint                     `yaml:"enclave-size-in-megabytes,omitempty"`
+	EngineNodeName         *string                   `yaml:"engine-node-name,omitempty"`
+	NodeSelectors          map[string]string         `yaml:"node-selectors,omitempty"`
+	Tolerations            []*KubernetesTolerationV9 `yaml:"tolerations,omitempty"`
+}

--- a/cli/cli/kurtosis_config/overrides_objects/v9/kubernetes_toleration_v9.go
+++ b/cli/cli/kurtosis_config/overrides_objects/v9/kubernetes_toleration_v9.go
@@ -1,0 +1,19 @@
+package v9
+
+/*
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! WARNING !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+                           DO NOT CHANGE THIS FILE!
+  If you change this file, it will break config for users who have instantiated an
+           overrides file with this version of config overrides!
+    Instead, to make changes, you will need to add a new version of the config
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! WARNING !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+*/
+
+// KubernetesTolerationV9 represents a Kubernetes toleration for pod scheduling.
+type KubernetesTolerationV9 struct {
+	Key               *string `yaml:"key,omitempty"`
+	Operator          *string `yaml:"operator,omitempty"`
+	Value             *string `yaml:"value,omitempty"`
+	Effect            *string `yaml:"effect,omitempty"`
+	TolerationSeconds *int64  `yaml:"toleration-seconds,omitempty"`
+}

--- a/cli/cli/kurtosis_config/overrides_objects/v9/kurtosis_cloud_config_v9.go
+++ b/cli/cli/kurtosis_config/overrides_objects/v9/kurtosis_cloud_config_v9.go
@@ -1,0 +1,16 @@
+package v9
+
+/*
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! WARNING !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+                           DO NOT CHANGE THIS FILE!
+  If you change this file, it will break config for users who have instantiated an
+           overrides file with this version of config overrides!
+    Instead, to make changes, you will need to add a new version of the config
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! WARNING !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+*/
+
+type KurtosisCloudConfigV9 struct {
+	ApiUrl           *string `yaml:"api-url,omitempty"`
+	Port             *uint   `yaml:"port,omitempty"`
+	CertificateChain *string `yaml:"certificate-chain,omitempty"`
+}

--- a/cli/cli/kurtosis_config/overrides_objects/v9/kurtosis_cluster_config_v9.go
+++ b/cli/cli/kurtosis_config/overrides_objects/v9/kurtosis_cluster_config_v9.go
@@ -1,0 +1,31 @@
+package v9
+
+/*
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! WARNING !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+                           DO NOT CHANGE THIS FILE!
+  If you change this file, it will break config for users who have instantiated an
+           overrides file with this version of config overrides!
+    Instead, to make changes, you will need to add a new version of the config
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! WARNING !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+*/
+
+type KurtosisClusterConfigV9 struct {
+	Type *string `yaml:"type,omitempty"`
+	// If we ever get another type of cluster that has configuration, this will need to be polymorphically deserialized
+	Config            *KubernetesClusterConfigV9 `yaml:"config,omitempty"`
+	LogsAggregator    *LogsAggregatorConfigV9    `yaml:"logs-aggregator,omitempty"`
+	LogsCollector     *LogsCollectorConfigV9     `yaml:"logs-collector,omitempty"`
+	GrafanaLokiConfig *GrafanaLokiConfigV9       `yaml:"grafana-loki,omitempty"`
+
+	// ShouldEnableDefaultLogsSink controls use of PersistentVolumeLogsDB (default: true) as the storage location for logs.
+	// Useful for saving storage when using custom or Grafana Loki-based logging.
+	ShouldEnableDefaultLogsSink *bool `yaml:"should-enable-default-logs-sink,omitempty"`
+
+	// AllowPrivilegedMode permits Docker-only privileged containers, host bind mounts, and host PID namespace for Starlark runs.
+	AllowPrivilegedMode *bool `yaml:"allow-privileged-mode,omitempty"`
+
+	// BackendLogCollector selects which log-collector stack the engine wires up at start. Accepted values: "vector" (default), "otel".
+	// When set to "otel" and the cluster type is Docker, `kurtosis engine start`/`restart` auto-starts the OpenTelemetry side
+	// containers (collector + ClickHouse) and configures the engine's Vector aggregator to ship logs to the collector.
+	BackendLogCollector *string `yaml:"backend-log-collector,omitempty"`
+}

--- a/cli/cli/kurtosis_config/overrides_objects/v9/kurtosis_config_v9.go
+++ b/cli/cli/kurtosis_config/overrides_objects/v9/kurtosis_config_v9.go
@@ -1,0 +1,26 @@
+package v9
+
+import "github.com/kurtosis-tech/kurtosis/cli/cli/kurtosis_config/config_version"
+
+/*
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! WARNING !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+                           DO NOT CHANGE THIS FILE!
+  If you change this file, it will break config for users who have instantiated an
+           overrides file with this version of config overrides!
+    Instead, to make changes, you will need to add a new version of the config
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! WARNING !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+*/
+
+// NOTE: All new YAML property names here should be kebab-case because
+//  1. it's easier to read
+//  2. it's easier to write
+//  3. it's consistent with previous properties and changing the format of an already-written config file is very difficult
+type KurtosisConfigV9 struct {
+	// vvvvvvvvv Every new Kurtosis config version must have this key vvvvvvvv
+	ConfigVersion config_version.ConfigVersion `yaml:"config-version"`
+	// ^^^^^^^^^ Every new Kurtosis config version must have this key ^^^^^^^^
+
+	ShouldSendMetrics *bool                               `yaml:"should-send-metrics,omitempty"`
+	KurtosisClusters  map[string]*KurtosisClusterConfigV9 `yaml:"kurtosis-clusters,omitempty"`
+	CloudConfig       *KurtosisCloudConfigV9              `yaml:"cloud-config,omitempty"`
+}

--- a/cli/cli/kurtosis_config/overrides_objects/v9/logs_aggregator_config_v9.go
+++ b/cli/cli/kurtosis_config/overrides_objects/v9/logs_aggregator_config_v9.go
@@ -1,0 +1,17 @@
+package v9
+
+/*
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! WARNING !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+                           DO NOT CHANGE THIS FILE!
+  If you change this file, it will break config for users who have instantiated an
+           overrides file with this version of config overrides!
+    Instead, to make changes, you will need to add a new version of the config
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! WARNING !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+*/
+
+// LogsAggregatorConfigV9 is the configuration for the logs aggregator.
+// Kurtosis leverages a logs collector and logs aggregator to collect, aggregate, and logs from services in enclaves.
+// The logs aggregator aggregates logs forwarded to it by the logs collector and sends them to the configured sinks for storage and downstream processing.
+type LogsAggregatorConfigV9 struct {
+	Sinks map[string]map[string]interface{} `yaml:"sinks,omitempty"`
+}

--- a/cli/cli/kurtosis_config/overrides_objects/v9/logs_collector_config_v9.go
+++ b/cli/cli/kurtosis_config/overrides_objects/v9/logs_collector_config_v9.go
@@ -1,0 +1,20 @@
+package v9
+
+import "github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/logs_collector"
+
+/*
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! WARNING !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+                           DO NOT CHANGE THIS FILE!
+  If you change this file, it will break config for users who have instantiated an
+           overrides file with this version of config overrides!
+    Instead, to make changes, you will need to add a new version of the config
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! WARNING !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+*/
+
+// LogsCollectorConfigV9 is the configuration for the logs collector.
+// Kurtosis leverages a logs collector and logs aggregator to collect, aggregate, and logs from services in enclaves.
+// The logs collector picks up logs from services in enclaves and sends them to the logs aggregator.
+type LogsCollectorConfigV9 struct {
+	Parsers []logs_collector.Parser `yaml:"parsers,omitempty"`
+	Filters []logs_collector.Filter `yaml:"filters,omitempty"`
+}

--- a/cli/cli/kurtosis_config/resolved_config/kurtosis_cluster_config.go
+++ b/cli/cli/kurtosis_config/resolved_config/kurtosis_cluster_config.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"strings"
 
-	v8 "github.com/kurtosis-tech/kurtosis/cli/cli/kurtosis_config/overrides_objects/v8"
+	v9 "github.com/kurtosis-tech/kurtosis/cli/cli/kurtosis_config/overrides_objects/v9"
 	"github.com/kurtosis-tech/kurtosis/contexts-config-store/store"
 
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_impls/docker/docker_kurtosis_backend/backend_creator"
@@ -24,6 +24,28 @@ const (
 	defaultEngineNodeName = ""
 )
 
+// BackendLogCollector selects the log-collector stack the engine wires up at start.
+type BackendLogCollector string
+
+const (
+	// BackendLogCollectorVector is the existing Vector-only behaviour and the default when the field is unset.
+	BackendLogCollectorVector BackendLogCollector = "vector"
+	// BackendLogCollectorOtel auto-starts the OpenTelemetry collector + ClickHouse side containers (Docker-only) when the
+	// engine starts and configures Vector to ship logs to the collector via Loki HTTP.
+	BackendLogCollectorOtel BackendLogCollector = "otel"
+
+	DefaultBackendLogCollector = BackendLogCollectorVector
+)
+
+// IsValid reports whether s is a recognised BackendLogCollector value.
+func (b BackendLogCollector) IsValid() bool {
+	switch b {
+	case BackendLogCollectorVector, BackendLogCollectorOtel:
+		return true
+	}
+	return false
+}
+
 type kurtosisBackendSupplier func(ctx context.Context) (backend_interface.KurtosisBackend, error)
 
 type KurtosisClusterConfig struct {
@@ -35,6 +57,7 @@ type KurtosisClusterConfig struct {
 	graflokiConfig              GrafanaLokiConfig
 	shouldEnableDefaultLogsSink bool
 	allowPrivilegedMode         bool
+	backendLogCollector         BackendLogCollector
 }
 
 type LogsAggregatorConfig struct {
@@ -52,7 +75,7 @@ type GrafanaLokiConfig struct {
 	LokiImage               string
 }
 
-func NewKurtosisClusterConfigFromOverrides(clusterId string, overrides *v8.KurtosisClusterConfigV8) (*KurtosisClusterConfig, error) {
+func NewKurtosisClusterConfigFromOverrides(clusterId string, overrides *v9.KurtosisClusterConfigV9) (*KurtosisClusterConfig, error) {
 	if overrides.Type == nil {
 		return nil, stacktrace.NewError("Kurtosis cluster must have a defined type")
 	}
@@ -120,6 +143,36 @@ func NewKurtosisClusterConfigFromOverrides(clusterId string, overrides *v8.Kurto
 		allowPrivilegedMode = *overrides.AllowPrivilegedMode
 	}
 
+	backendLogCollector := DefaultBackendLogCollector
+	if overrides.BackendLogCollector != nil {
+		candidate := BackendLogCollector(*overrides.BackendLogCollector)
+		if !candidate.IsValid() {
+			return nil, stacktrace.NewError(
+				"Cluster '%v' has unrecognized backend-log-collector '%v'; valid values are: '%v', '%v'",
+				clusterId,
+				*overrides.BackendLogCollector,
+				BackendLogCollectorVector,
+				BackendLogCollectorOtel,
+			)
+		}
+		if candidate == BackendLogCollectorOtel && clusterType != KurtosisClusterType_Docker {
+			return nil, stacktrace.NewError(
+				"Cluster '%v' sets backend-log-collector='%v' but its type is '%v'; the OpenTelemetry backend is Docker-only",
+				clusterId,
+				candidate,
+				clusterType.String(),
+			)
+		}
+		if candidate == BackendLogCollectorOtel && grafloki.ShouldStartBeforeEngine {
+			return nil, stacktrace.NewError(
+				"Cluster '%v' sets backend-log-collector='%v' and grafana-loki.should-start-before-engine=true; pick one log backend at engine start",
+				clusterId,
+				candidate,
+			)
+		}
+		backendLogCollector = candidate
+	}
+
 	return &KurtosisClusterConfig{
 		kurtosisBackendSupplier:     backendSupplier,
 		engineBackendConfigSupplier: engineBackendConfigSupplier,
@@ -129,6 +182,7 @@ func NewKurtosisClusterConfigFromOverrides(clusterId string, overrides *v8.Kurto
 		graflokiConfig:              grafloki,
 		shouldEnableDefaultLogsSink: shouldEnableDefaultLogsSink,
 		allowPrivilegedMode:         allowPrivilegedMode,
+		backendLogCollector:         backendLogCollector,
 	}, nil
 }
 
@@ -168,12 +222,16 @@ func (clusterConfig *KurtosisClusterConfig) GetAllowPrivilegedMode() bool {
 	return clusterConfig.allowPrivilegedMode
 }
 
+func (clusterConfig *KurtosisClusterConfig) GetBackendLogCollector() BackendLogCollector {
+	return clusterConfig.backendLogCollector
+}
+
 // ====================================================================================================
 //
 //	Private Helpers
 //
 // ====================================================================================================
-func getSuppliers(clusterId string, clusterType KurtosisClusterType, kubernetesConfig *v8.KubernetesClusterConfigV8) (
+func getSuppliers(clusterId string, clusterType KurtosisClusterType, kubernetesConfig *v9.KubernetesClusterConfigV9) (
 	kurtosisBackendSupplier,
 	engine_server_launcher.KurtosisBackendConfigSupplier,
 	error,
@@ -304,7 +362,7 @@ func getSuppliers(clusterId string, clusterType KurtosisClusterType, kubernetesC
 	return backendSupplier, engineConfigSupplier, nil
 }
 
-func convertTolerations(configTolerations []*v8.KubernetesTolerationV8) []apiv1.Toleration {
+func convertTolerations(configTolerations []*v9.KubernetesTolerationV9) []apiv1.Toleration {
 	if len(configTolerations) == 0 {
 		return nil
 	}

--- a/cli/cli/kurtosis_config/resolved_config/kurtosis_cluster_config_test.go
+++ b/cli/cli/kurtosis_config/resolved_config/kurtosis_cluster_config_test.go
@@ -3,7 +3,7 @@ package resolved_config
 import (
 	"testing"
 
-	v8 "github.com/kurtosis-tech/kurtosis/cli/cli/kurtosis_config/overrides_objects/v8"
+	v9 "github.com/kurtosis-tech/kurtosis/cli/cli/kurtosis_config/overrides_objects/v9"
 
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/logs_aggregator"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/logs_collector"
@@ -11,7 +11,7 @@ import (
 )
 
 func TestNewKurtosisClusterConfigEmptyOverrides(t *testing.T) {
-	kurtosisClusterConfigOverrides := v8.KurtosisClusterConfigV8{
+	kurtosisClusterConfigOverrides := v9.KurtosisClusterConfigV9{
 		Type:                        nil,
 		Config:                      nil,
 		LogsAggregator:              nil,
@@ -26,7 +26,7 @@ func TestNewKurtosisClusterConfigEmptyOverrides(t *testing.T) {
 
 func TestNewKurtosisClusterConfigDockerType(t *testing.T) {
 	dockerType := KurtosisClusterType_Docker.String()
-	kurtosisClusterConfigOverrides := v8.KurtosisClusterConfigV8{
+	kurtosisClusterConfigOverrides := v9.KurtosisClusterConfigV9{
 		Type:                        &dockerType,
 		Config:                      nil,
 		LogsAggregator:              nil,
@@ -42,7 +42,7 @@ func TestNewKurtosisClusterConfigDockerType(t *testing.T) {
 func TestNewKurtosisClusterConfigAllowPrivilegedMode(t *testing.T) {
 	dockerType := KurtosisClusterType_Docker.String()
 	allowPrivilegedMode := true
-	kurtosisClusterConfigOverrides := v8.KurtosisClusterConfigV8{
+	kurtosisClusterConfigOverrides := v9.KurtosisClusterConfigV9{
 		Type:                        &dockerType,
 		Config:                      nil,
 		LogsAggregator:              nil,
@@ -58,7 +58,7 @@ func TestNewKurtosisClusterConfigAllowPrivilegedMode(t *testing.T) {
 
 func TestNewKurtosisClusterConfigKubernetesNoConfig(t *testing.T) {
 	kubernetesType := KurtosisClusterType_Kubernetes.String()
-	kurtosisClusterConfigOverrides := v8.KurtosisClusterConfigV8{
+	kurtosisClusterConfigOverrides := v9.KurtosisClusterConfigV9{
 		Type:                        &kubernetesType,
 		Config:                      nil,
 		LogsAggregator:              nil,
@@ -73,7 +73,7 @@ func TestNewKurtosisClusterConfigKubernetesNoConfig(t *testing.T) {
 
 func TestNewKurtosisClusterConfigNonsenseType(t *testing.T) {
 	clusterType := "gdsfgsdfvsf"
-	kurtosisClusterConfigOverrides := v8.KurtosisClusterConfigV8{
+	kurtosisClusterConfigOverrides := v9.KurtosisClusterConfigV9{
 		Type:                        &clusterType,
 		Config:                      nil,
 		LogsAggregator:              nil,
@@ -89,7 +89,7 @@ func TestNewKurtosisClusterConfigNonsenseType(t *testing.T) {
 func TestNewKurtosisClusterConfigKubernetesPartialConfig(t *testing.T) {
 	kubernetesType := KurtosisClusterType_Kubernetes.String()
 	kubernetesClusterName := "some-name"
-	kubernetesPartialConfig := v8.KubernetesClusterConfigV8{
+	kubernetesPartialConfig := v9.KubernetesClusterConfigV9{
 		KubernetesClusterName:  &kubernetesClusterName,
 		StorageClass:           nil,
 		EnclaveSizeInMegabytes: nil,
@@ -97,7 +97,7 @@ func TestNewKurtosisClusterConfigKubernetesPartialConfig(t *testing.T) {
 		NodeSelectors:          nil,
 		Tolerations:            nil,
 	}
-	kurtosisClusterConfigOverrides := v8.KurtosisClusterConfigV8{
+	kurtosisClusterConfigOverrides := v9.KurtosisClusterConfigV9{
 		Type:                        &kubernetesType,
 		Config:                      &kubernetesPartialConfig,
 		LogsAggregator:              nil,
@@ -116,7 +116,7 @@ func TestNewKurtosisClusterConfigKubernetesFullConfig(t *testing.T) {
 	kubernetesStorageClass := "some-storage-class"
 	kubernetesEnclaveSizeInMB := uint(5)
 	kubernetesEngineNodeName := "some-node-name"
-	kubernetesFullConfig := v8.KubernetesClusterConfigV8{
+	kubernetesFullConfig := v9.KubernetesClusterConfigV9{
 		KubernetesClusterName:  &kubernetesClusterName,
 		StorageClass:           &kubernetesStorageClass,
 		EnclaveSizeInMegabytes: &kubernetesEnclaveSizeInMB,
@@ -124,7 +124,7 @@ func TestNewKurtosisClusterConfigKubernetesFullConfig(t *testing.T) {
 		NodeSelectors:          nil,
 		Tolerations:            nil,
 	}
-	kurtosisClusterConfigOverrides := v8.KurtosisClusterConfigV8{
+	kurtosisClusterConfigOverrides := v9.KurtosisClusterConfigV9{
 		Type:                        &kubernetesType,
 		Config:                      &kubernetesFullConfig,
 		LogsAggregator:              nil,
@@ -143,7 +143,7 @@ func TestNewKurtosisClusterConfigLogsAggregatorNoConfig(t *testing.T) {
 	kubernetesStorageClass := "some-storage-class"
 	kubernetesEnclaveSizeInMB := uint(5)
 	kubernetesEngineNodeName := "some-node-name"
-	kubernetesFullConfig := v8.KubernetesClusterConfigV8{
+	kubernetesFullConfig := v9.KubernetesClusterConfigV9{
 		KubernetesClusterName:  &kubernetesClusterName,
 		StorageClass:           &kubernetesStorageClass,
 		EnclaveSizeInMegabytes: &kubernetesEnclaveSizeInMB,
@@ -151,7 +151,7 @@ func TestNewKurtosisClusterConfigLogsAggregatorNoConfig(t *testing.T) {
 		NodeSelectors:          nil,
 		Tolerations:            nil,
 	}
-	kurtosisClusterConfigOverrides := v8.KurtosisClusterConfigV8{
+	kurtosisClusterConfigOverrides := v9.KurtosisClusterConfigV9{
 		Type:                        &kubernetesType,
 		Config:                      &kubernetesFullConfig,
 		LogsAggregator:              nil,
@@ -170,7 +170,7 @@ func TestNewKurtosisClusterConfigLogsAggregatorReservedSinkId(t *testing.T) {
 	kubernetesStorageClass := "some-storage-class"
 	kubernetesEnclaveSizeInMB := uint(5)
 	kubernetesEngineNodeName := "some-node-name"
-	kubernetesFullConfig := v8.KubernetesClusterConfigV8{
+	kubernetesFullConfig := v9.KubernetesClusterConfigV9{
 		KubernetesClusterName:  &kubernetesClusterName,
 		StorageClass:           &kubernetesStorageClass,
 		EnclaveSizeInMegabytes: &kubernetesEnclaveSizeInMB,
@@ -178,10 +178,10 @@ func TestNewKurtosisClusterConfigLogsAggregatorReservedSinkId(t *testing.T) {
 		NodeSelectors:          nil,
 		Tolerations:            nil,
 	}
-	kurtosisClusterConfigOverrides := v8.KurtosisClusterConfigV8{
+	kurtosisClusterConfigOverrides := v9.KurtosisClusterConfigV9{
 		Type:   &kubernetesType,
 		Config: &kubernetesFullConfig,
-		LogsAggregator: &v8.LogsAggregatorConfigV8{
+		LogsAggregator: &v9.LogsAggregatorConfigV9{
 			Sinks: map[string]map[string]interface{}{
 				logs_aggregator.DefaultSinkId: {
 					"type": "elasticsearch",
@@ -203,7 +203,7 @@ func TestNewKurtosisClusterConfigLogsAggregatorFullConfig(t *testing.T) {
 	kubernetesStorageClass := "some-storage-class"
 	kubernetesEnclaveSizeInMB := uint(5)
 	kubernetesEngineNodeName := "some-node-name"
-	kubernetesFullConfig := v8.KubernetesClusterConfigV8{
+	kubernetesFullConfig := v9.KubernetesClusterConfigV9{
 		KubernetesClusterName:  &kubernetesClusterName,
 		StorageClass:           &kubernetesStorageClass,
 		EnclaveSizeInMegabytes: &kubernetesEnclaveSizeInMB,
@@ -211,10 +211,10 @@ func TestNewKurtosisClusterConfigLogsAggregatorFullConfig(t *testing.T) {
 		NodeSelectors:          nil,
 		Tolerations:            nil,
 	}
-	kurtosisClusterConfigOverrides := v8.KurtosisClusterConfigV8{
+	kurtosisClusterConfigOverrides := v9.KurtosisClusterConfigV9{
 		Type:   &kubernetesType,
 		Config: &kubernetesFullConfig,
-		LogsAggregator: &v8.LogsAggregatorConfigV8{
+		LogsAggregator: &v9.LogsAggregatorConfigV9{
 			Sinks: map[string]map[string]interface{}{
 				"elasticsearch": {
 					"type": "elasticsearch",
@@ -236,7 +236,7 @@ func TestNewKurtosisClusterConfigGraflokiNoConfig(t *testing.T) {
 	kubernetesStorageClass := "some-storage-class"
 	kubernetesEnclaveSizeInMB := uint(5)
 	kubernetesEngineNodeName := "some-node-name"
-	kubernetesFullConfig := v8.KubernetesClusterConfigV8{
+	kubernetesFullConfig := v9.KubernetesClusterConfigV9{
 		KubernetesClusterName:  &kubernetesClusterName,
 		StorageClass:           &kubernetesStorageClass,
 		EnclaveSizeInMegabytes: &kubernetesEnclaveSizeInMB,
@@ -244,10 +244,10 @@ func TestNewKurtosisClusterConfigGraflokiNoConfig(t *testing.T) {
 		NodeSelectors:          nil,
 		Tolerations:            nil,
 	}
-	kurtosisClusterConfigOverrides := v8.KurtosisClusterConfigV8{
+	kurtosisClusterConfigOverrides := v9.KurtosisClusterConfigV9{
 		Type:   &kubernetesType,
 		Config: &kubernetesFullConfig,
-		LogsAggregator: &v8.LogsAggregatorConfigV8{
+		LogsAggregator: &v9.LogsAggregatorConfigV9{
 			Sinks: map[string]map[string]interface{}{
 				"elasticsearch": {
 					"type": "elasticsearch",
@@ -271,7 +271,7 @@ func TestNewKurtosisClusterConfigGraflokiFullConfig(t *testing.T) {
 	kubernetesEngineNodeName := "some-node-name"
 	grafanaImage := "grafana:1.32"
 	lokiImage := "loki:1.32"
-	kubernetesFullConfig := v8.KubernetesClusterConfigV8{
+	kubernetesFullConfig := v9.KubernetesClusterConfigV9{
 		KubernetesClusterName:  &kubernetesClusterName,
 		StorageClass:           &kubernetesStorageClass,
 		EnclaveSizeInMegabytes: &kubernetesEnclaveSizeInMB,
@@ -279,11 +279,11 @@ func TestNewKurtosisClusterConfigGraflokiFullConfig(t *testing.T) {
 		NodeSelectors:          nil,
 		Tolerations:            nil,
 	}
-	kurtosisClusterConfigOverrides := v8.KurtosisClusterConfigV8{
+	kurtosisClusterConfigOverrides := v9.KurtosisClusterConfigV9{
 		Type:           &kubernetesType,
 		Config:         &kubernetesFullConfig,
 		LogsAggregator: nil,
-		GrafanaLokiConfig: &v8.GrafanaLokiConfigV8{
+		GrafanaLokiConfig: &v9.GrafanaLokiConfigV9{
 			ShouldStartBeforeEngine: false,
 			GrafanaImage:            grafanaImage,
 			LokiImage:               lokiImage,
@@ -307,7 +307,7 @@ func TestNewKurtosisClusterConfigShouldEnableDefaultLogsSink(t *testing.T) {
 	kubernetesEnclaveSizeInMB := uint(5)
 	kubernetesEngineNodeName := "some-node-name"
 	ShouldEnableDefaultLogsSink := true
-	kubernetesFullConfig := v8.KubernetesClusterConfigV8{
+	kubernetesFullConfig := v9.KubernetesClusterConfigV9{
 		KubernetesClusterName:  &kubernetesClusterName,
 		StorageClass:           &kubernetesStorageClass,
 		EnclaveSizeInMegabytes: &kubernetesEnclaveSizeInMB,
@@ -315,7 +315,7 @@ func TestNewKurtosisClusterConfigShouldEnableDefaultLogsSink(t *testing.T) {
 		NodeSelectors:          nil,
 		Tolerations:            nil,
 	}
-	kurtosisClusterConfigOverrides := v8.KurtosisClusterConfigV8{
+	kurtosisClusterConfigOverrides := v9.KurtosisClusterConfigV9{
 		Type:                        &kubernetesType,
 		Config:                      &kubernetesFullConfig,
 		LogsAggregator:              nil,
@@ -334,7 +334,7 @@ func TestNewKurtosisClusterConfigLogsCollectorNoConfig(t *testing.T) {
 	kubernetesStorageClass := "some-storage-class"
 	kubernetesEnclaveSizeInMB := uint(5)
 	kubernetesEngineNodeName := "some-node-name"
-	kubernetesFullConfig := v8.KubernetesClusterConfigV8{
+	kubernetesFullConfig := v9.KubernetesClusterConfigV9{
 		KubernetesClusterName:  &kubernetesClusterName,
 		StorageClass:           &kubernetesStorageClass,
 		EnclaveSizeInMegabytes: &kubernetesEnclaveSizeInMB,
@@ -342,7 +342,7 @@ func TestNewKurtosisClusterConfigLogsCollectorNoConfig(t *testing.T) {
 		NodeSelectors:          nil,
 		Tolerations:            nil,
 	}
-	kurtosisClusterConfigOverrides := v8.KurtosisClusterConfigV8{
+	kurtosisClusterConfigOverrides := v9.KurtosisClusterConfigV9{
 		Type:                        &kubernetesType,
 		Config:                      &kubernetesFullConfig,
 		LogsAggregator:              nil,
@@ -363,7 +363,7 @@ func TestNewKurtosisClusterConfigLogsCollectorFullConfig(t *testing.T) {
 	kubernetesStorageClass := "some-storage-class"
 	kubernetesEnclaveSizeInMB := uint(5)
 	kubernetesEngineNodeName := "some-node-name"
-	kubernetesFullConfig := v8.KubernetesClusterConfigV8{
+	kubernetesFullConfig := v9.KubernetesClusterConfigV9{
 		KubernetesClusterName:  &kubernetesClusterName,
 		StorageClass:           &kubernetesStorageClass,
 		EnclaveSizeInMegabytes: &kubernetesEnclaveSizeInMB,
@@ -371,17 +371,17 @@ func TestNewKurtosisClusterConfigLogsCollectorFullConfig(t *testing.T) {
 		NodeSelectors:          nil,
 		Tolerations:            nil,
 	}
-	kurtosisClusterConfigOverrides := v8.KurtosisClusterConfigV8{
+	kurtosisClusterConfigOverrides := v9.KurtosisClusterConfigV9{
 		Type:   &kubernetesType,
 		Config: &kubernetesFullConfig,
-		LogsAggregator: &v8.LogsAggregatorConfigV8{
+		LogsAggregator: &v9.LogsAggregatorConfigV9{
 			Sinks: map[string]map[string]interface{}{
 				"elasticsearch": {
 					"type": "elasticsearch",
 				},
 			},
 		},
-		LogsCollector: &v8.LogsCollectorConfigV8{
+		LogsCollector: &v9.LogsCollectorConfigV9{
 			Filters: []logs_collector.Filter{
 				{
 					Name:  "grep",

--- a/cli/cli/kurtosis_config/resolved_config/kurtosis_cluster_config_test.go
+++ b/cli/cli/kurtosis_config/resolved_config/kurtosis_cluster_config_test.go
@@ -19,6 +19,7 @@ func TestNewKurtosisClusterConfigEmptyOverrides(t *testing.T) {
 		GrafanaLokiConfig:           nil,
 		ShouldEnableDefaultLogsSink: nil,
 		AllowPrivilegedMode:         nil,
+		BackendLogCollector:         nil,
 	}
 	_, err := NewKurtosisClusterConfigFromOverrides("test", &kurtosisClusterConfigOverrides)
 	require.Error(t, err)
@@ -34,6 +35,7 @@ func TestNewKurtosisClusterConfigDockerType(t *testing.T) {
 		GrafanaLokiConfig:           nil,
 		ShouldEnableDefaultLogsSink: nil,
 		AllowPrivilegedMode:         nil,
+		BackendLogCollector:         nil,
 	}
 	_, err := NewKurtosisClusterConfigFromOverrides("test", &kurtosisClusterConfigOverrides)
 	require.NoError(t, err)
@@ -50,6 +52,7 @@ func TestNewKurtosisClusterConfigAllowPrivilegedMode(t *testing.T) {
 		GrafanaLokiConfig:           nil,
 		ShouldEnableDefaultLogsSink: nil,
 		AllowPrivilegedMode:         &allowPrivilegedMode,
+		BackendLogCollector:         nil,
 	}
 	clusterConfig, err := NewKurtosisClusterConfigFromOverrides("test", &kurtosisClusterConfigOverrides)
 	require.NoError(t, err)
@@ -66,6 +69,7 @@ func TestNewKurtosisClusterConfigKubernetesNoConfig(t *testing.T) {
 		GrafanaLokiConfig:           nil,
 		ShouldEnableDefaultLogsSink: nil,
 		AllowPrivilegedMode:         nil,
+		BackendLogCollector:         nil,
 	}
 	_, err := NewKurtosisClusterConfigFromOverrides("test", &kurtosisClusterConfigOverrides)
 	require.Error(t, err)
@@ -81,6 +85,7 @@ func TestNewKurtosisClusterConfigNonsenseType(t *testing.T) {
 		GrafanaLokiConfig:           nil,
 		ShouldEnableDefaultLogsSink: nil,
 		AllowPrivilegedMode:         nil,
+		BackendLogCollector:         nil,
 	}
 	_, err := NewKurtosisClusterConfigFromOverrides("test", &kurtosisClusterConfigOverrides)
 	require.Error(t, err)
@@ -105,6 +110,7 @@ func TestNewKurtosisClusterConfigKubernetesPartialConfig(t *testing.T) {
 		GrafanaLokiConfig:           nil,
 		ShouldEnableDefaultLogsSink: nil,
 		AllowPrivilegedMode:         nil,
+		BackendLogCollector:         nil,
 	}
 	_, err := NewKurtosisClusterConfigFromOverrides("test", &kurtosisClusterConfigOverrides)
 	require.Error(t, err)
@@ -132,6 +138,7 @@ func TestNewKurtosisClusterConfigKubernetesFullConfig(t *testing.T) {
 		GrafanaLokiConfig:           nil,
 		ShouldEnableDefaultLogsSink: nil,
 		AllowPrivilegedMode:         nil,
+		BackendLogCollector:         nil,
 	}
 	_, err := NewKurtosisClusterConfigFromOverrides("test", &kurtosisClusterConfigOverrides)
 	require.NoError(t, err)
@@ -159,6 +166,7 @@ func TestNewKurtosisClusterConfigLogsAggregatorNoConfig(t *testing.T) {
 		GrafanaLokiConfig:           nil,
 		ShouldEnableDefaultLogsSink: nil,
 		AllowPrivilegedMode:         nil,
+		BackendLogCollector:         nil,
 	}
 	_, err := NewKurtosisClusterConfigFromOverrides("test", &kurtosisClusterConfigOverrides)
 	require.NoError(t, err)
@@ -192,6 +200,7 @@ func TestNewKurtosisClusterConfigLogsAggregatorReservedSinkId(t *testing.T) {
 		ShouldEnableDefaultLogsSink: nil,
 		LogsCollector:               nil,
 		AllowPrivilegedMode:         nil,
+		BackendLogCollector:         nil,
 	}
 	_, err := NewKurtosisClusterConfigFromOverrides("test", &kurtosisClusterConfigOverrides)
 	require.Error(t, err)
@@ -225,6 +234,7 @@ func TestNewKurtosisClusterConfigLogsAggregatorFullConfig(t *testing.T) {
 		ShouldEnableDefaultLogsSink: nil,
 		LogsCollector:               nil,
 		AllowPrivilegedMode:         nil,
+		BackendLogCollector:         nil,
 	}
 	_, err := NewKurtosisClusterConfigFromOverrides("test", &kurtosisClusterConfigOverrides)
 	require.NoError(t, err)
@@ -258,6 +268,7 @@ func TestNewKurtosisClusterConfigGraflokiNoConfig(t *testing.T) {
 		ShouldEnableDefaultLogsSink: nil,
 		LogsCollector:               nil,
 		AllowPrivilegedMode:         nil,
+		BackendLogCollector:         nil,
 	}
 	_, err := NewKurtosisClusterConfigFromOverrides("test", &kurtosisClusterConfigOverrides)
 	require.NoError(t, err)
@@ -291,6 +302,7 @@ func TestNewKurtosisClusterConfigGraflokiFullConfig(t *testing.T) {
 		ShouldEnableDefaultLogsSink: nil,
 		LogsCollector:               nil,
 		AllowPrivilegedMode:         nil,
+		BackendLogCollector:         nil,
 	}
 	actualKurtosisClusterConfig, err := NewKurtosisClusterConfigFromOverrides("test", &kurtosisClusterConfigOverrides)
 	require.NotNil(t, actualKurtosisClusterConfig.graflokiConfig)
@@ -323,6 +335,7 @@ func TestNewKurtosisClusterConfigShouldEnableDefaultLogsSink(t *testing.T) {
 		GrafanaLokiConfig:           nil,
 		ShouldEnableDefaultLogsSink: &ShouldEnableDefaultLogsSink,
 		AllowPrivilegedMode:         nil,
+		BackendLogCollector:         nil,
 	}
 	_, err := NewKurtosisClusterConfigFromOverrides("test", &kurtosisClusterConfigOverrides)
 	require.NoError(t, err)
@@ -350,6 +363,7 @@ func TestNewKurtosisClusterConfigLogsCollectorNoConfig(t *testing.T) {
 		GrafanaLokiConfig:           nil,
 		ShouldEnableDefaultLogsSink: nil,
 		AllowPrivilegedMode:         nil,
+		BackendLogCollector:         nil,
 	}
 	actualKurtosisClusterConfig, err := NewKurtosisClusterConfigFromOverrides("test", &kurtosisClusterConfigOverrides)
 	require.NoError(t, err)
@@ -417,6 +431,7 @@ func TestNewKurtosisClusterConfigLogsCollectorFullConfig(t *testing.T) {
 		GrafanaLokiConfig:           nil,
 		ShouldEnableDefaultLogsSink: nil,
 		AllowPrivilegedMode:         nil,
+		BackendLogCollector:         nil,
 	}
 	actualKurtosisClusterConfig, err := NewKurtosisClusterConfigFromOverrides("test", &kurtosisClusterConfigOverrides)
 	require.NoError(t, err)

--- a/cli/cli/kurtosis_config/resolved_config/kurtosis_config.go
+++ b/cli/cli/kurtosis_config/resolved_config/kurtosis_config.go
@@ -2,7 +2,7 @@ package resolved_config
 
 import (
 	"github.com/kurtosis-tech/kurtosis/cli/cli/kurtosis_config/config_version"
-	v8 "github.com/kurtosis-tech/kurtosis/cli/cli/kurtosis_config/overrides_objects/v8"
+	v9 "github.com/kurtosis-tech/kurtosis/cli/cli/kurtosis_config/overrides_objects/v9"
 	"github.com/kurtosis-tech/stacktrace"
 )
 
@@ -42,7 +42,7 @@ the overrides on top of the default config.
 */
 type KurtosisConfig struct {
 	// Only necessary to store for when we serialize overrides
-	overrides *v8.KurtosisConfigV8
+	overrides *v9.KurtosisConfigV9
 
 	shouldSendMetrics bool
 	clusters          map[string]*KurtosisClusterConfig
@@ -140,7 +140,7 @@ func NewKurtosisConfigFromOverrides(uncastedOverrides interface{}) (*KurtosisCon
 
 // NOTE: We probably want to remove this function entirely
 func NewKurtosisConfigFromRequiredFields(shouldSendMetrics bool) (*KurtosisConfig, error) {
-	overrides := &v8.KurtosisConfigV8{
+	overrides := &v9.KurtosisConfigV9{
 		ConfigVersion:     0,
 		ShouldSendMetrics: &shouldSendMetrics,
 		KurtosisClusters:  nil,
@@ -172,7 +172,7 @@ func (kurtosisConfig *KurtosisConfig) GetKurtosisClusters() map[string]*Kurtosis
 	return kurtosisConfig.clusters
 }
 
-func (kurtosisConfig *KurtosisConfig) GetOverrides() *v8.KurtosisConfigV8 {
+func (kurtosisConfig *KurtosisConfig) GetOverrides() *v9.KurtosisConfigV9 {
 	return kurtosisConfig.overrides
 }
 
@@ -186,15 +186,15 @@ func (kurtosisConfig *KurtosisConfig) GetCloudConfig() *KurtosisCloudConfig {
 //
 // ====================================================================================================
 // This is a separate helper function so that we can use it to ensure that the
-func castUncastedOverrides(uncastedOverrides interface{}) (*v8.KurtosisConfigV8, error) {
-	castedOverrides, ok := uncastedOverrides.(*v8.KurtosisConfigV8)
+func castUncastedOverrides(uncastedOverrides interface{}) (*v9.KurtosisConfigV9, error) {
+	castedOverrides, ok := uncastedOverrides.(*v9.KurtosisConfigV9)
 	if !ok {
 		return nil, stacktrace.NewError("An error occurred casting the uncasted config overrides to the right version")
 	}
 	return castedOverrides, nil
 }
 
-func getDefaultKurtosisClusterConfigOverrides() map[string]*v8.KurtosisClusterConfigV8 {
+func getDefaultKurtosisClusterConfigOverrides() map[string]*v9.KurtosisClusterConfigV9 {
 	dockerClusterType := KurtosisClusterType_Docker.String()
 	minikubeClusterType := KurtosisClusterType_Kubernetes.String()
 	minikubeKubernetesClusterName := defaultMinikubeClusterKubernetesClusterNameStr
@@ -203,7 +203,7 @@ func getDefaultKurtosisClusterConfigOverrides() map[string]*v8.KurtosisClusterCo
 	minikubeEngineNodeName := defaultMinikubeEngineNodeName
 	shouldEnableDefaultLogsSink := DefaultShouldEnableDefaultLogsSink
 
-	result := map[string]*v8.KurtosisClusterConfigV8{
+	result := map[string]*v9.KurtosisClusterConfigV9{
 		DefaultDockerClusterName: {
 			Type:              &dockerClusterType,
 			Config:            nil, // Must be nil for Docker
@@ -213,7 +213,7 @@ func getDefaultKurtosisClusterConfigOverrides() map[string]*v8.KurtosisClusterCo
 		},
 		defaultMinikubeClusterName: {
 			Type: &minikubeClusterType,
-			Config: &v8.KubernetesClusterConfigV8{
+			Config: &v9.KubernetesClusterConfigV9{
 				KubernetesClusterName:  &minikubeKubernetesClusterName,
 				StorageClass:           &minikubeStorageClass,
 				EnclaveSizeInMegabytes: &minikubeEnclaveDataVolSizeMB,

--- a/cli/cli/kurtosis_config/resolved_config/kurtosis_config_test.go
+++ b/cli/cli/kurtosis_config/resolved_config/kurtosis_config_test.go
@@ -4,7 +4,7 @@ import (
 	"sort"
 	"testing"
 
-	v8 "github.com/kurtosis-tech/kurtosis/cli/cli/kurtosis_config/overrides_objects/v8"
+	v9 "github.com/kurtosis-tech/kurtosis/cli/cli/kurtosis_config/overrides_objects/v9"
 
 	"github.com/kurtosis-tech/kurtosis/cli/cli/kurtosis_config/config_version"
 	"github.com/kurtosis-tech/kurtosis/cli/cli/kurtosis_config/overrides_objects"
@@ -52,7 +52,7 @@ func TestNewKurtosisConfigFromRequiredFields_MetricsElectionIsSent(t *testing.T)
 }
 
 func TestNewKurtosisConfigEmptyOverrides(t *testing.T) {
-	_, err := NewKurtosisConfigFromOverrides(&v8.KurtosisConfigV8{
+	_, err := NewKurtosisConfigFromOverrides(&v9.KurtosisConfigV9{
 		ConfigVersion:     0,
 		ShouldSendMetrics: nil,
 		KurtosisClusters:  nil,
@@ -63,9 +63,9 @@ func TestNewKurtosisConfigEmptyOverrides(t *testing.T) {
 }
 
 func TestNewKurtosisConfigJustMetrics(t *testing.T) {
-	version := config_version.ConfigVersion_v8
+	version := config_version.ConfigVersion_v9
 	shouldSendMetrics := true
-	originalOverrides := v8.KurtosisConfigV8{
+	originalOverrides := v9.KurtosisConfigV9{
 		ConfigVersion:     version,
 		ShouldSendMetrics: &shouldSendMetrics,
 		KurtosisClusters:  nil,
@@ -93,14 +93,14 @@ func TestNewKurtosisConfigOverridesAreLatestVersion(t *testing.T) {
 }
 
 func TestCloudConfigOverridesApiUrl(t *testing.T) {
-	version := config_version.ConfigVersion_v8
+	version := config_version.ConfigVersion_v9
 	shouldSendMetrics := true
 	apiUrl := "test.com"
-	originalOverrides := v8.KurtosisConfigV8{
+	originalOverrides := v9.KurtosisConfigV9{
 		ConfigVersion:     version,
 		ShouldSendMetrics: &shouldSendMetrics,
 		KurtosisClusters:  nil,
-		CloudConfig: &v8.KurtosisCloudConfigV8{
+		CloudConfig: &v9.KurtosisCloudConfigV9{
 			ApiUrl:           &apiUrl,
 			Port:             nil,
 			CertificateChain: nil,

--- a/docs/docs/advanced-concepts/kurtosis-config.md
+++ b/docs/docs/advanced-concepts/kurtosis-config.md
@@ -14,8 +14,8 @@ Below is a fully annotated example of a `kurtosis-config.yml` with explanations 
 
 # Required. The version of the Kurtosis config schema.
 # This ensures compatibility with the CLI. 
-# Latest supported version is 8.
-config-version: 8
+# Latest supported version is 9.
+config-version: 9
 
 # Optional. Whether Kurtosis should send anonymous telemetry (usage) data.
 # Default: true
@@ -40,6 +40,15 @@ kurtosis-clusters:
     # This is a CLI/request opt-in, not an engine-side operator policy. Direct API
     # clients can also opt in by setting allow_privileged_mode on the run request.
     allow-privileged-mode: false
+
+    # Optional. Selects which log-collector stack the engine wires up at start.
+    # Valid values: "vector" (default), "otel".
+    # When set to "otel" (Docker only), `kurtosis engine start`/`restart` auto-starts the
+    # OpenTelemetry collector and ClickHouse side containers and configures the engine's
+    # Vector aggregator to ship logs to the collector via Loki HTTP. Equivalent to running
+    # `kurtosis otel start` before `kurtosis engine start`.
+    # Mutually exclusive with `grafana-loki.should-start-before-engine: true` below.
+    backend-log-collector: vector
 
     # Optional. Configures external sinks to export service logs from enclaves.
     # This uses Vector under the hood and supports all Vector sink types.


### PR DESCRIPTION
## Summary
Adds a new opt-in cluster config field — `backend-log-collector` — to `kurtosis-config.yml` so users can make OpenTelemetry the default log collector at engine start, instead of having to run `kurtosis otel start` manually each time.

| Value     | Behaviour                                                                                                                                                          |
|-----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| _(unset)_ | Existing behaviour (Vector → default sinks). Default.                                                                                                              |
| `vector`  | Same as unset; explicit.                                                                                                                                            |
| `otel`    | Docker-only. `engine start`/`restart` auto-starts the OpenTelemetry collector + ClickHouse side containers and adds a Loki sink → collector to the engine's Vector aggregator. Same wiring `kurtosis otel start` does manually. |

### Example

```yaml
config-version: 9
should-send-metrics: true
kurtosis-clusters:
  docker:
    type: docker
    backend-log-collector: otel    # ← new
```

## Implementation
- **Config overrides v9.** New `cli/cli/kurtosis_config/overrides_objects/v9/` directory with the new `BackendLogCollector *string` field, plus the matching `migrateFromV8`, deserializer entry, and empty-struct registration. `config_version.go` and the enumer are bumped. The existing v8 path remains as the source for the migrator and stays unchanged.
- **Resolved config validation.**
  - Unknown values are rejected with a list of valid options.
  - `otel` on Kubernetes/Podman is rejected (OTel side containers are Docker-only).
  - `backend-log-collector: otel` combined with `grafana-loki.should-start-before-engine: true` is rejected — pick one log backend per engine start.
- **Engine manager auto-start.** Both `StartEngineIdempotentlyWith{Default,Custom}Version` gain a parallel OTel block right after the grafloki one: if `!skipConfiguredOtel && clusterConfig.GetBackendLogCollector() == otel`, call `otel.StartOtel(...)`, log the endpoints, and merge `otel.NewLokiSink(...)` into `additionalSinks` before the engine is launched.
- **Skip flag for manual commands.** New `SetSkipConfiguredOtel(bool)` parallels the existing `SetSkipConfiguredGrafloki`. `grafloki start`, `loki start`, and `otel start` all set it so the auto-start path doesn't double-fire when the user explicitly picks a stack.
- **Docs.** `advanced-concepts/kurtosis-config.md` now lists the field with its accepted values and the mutual-exclusion note. `config-version` in the example bumped 8 → 9.

## Follow-up
Once #3135 (the docs PR adding `otel-start.md` / `otel-stop.md`) lands, that page's "There is currently no \`kurtosis-config.yml\` switch to enable the OpenTelemetry collector by default" sentence will be stale and should be replaced with a pointer to `backend-log-collector: otel`. Happy to push that as a follow-up commit once both PRs are queued.

## Test plan
- [x] `go test ./cli/cli/kurtosis_config/...` — all existing tests green against v9
- [x] `go build ./cli/cli/...` — clean build
- [ ] Smoke test on Docker: `backend-log-collector: otel` in `~/.kurtosis/kurtosis-config.yml`, then `kurtosis engine restart` → OTel collector + ClickHouse come up, logs land in ClickHouse
- [ ] Smoke test on Kubernetes: `backend-log-collector: otel` + `type: kubernetes` returns the expected "Docker-only" error
- [ ] Smoke test mutual exclusion: `backend-log-collector: otel` + `grafana-loki.should-start-before-engine: true` returns the expected error
- [ ] Smoke test backwards compat: an existing v8 config still loads and resolves with `backend-log-collector` defaulting to `vector`