### PR TITLE
ci: log in to Docker Hub in build/test jobs to avoid anonymous pull rate limits

### DIFF
--- a/.github/actions/prepare-k8s-testing/action.yml
+++ b/.github/actions/prepare-k8s-testing/action.yml
@@ -29,8 +29,10 @@ runs:
     - name: Create K3D/K3S cluster
       shell: bash
       run: |
+        # Per-attempt timeout: k3d's --wait has no deadline of its own, so a wedged
+        # node container would otherwise hang the job forever and defeat the retry.
         for i in $(seq 1 3); do
-          if k3d cluster create -p "${{ inputs.reverse-proxy-port }}:80@loadbalancer" --servers 1 --wait --verbose; then
+          if timeout 300 k3d cluster create -p "${{ inputs.reverse-proxy-port }}:80@loadbalancer" --servers 1 --wait --verbose; then
             echo "Cluster created on attempt ${i}"
             break
           fi
@@ -119,7 +121,7 @@ runs:
       shell: bash
       run: |
         for i in $(seq 1 3); do
-          if ${{ inputs.kurtosis-binpath }} engine start --cli-log-level=debug --enclave-pool-size 2; then
+          if timeout 300 ${{ inputs.kurtosis-binpath }} engine start --cli-log-level=debug --enclave-pool-size 2; then
             echo "Engine started on attempt ${i}"
             break
           fi

--- a/.github/actions/prepare-k8s-testing/action.yml
+++ b/.github/actions/prepare-k8s-testing/action.yml
@@ -28,7 +28,40 @@ runs:
 
     - name: Create K3D/K3S cluster
       shell: bash
-      run: k3d cluster create -p "${{ inputs.reverse-proxy-port }}:80@loadbalancer" --servers 1 --wait --verbose
+      run: |
+        for i in $(seq 1 3); do
+          if k3d cluster create -p "${{ inputs.reverse-proxy-port }}:80@loadbalancer" --servers 1 --wait --verbose; then
+            echo "Cluster created on attempt ${i}"
+            break
+          fi
+          echo "Attempt ${i}: k3d cluster create failed, retrying in 10s..."
+          k3d cluster delete 2>/dev/null || true
+          sleep 10
+          if [ "${i}" = "3" ]; then
+            echo "Failed to create cluster after 3 attempts"
+            exit 1
+          fi
+        done
+
+    # k3d's --wait only waits for the node containers; the apiserver can still refuse
+    # requests ('apiserver not ready') for a while after. Wait until it serves reads.
+    - name: Wait for Kubernetes API server to be ready
+      shell: bash
+      run: |
+        for i in $(seq 1 60); do
+          if kubectl get --raw='/readyz' >/dev/null 2>&1 && kubectl get namespaces >/dev/null 2>&1; then
+            echo "API server is ready after ${i} attempts"
+            break
+          fi
+          echo "Attempt ${i}: API server not ready, retrying in 2s..."
+          sleep 2
+          if [ "${i}" = "60" ]; then
+            echo "API server did not become ready in time"
+            kubectl get --raw='/readyz?verbose' || true
+            exit 1
+          fi
+        done
+        kubectl wait --for=condition=Ready node --all --timeout=120s
 
     - name: Load Docker images
       shell: bash
@@ -84,7 +117,20 @@ runs:
 
     - name: Start Kurtosis engine in K8s backend
       shell: bash
-      run: ${{ inputs.kurtosis-binpath }} engine start --cli-log-level=debug --enclave-pool-size 2
+      run: |
+        for i in $(seq 1 3); do
+          if ${{ inputs.kurtosis-binpath }} engine start --cli-log-level=debug --enclave-pool-size 2; then
+            echo "Engine started on attempt ${i}"
+            break
+          fi
+          echo "Attempt ${i}: engine start failed, retrying in 10s..."
+          ${{ inputs.kurtosis-binpath }} engine stop 2>/dev/null || true
+          sleep 10
+          if [ "${i}" = "3" ]; then
+            echo "Failed to start engine after 3 attempts"
+            exit 1
+          fi
+        done
 
     - name: Run Kurtosis gateway (background)
       shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -180,6 +180,15 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
