### PR TITLE
feat(otel): publish ClickHouse native port + cluster config for native-protocol tenants

### DIFF
--- a/cli/cli/helpers/otel/docker_otel.go
+++ b/cli/cli/helpers/otel/docker_otel.go
@@ -26,6 +26,7 @@ const (
 	bridgeNetworkName = "bridge"
 
 	clickHouseInitSQLMountPath = "/docker-entrypoint-initdb.d/init.sql"
+	clickHouseConfigMountPath  = "/etc/clickhouse-server/config.d/kurtosis-otel.xml"
 	collectorConfigMountPath   = "/etc/otelcol/config.yaml"
 
 	clickHouseMaxAvailabilityRetries    = 60
@@ -46,6 +47,9 @@ var collectorContainerLabels = map[string]string{
 
 //go:embed files/init.sql
 var clickHouseInitSQL string
+
+//go:embed files/clickhouse-config.xml
+var clickHouseConfigXML string
 
 //go:embed files/collector-bootstrap-config.yaml
 var collectorBootstrapConfig string
@@ -145,6 +149,11 @@ func createClickHouseContainer(ctx context.Context, dockerManager *docker_manage
 		return "", "", nil, stacktrace.Propagate(err, "An error occurred writing ClickHouse init SQL.")
 	}
 
+	configFilepath, err := writeTempFile("otel-clickhouse-config-*.xml", clickHouseConfigXML)
+	if err != nil {
+		return "", "", nil, stacktrace.Propagate(err, "An error occurred writing ClickHouse config.")
+	}
+
 	clickHouseUuid, err := uuid_generator.GenerateUUIDString()
 	if err != nil {
 		return "", "", nil, stacktrace.Propagate(err, "An error occurred generating a uuid for otel ClickHouse.")
@@ -153,7 +162,7 @@ func createClickHouseContainer(ctx context.Context, dockerManager *docker_manage
 	clickHouseArgs := docker_manager.NewCreateAndStartContainerArgsBuilder(defaultClickHouseImage, clickHouseContainerName, bridgeNetworkId).
 		WithUsedPorts(map[nat.Port]docker_manager.PortPublishSpec{
 			nat.Port(strconv.Itoa(int(clickHouseHTTPPort)) + "/tcp"):   docker_manager.NewManualPublishingSpec(clickHouseHTTPHostPort),
-			nat.Port(strconv.Itoa(int(clickHouseNativePort)) + "/tcp"): docker_manager.NewNoPublishingSpec(),
+			nat.Port(strconv.Itoa(int(clickHouseNativePort)) + "/tcp"): docker_manager.NewManualPublishingSpec(clickHouseNativeHostPort),
 		}).
 		WithEnvironmentVariables(map[string]string{
 			"CLICKHOUSE_DB":                        "otel",
@@ -161,6 +170,7 @@ func createClickHouseContainer(ctx context.Context, dockerManager *docker_manage
 		}).
 		WithBindMounts(map[string]string{
 			initSQLFilepath: clickHouseInitSQLMountPath,
+			configFilepath:  clickHouseConfigMountPath,
 		}).
 		WithFetchingLatestImageIfMissing().
 		WithRestartPolicy(docker_manager.RestartOnFailure).
@@ -289,7 +299,9 @@ func clickHouseContainerNeedsRecreation(clickHouseContainer *types.Container) bo
 	if clickHouseContainer == nil {
 		return false
 	}
-	return !hasExpectedHostPortBinding(clickHouseContainer.GetHostPortBindings(), clickHouseHTTPPort, clickHouseHTTPHostPort)
+	hostPortBindings := clickHouseContainer.GetHostPortBindings()
+	return !hasExpectedHostPortBinding(hostPortBindings, clickHouseHTTPPort, clickHouseHTTPHostPort) ||
+		!hasExpectedHostPortBinding(hostPortBindings, clickHouseNativePort, clickHouseNativeHostPort)
 }
 
 func collectorContainerNeedsRecreation(collectorContainer *types.Container, clickHouseWasCreated bool) bool {

--- a/cli/cli/helpers/otel/files/clickhouse-config.xml
+++ b/cli/cli/helpers/otel/files/clickhouse-config.xml
@@ -1,0 +1,64 @@
+<clickhouse>
+    <!--
+        Single-node "cluster" configuration for the kurtosis otel ClickHouse.
+
+        The otel_logs / otel_traces tables are plain MergeTree and do not need
+        any of this. It exists so that tenants whose schema uses Replicated
+        engines and `ON CLUSTER '{cluster}'` DDL — e.g. the ethereum-package
+        observoor eBPF profiler — can create their tables in this same instance
+        instead of standing up a second ClickHouse.
+
+        Mounted as a single file into /etc/clickhouse-server/config.d/, so it is
+        merged with (not a replacement for) the image's default config, including
+        docker_related_config.xml which already sets listen_host=0.0.0.0.
+    -->
+
+    <macros>
+        <installation>kurtosis-otel</installation>
+        <cluster>kurtosis-otel</cluster>
+        <shard>1</shard>
+        <replica>kurtosis-otel-clickhouse</replica>
+    </macros>
+
+    <!--
+        Single-replica cluster. The replica host is "localhost" so distributed
+        DDL resolves to this node regardless of the container's hostname.
+    -->
+    <remote_servers replace="true">
+        <kurtosis-otel>
+            <shard>
+                <replica>
+                    <host>localhost</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+        </kurtosis-otel>
+    </remote_servers>
+
+    <!-- Embedded ClickHouse Keeper, required by Replicated table engines. -->
+    <keeper_server>
+        <tcp_port>9181</tcp_port>
+        <server_id>1</server_id>
+        <log_storage_path>/var/lib/clickhouse/coordination/log</log_storage_path>
+        <snapshot_storage_path>/var/lib/clickhouse/coordination/snapshots</snapshot_storage_path>
+        <coordination_settings>
+            <operation_timeout_ms>10000</operation_timeout_ms>
+            <session_timeout_ms>30000</session_timeout_ms>
+            <raft_logs_level>warning</raft_logs_level>
+        </coordination_settings>
+        <raft_configuration>
+            <server>
+                <id>1</id>
+                <hostname>localhost</hostname>
+                <port>9444</port>
+            </server>
+        </raft_configuration>
+    </keeper_server>
+
+    <zookeeper>
+        <node>
+            <host>localhost</host>
+            <port>9181</port>
+        </node>
+    </zookeeper>
+</clickhouse>

--- a/cli/cli/helpers/otel/files/init.sql
+++ b/cli/cli/helpers/otel/files/init.sql
@@ -1,5 +1,9 @@
 CREATE DATABASE IF NOT EXISTS otel;
 
+-- Database for the ethereum-package observoor eBPF profiler. observoor's
+-- migrator creates its own tables on startup but expects the database to exist.
+CREATE DATABASE IF NOT EXISTS observoor;
+
 CREATE TABLE IF NOT EXISTS otel.otel_logs
 (
     Timestamp                  DateTime64(9) CODEC(Delta(8), ZSTD(1)),

--- a/cli/cli/helpers/otel/shared.go
+++ b/cli/cli/helpers/otel/shared.go
@@ -28,7 +28,12 @@ const (
 	// collide with a developer's own ClickHouse (8123) or OTLP collector (4317/4318)
 	// already bound on the Docker host. Must match the ethereum-package's
 	// ENGINE_OTEL_* constants in main.star.
-	clickHouseHTTPHostPort    = uint16(18123)
+	clickHouseHTTPHostPort = uint16(18123)
+	// clickHouseNativeHostPort publishes ClickHouse's native (binary) protocol on
+	// the Docker host so enclave services that speak it directly — e.g.
+	// ethereum-package's observoor eBPF profiler — can write into the same
+	// ClickHouse as traces/logs instead of standing up their own instance.
+	clickHouseNativeHostPort  = uint16(19000)
 	collectorOTLPGRPCHostPort = uint16(14317)
 	collectorOTLPHTTPHostPort = uint16(14318)
 


### PR DESCRIPTION
## What

The `kurtosis otel` ClickHouse only published its **HTTP** port (host `18123`). Enclave services that speak the ClickHouse **native binary protocol** had no way to write into it.

[ethereum-package](https://github.com/ethpandaops/ethereum-package)'s upcoming `observoor` eBPF profiler uses `clickhouse-rs` (native TCP) and a `ReplicatedReplacingMergeTree` / `ON CLUSTER` schema. Without a native endpoint + cluster config it would have to stand up a **second** ClickHouse instead of sharing the one that already collects traces/logs.

## Changes

- **Publish the native port** 9000 on the Docker host as `19000` (matches ethereum-package's `ENGINE_OTEL_CLICKHOUSE_NATIVE_PORT`). It was previously `NewNoPublishingSpec()`.
- **Mount a single-node cluster config** (`files/clickhouse-config.xml`): macros (`{cluster}`/`{installation}`/`{shard}`/`{replica}`), a single-replica `remote_servers` entry (host `localhost` so DDL resolves on any node), and an embedded ClickHouse Keeper — required by Replicated table engines. Mounted as a single file into `config.d/`, so it merges with the image defaults (incl. `docker_related_config.xml`); the `otel_logs`/`otel_traces` tables are plain `MergeTree` and are unaffected.
- **Pre-create the `observoor` database** alongside `otel` in `init.sql`.
- **Recreate** a stale ClickHouse container when the native host-port binding is missing.

The collector keeps reaching ClickHouse over the bridge network as before; the new host publish is purely additive for enclave-side native clients.

## Verification

Ran `clickhouse-server:26.3-alpine` with the exact env, `init.sql` and config this code mounts:

- ClickHouse comes up healthy; `otel` (4 tables) **and** `observoor` databases present
- `kurtosis-otel` cluster + Keeper macros resolve
- observoor's real `ReplicatedReplacingMergeTree` `ON CLUSTER '{cluster}'` DDL **succeeds over the published native port 19000**

`go build` / `go vet` / `gofmt` clean on `cli/cli/helpers/otel`.