+      # Authenticated pulls avoid Docker Hub anonymous rate limits on shared runner IPs.
+      # Skipped when secrets are unavailable (fork PRs, Dependabot) - pulls fall back to anonymous.
+      - name: Login to Docker Hub
+        if: ${{ secrets.DOCKERHUB_USERNAME != '' }}
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
       - name: Build and save image
         run: |
           core/files_artifacts_expander/scripts/build.sh
@@ -237,6 +246,15 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      # Authenticated pulls avoid Docker Hub anonymous rate limits on shared runner IPs.
+      # Skipped when secrets are unavailable (fork PRs, Dependabot) - pulls fall back to anonymous.
+      - name: Login to Docker Hub
+        if: ${{ secrets.DOCKERHUB_USERNAME != '' }}
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Build and save image
         run: |
@@ -327,6 +345,15 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      # Authenticated pulls avoid Docker Hub anonymous rate limits on shared runner IPs.
+      # Skipped when secrets are unavailable (fork PRs, Dependabot) - pulls fall back to anonymous.
+      - name: Login to Docker Hub
+        if: ${{ secrets.DOCKERHUB_USERNAME != '' }}
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Build and save image
         run: |
@@ -512,6 +539,15 @@ jobs:
 
       - name: Disable analytics
         run: $KURTOSIS_BINPATH analytics disable
+
+      # Authenticated pulls avoid Docker Hub anonymous rate limits on shared runner IPs.
+      # Skipped when secrets are unavailable (fork PRs, Dependabot) - pulls fall back to anonymous.
+      - name: Login to Docker Hub
+        if: ${{ secrets.DOCKERHUB_USERNAME != '' }}
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Prepare Docker testing
         uses: ./.github/actions/prepare-docker-testing
@@ -722,6 +758,15 @@ jobs:
       - name: Disable analytics
         run: $KURTOSIS_BINPATH analytics disable
 
+      # Authenticated pulls avoid Docker Hub anonymous rate limits on shared runner IPs.
+      # Skipped when secrets are unavailable (fork PRs, Dependabot) - pulls fall back to anonymous.
+      - name: Login to Docker Hub
+        if: ${{ secrets.DOCKERHUB_USERNAME != '' }}
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
       - name: Prepare Docker testing
         uses: ./.github/actions/prepare-docker-testing
         with:
@@ -768,6 +813,15 @@ jobs:
 
       - name: Disable analytics
         run: $KURTOSIS_BINPATH analytics disable
+
+      # Authenticated pulls avoid Docker Hub anonymous rate limits on shared runner IPs.
+      # Skipped when secrets are unavailable (fork PRs, Dependabot) - pulls fall back to anonymous.
+      - name: Login to Docker Hub
+        if: ${{ secrets.DOCKERHUB_USERNAME != '' }}
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Prepare Docker testing
         uses: ./.github/actions/prepare-docker-testing
@@ -820,6 +874,16 @@ jobs:
 
       - name: Disable analytics
         run: $KURTOSIS_BINPATH analytics disable
+
+      # Authenticated pulls avoid Docker Hub anonymous rate limits on shared runner IPs.
+      # k3d node images (rancher/k3s, k3d-io tools/proxy) are pulled via the Docker daemon, so this covers them too.
+      # Skipped when secrets are unavailable (fork PRs, Dependabot) - pulls fall back to anonymous.
+      - name: Login to Docker Hub
+        if: ${{ secrets.DOCKERHUB_USERNAME != '' }}
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Prepare K8s testing
         uses: ./.github/actions/prepare-k8s-testing
@@ -874,6 +938,15 @@ jobs:
 
       - name: Disable analytics
         run: $KURTOSIS_BINPATH analytics disable
+
+      # Authenticated pulls avoid Docker Hub anonymous rate limits on shared runner IPs.
+      # Skipped when secrets are unavailable (fork PRs, Dependabot) - pulls fall back to anonymous.
+      - name: Login to Docker Hub
+        if: ${{ secrets.DOCKERHUB_USERNAME != '' }}
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Prepare Docker testing
         uses: ./.github/actions/prepare-docker-testing
@@ -940,6 +1013,16 @@ jobs:
       - name: Disable analytics
         run: $KURTOSIS_BINPATH analytics disable
 
+      # Authenticated pulls avoid Docker Hub anonymous rate limits on shared runner IPs.
+      # k3d node images (rancher/k3s, k3d-io tools/proxy) are pulled via the Docker daemon, so this covers them too.
+      # Skipped when secrets are unavailable (fork PRs, Dependabot) - pulls fall back to anonymous.
+      - name: Login to Docker Hub
+        if: ${{ secrets.DOCKERHUB_USERNAME != '' }}
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
       - name: Prepare K8s testing
         uses: ./.github/actions/prepare-k8s-testing
         with:
@@ -976,6 +1059,15 @@ jobs:
         with:
           path: ${{ env.WORKSPACE_PATH }}
           merge-multiple: true
+
+      # Authenticated pulls avoid Docker Hub anonymous rate limits on shared runner IPs.
+      # Skipped when secrets are unavailable (fork PRs, Dependabot) - pulls fall back to anonymous.
+      - name: Login to Docker Hub
+        if: ${{ secrets.DOCKERHUB_USERNAME != '' }}
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       # Install released Kurtosis CLI from apt
       - name: Install released Kurtosis CLI
@@ -1078,6 +1170,15 @@ jobs:
       - name: Disable analytics
         run: $KURTOSIS_BINPATH analytics disable
 
+      # Authenticated pulls avoid Docker Hub anonymous rate limits on shared runner IPs.
+      # Skipped when secrets are unavailable (fork PRs, Dependabot) - pulls fall back to anonymous.
+      - name: Login to Docker Hub
+        if: ${{ secrets.DOCKERHUB_USERNAME != '' }}
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
       - name: Prepare Docker testing
         uses: ./.github/actions/prepare-docker-testing
         with:
@@ -1152,6 +1253,16 @@ jobs:
 
       - name: Disable analytics
         run: $KURTOSIS_BINPATH analytics disable
+
+      # Authenticated pulls avoid Docker Hub anonymous rate limits on shared runner IPs.
+      # k3d node images (rancher/k3s, k3d-io tools/proxy) are pulled via the Docker daemon, so this covers them too.
+      # Skipped when secrets are unavailable (fork PRs, Dependabot) - pulls fall back to anonymous.
+      - name: Login to Docker Hub
+        if: ${{ secrets.DOCKERHUB_USERNAME != '' }}
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Prepare K8s testing
         uses: ./.github/actions/prepare-k8s-testing

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,8 @@ env:
   ENGINE_IMAGE_FILENAME: engine-server-image.tgz
   FILES_ARTIFACTS_EXPANDER_IMAGE_FILENAME: files-artifacts-expander-image.tgz
   REVERSE_PROXY_PORT: '9730'
+  # Exposed as env because the secrets context is not available in step-level `if` conditions
+  DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
 
 jobs:
   # ============================================================================
@@ -183,7 +185,7 @@ jobs:
       # Authenticated pulls avoid Docker Hub anonymous rate limits on shared runner IPs.
       # Skipped when secrets are unavailable (fork PRs, Dependabot) - pulls fall back to anonymous.
       - name: Login to Docker Hub
-        if: ${{ secrets.DOCKERHUB_USERNAME != '' }}
+        if: ${{ env.DOCKERHUB_USERNAME != '' }}
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -250,7 +252,7 @@ jobs:
       # Authenticated pulls avoid Docker Hub anonymous rate limits on shared runner IPs.
       # Skipped when secrets are unavailable (fork PRs, Dependabot) - pulls fall back to anonymous.
       - name: Login to Docker Hub
-        if: ${{ secrets.DOCKERHUB_USERNAME != '' }}
+        if: ${{ env.DOCKERHUB_USERNAME != '' }}
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -349,7 +351,7 @@ jobs:
       # Authenticated pulls avoid Docker Hub anonymous rate limits on shared runner IPs.
       # Skipped when secrets are unavailable (fork PRs, Dependabot) - pulls fall back to anonymous.
       - name: Login to Docker Hub
-        if: ${{ secrets.DOCKERHUB_USERNAME != '' }}
+        if: ${{ env.DOCKERHUB_USERNAME != '' }}
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -543,7 +545,7 @@ jobs:
       # Authenticated pulls avoid Docker Hub anonymous rate limits on shared runner IPs.
       # Skipped when secrets are unavailable (fork PRs, Dependabot) - pulls fall back to anonymous.
       - name: Login to Docker Hub
-        if: ${{ secrets.DOCKERHUB_USERNAME != '' }}
+        if: ${{ env.DOCKERHUB_USERNAME != '' }}
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -761,7 +763,7 @@ jobs:
       # Authenticated pulls avoid Docker Hub anonymous rate limits on shared runner IPs.
       # Skipped when secrets are unavailable (fork PRs, Dependabot) - pulls fall back to anonymous.
       - name: Login to Docker Hub
-        if: ${{ secrets.DOCKERHUB_USERNAME != '' }}
+        if: ${{ env.DOCKERHUB_USERNAME != '' }}
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -817,7 +819,7 @@ jobs:
       # Authenticated pulls avoid Docker Hub anonymous rate limits on shared runner IPs.
       # Skipped when secrets are unavailable (fork PRs, Dependabot) - pulls fall back to anonymous.
       - name: Login to Docker Hub
-        if: ${{ secrets.DOCKERHUB_USERNAME != '' }}
+        if: ${{ env.DOCKERHUB_USERNAME != '' }}
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -879,7 +881,7 @@ jobs:
       # k3d node images (rancher/k3s, k3d-io tools/proxy) are pulled via the Docker daemon, so this covers them too.
       # Skipped when secrets are unavailable (fork PRs, Dependabot) - pulls fall back to anonymous.
       - name: Login to Docker Hub
-        if: ${{ secrets.DOCKERHUB_USERNAME != '' }}
+        if: ${{ env.DOCKERHUB_USERNAME != '' }}
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -942,7 +944,7 @@ jobs:
       # Authenticated pulls avoid Docker Hub anonymous rate limits on shared runner IPs.
       # Skipped when secrets are unavailable (fork PRs, Dependabot) - pulls fall back to anonymous.
       - name: Login to Docker Hub
-        if: ${{ secrets.DOCKERHUB_USERNAME != '' }}
+        if: ${{ env.DOCKERHUB_USERNAME != '' }}
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -1017,7 +1019,7 @@ jobs:
       # k3d node images (rancher/k3s, k3d-io tools/proxy) are pulled via the Docker daemon, so this covers them too.
       # Skipped when secrets are unavailable (fork PRs, Dependabot) - pulls fall back to anonymous.
       - name: Login to Docker Hub
-        if: ${{ secrets.DOCKERHUB_USERNAME != '' }}
+        if: ${{ env.DOCKERHUB_USERNAME != '' }}
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -1063,7 +1065,7 @@ jobs:
       # Authenticated pulls avoid Docker Hub anonymous rate limits on shared runner IPs.
       # Skipped when secrets are unavailable (fork PRs, Dependabot) - pulls fall back to anonymous.
       - name: Login to Docker Hub
-        if: ${{ secrets.DOCKERHUB_USERNAME != '' }}
+        if: ${{ env.DOCKERHUB_USERNAME != '' }}
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -1173,7 +1175,7 @@ jobs:
       # Authenticated pulls avoid Docker Hub anonymous rate limits on shared runner IPs.
       # Skipped when secrets are unavailable (fork PRs, Dependabot) - pulls fall back to anonymous.
       - name: Login to Docker Hub
-        if: ${{ secrets.DOCKERHUB_USERNAME != '' }}
+        if: ${{ env.DOCKERHUB_USERNAME != '' }}
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -1258,7 +1260,7 @@ jobs:
       # k3d node images (rancher/k3s, k3d-io tools/proxy) are pulled via the Docker daemon, so this covers them too.
       # Skipped when secrets are unavailable (fork PRs, Dependabot) - pulls fall back to anonymous.
       - name: Login to Docker Hub
-        if: ${{ secrets.DOCKERHUB_USERNAME != '' }}
+        if: ${{ env.DOCKERHUB_USERNAME != '' }}
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}


### PR DESCRIPTION
## Why

PRs #3146 and #3071 have been repeatedly kicked out of the merge queue by `Build` workflow failures that are all Docker Hub pull flakiness, e.g.:

- `k3d cluster create` pulling `rancher/k3s`: `Get "https://registry-1.docker.io/v2/": context deadline exceeded`
- `kurtosis engine start` pulling `timberio/vector`: `Client.Timeout exceeded while awaiting headers`

Every pull in the Build workflow is anonymous — the only `docker/login-action` usage in CI is in `publish.yml`. GitHub-hosted runners share IP pools, so anonymous pulls regularly hit Docker Hub rate limits, and the merge queue re-runs the whole workflow on a fresh runner for every queue entry (testing entries together, so one flake kicks out every queued PR).

## What

Add a `Login to Docker Hub` step (same pinned `docker/login-action` version as `publish.yml`, using the existing `DOCKERHUB_USERNAME`/`DOCKERHUB_PASSWORD` secrets) to the 12 `build.yml` jobs that pull from Docker Hub:

**Image builds** (buildx pulls base images): `build-files-artifacts-expander`, `build-api-container-server`, `build-engine-server`

**Docker-backend tests**: `test-basic-cli-docker`, `test-ci-for-failure`, `build-golang-testsuite-docker`, `build-typescript-testsuite-docker`, `test-old-enclave-continuity`, `test-reverse-proxy-docker`

**K8s-backend tests** (k3d node images are pulled via the Docker daemon, so login covers them): `build-golang-testsuite-k8s-matrix`, `build-typescript-testsuite-k8s`, `test-reverse-proxy-k8s`

The step is guarded with `if: ${{ secrets.DOCKERHUB_USERNAME != '' }}` so fork PRs and Dependabot runs (where these secrets are unavailable) skip the login and keep working with anonymous pulls, same as today.

## Not covered

- Images pulled *inside* the k3s cluster by containerd don't use the host Docker credentials. The locally built SHA-tagged images are imported via `k3d image import`, so this mostly matters for the occasional `ImagePullBackOff` flake — separate issue.
- `push-cli-artifacts.yml` runs its job in a `docker/tilt-releaser` container image pulled anonymously. `container.credentials` can't be conditionally applied, so adding it would break runs without secrets; left alone.
- The exec race (`container not found ("user-service-container")`) seen in one merge-queue failure is addressed separately by the `bbusa/k8s-exec-retry-container-not-ready` branch.

## Update: k8s test-prep hardening

The merge-queue run of this very PR hit a different infra flake: `apiserver not ready` when starting the Kurtosis engine right after `k3d cluster create` (k3d's `--wait` only waits for node containers, not for the apiserver to serve requests). Added to this PR:

- retry `k3d cluster create` up to 3× (deleting the half-created cluster between attempts)
- explicit wait on the apiserver `/readyz` endpoint + node `Ready` condition before proceeding
- retry `kurtosis engine start` up to 3×