### PR TITLE
fix(kubernetes): retry exec when kubelet refuses the stream before the container is ready

### DIFF
--- a/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_manager/kubernetes_manager.go
+++ b/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_manager/kubernetes_manager.go
@@ -89,6 +89,9 @@ const (
 	execConnectionUpgradeFailureSubstr = "unable to upgrade connection"
 	execNotReadyRetryTimeout           = 90 * time.Second
 	execNotReadyRetryInterval          = 1 * time.Second
+	// Exit code returned when the exec command could not be run at all (as opposed to a command
+	// that ran and exited non-zero).
+	execFailureExitCode = 1
 )
 
 // We'll try to use the nicer-to-use shells first before we drop down to the lower shells
@@ -2008,7 +2011,22 @@ func (manager *KubernetesManager) RunExecCommandWithContext(
 			Tty:               false,
 			TerminalSizeQueue: nil,
 		})
-		if streamErr == nil || !strings.Contains(streamErr.Error(), execConnectionUpgradeFailureSubstr) || time.Now().After(retryDeadline) {
+		// The only retryable failure is the kubelet refusing the stream upgrade because it
+		// can't find a running container; anything else is a real exec result/error.
+		if streamErr == nil || !strings.Contains(streamErr.Error(), execConnectionUpgradeFailureSubstr) {
+			break
+		}
+		// The kubelet refused because it has no running container by that name. That can mean
+		// the container is still starting (worth retrying) OR that it has already terminated -
+		// e.g. OOMKilled or evicted under node resource pressure. User-service pods use
+		// RestartPolicy=Never, so a terminated container never comes back and retrying for the
+		// full timeout just wastes time and buries the real cause behind an opaque "container
+		// not found". Inspect the container's actual state and fail fast with the reason if it
+		// is terminal.
+		if terminalErr := manager.getExecTargetTerminalStateError(ctx, namespaceName, podName, containerName, streamErr); terminalErr != nil {
+			return execFailureExitCode, terminalErr
+		}
+		if time.Now().After(retryDeadline) {
 			break
 		}
 		logrus.Debugf(
@@ -2019,7 +2037,7 @@ func (manager *KubernetesManager) RunExecCommandWithContext(
 		)
 		select {
 		case <-ctx.Done():
-			return 1, stacktrace.Propagate(ctx.Err(), "Context cancelled while waiting to retry exec into pod '%v' container '%v'", podName, containerName)
+			return execFailureExitCode, stacktrace.Propagate(ctx.Err(), "Context cancelled while waiting to retry exec into pod '%v' container '%v'", podName, containerName)
 		case <-time.After(execNotReadyRetryInterval):
 		}
 	}
@@ -2045,6 +2063,63 @@ func (manager *KubernetesManager) RunExecCommandWithContext(
 	}
 
 	return successExecCommandExitCode, nil
+}
+
+// getExecTargetTerminalStateError turns the kubelet's opaque "unable to upgrade connection:
+// container not found" exec refusal into the real root cause when the target container is in a
+// terminal state. It returns a descriptive error if the container has terminated (e.g. OOMKilled
+// or evicted under node resource pressure) - which, given user-service pods use RestartPolicy=Never,
+// means it will never come back and retrying is futile. It returns nil if the container is simply
+// still starting up (and the exec is therefore worth retrying) or if the state can't be determined.
+func (manager *KubernetesManager) getExecTargetTerminalStateError(
+	ctx context.Context,
+	namespaceName string,
+	podName string,
+	containerName string,
+	streamErr error,
+) error {
+	pod, err := manager.GetPod(ctx, namespaceName, podName)
+	if err != nil {
+		// We couldn't diagnose the container state; let the caller keep retrying rather than
+		// masking the original (retryable) error with a lookup failure.
+		logrus.Debugf("Couldn't fetch pod '%v' to diagnose exec refusal for container '%v': %v", podName, containerName, err)
+		return nil
+	}
+	for _, containerStatus := range pod.Status.ContainerStatuses {
+		if containerStatus.Name != containerName {
+			continue
+		}
+		if terminated := containerStatus.State.Terminated; terminated != nil {
+			return stacktrace.Propagate(
+				streamErr,
+				"Cannot exec into container '%v' in pod '%v': the container has terminated (reason: '%v', exit code: '%v', message: '%v'). "+
+					"Service pods are created with RestartPolicy=Never, so the container will not be restarted. This typically means the container "+
+					"was killed (e.g. OOMKilled, or evicted because the node ran low on memory/disk) rather than the exec racing container startup.",
+				containerName,
+				podName,
+				terminated.Reason,
+				terminated.ExitCode,
+				terminated.Message,
+			)
+		}
+		// Not currently running, and it has terminated at least once before: under RestartPolicy=Never
+		// there is nothing running to exec into, so surface why it last died instead of retrying.
+		if lastTerminated := containerStatus.LastTerminationState.Terminated; containerStatus.State.Running == nil && lastTerminated != nil {
+			return stacktrace.Propagate(
+				streamErr,
+				"Cannot exec into container '%v' in pod '%v': the container is not running; it previously terminated (reason: '%v', exit code: '%v').",
+				containerName,
+				podName,
+				lastTerminated.Reason,
+				lastTerminated.ExitCode,
+			)
+		}
+		// State is Waiting (e.g. ContainerCreating) or Running but the kubelet briefly can't resolve
+		// it - both are genuinely transient, so let the caller retry.
+		return nil
+	}
+	// No status for the target container yet (pod just created) - transient, keep retrying.
+	return nil
 }
 
 func (manager *KubernetesManager) RunExecCommand(

--- a/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_manager/kubernetes_manager.go
+++ b/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_manager/kubernetes_manager.go
@@ -87,8 +87,8 @@ const (
 	// so nothing has been written to the output writers and the attempt is safe
 	// to retry until the container becomes exec-ready.
 	execConnectionUpgradeFailureSubstr = "unable to upgrade connection"
-	execNotReadyRetryTimeout           = 30 * time.Second
-	execNotReadyRetryInterval          = 500 * time.Millisecond
+	execNotReadyRetryTimeout           = 90 * time.Second
+	execNotReadyRetryInterval          = 1 * time.Second
 )
 
 // We'll try to use the nicer-to-use shells first before we drop down to the lower shells
@@ -2929,7 +2929,20 @@ func (manager *KubernetesManager) waitForPodAvailability(ctx context.Context, na
 		case apiv1.PodUnknown:
 			// not impl - skipping
 		case apiv1.PodRunning:
-			return nil
+			// Phase Running only guarantees the containers have been created and at
+			// least one is running *or still starting/restarting*. The kubelet refuses
+			// execs against a container that isn't actually running ("unable to upgrade
+			// connection: container not found"), so wait until every container is.
+			allContainersRunning := len(pod.Status.ContainerStatuses) > 0
+			for _, containerStatus := range pod.Status.ContainerStatuses {
+				if containerStatus.State.Running == nil {
+					allContainersRunning = false
+					break
+				}
+			}
+			if allContainersRunning {
+				return nil
+			}
 		case apiv1.PodPending:
 			// check if pod is unschedulable (e.g. targeting a node with taints it doesn't tolerate)
 			for _, condition := range pod.Status.Conditions {

--- a/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_manager/kubernetes_manager.go
+++ b/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_manager/kubernetes_manager.go
@@ -79,6 +79,16 @@ const (
 	listOptionsTimeoutSeconds      int64 = 10
 	contextDeadlineExceeded              = "context deadline exceeded"
 	expectedStatusMessageSliceSize       = 6
+
+	// kubelet refuses exec streams with "unable to upgrade connection: container
+	// not found ..." while a pod's container is still being created — pod phase
+	// Running only guarantees the containers are created and at least one is
+	// running *or starting*. The refusal happens before the stream is upgraded,
+	// so nothing has been written to the output writers and the attempt is safe
+	// to retry until the container becomes exec-ready.
+	execConnectionUpgradeFailureSubstr = "unable to upgrade connection"
+	execNotReadyRetryTimeout           = 30 * time.Second
+	execNotReadyRetryInterval          = 500 * time.Millisecond
 )
 
 // We'll try to use the nicer-to-use shells first before we drop down to the lower shells
@@ -1988,13 +1998,32 @@ func (manager *KubernetesManager) RunExecCommandWithContext(
 		)
 	}
 
-	if err = exec.StreamWithContext(ctx, remotecommand.StreamOptions{
-		Stdin:             nil,
-		Stdout:            stdOutOutput,
-		Stderr:            stdErrOutput,
-		Tty:               false,
-		TerminalSizeQueue: nil,
-	}); err != nil {
+	var streamErr error
+	retryDeadline := time.Now().Add(execNotReadyRetryTimeout)
+	for {
+		streamErr = exec.StreamWithContext(ctx, remotecommand.StreamOptions{
+			Stdin:             nil,
+			Stdout:            stdOutOutput,
+			Stderr:            stdErrOutput,
+			Tty:               false,
+			TerminalSizeQueue: nil,
+		})
+		if streamErr == nil || !strings.Contains(streamErr.Error(), execConnectionUpgradeFailureSubstr) || time.Now().After(retryDeadline) {
+			break
+		}
+		logrus.Debugf(
+			"Exec into pod '%v' container '%v' was refused before the stream was upgraded (%v); the container is likely still starting, retrying",
+			podName,
+			containerName,
+			streamErr,
+		)
+		select {
+		case <-ctx.Done():
+			return 1, stacktrace.Propagate(ctx.Err(), "Context cancelled while waiting to retry exec into pod '%v' container '%v'", podName, containerName)
+		case <-time.After(execNotReadyRetryInterval):
+		}
+	}
+	if err = streamErr; err != nil {
 		// Kubernetes returns the exit code of the command via a string in the error message, so we have to extract it
 		statusError := err.Error()
 

--- a/internal_testsuites/golang/testsuite/startlark_user_passing_test/starlark_user_passing_test.go
+++ b/internal_testsuites/golang/testsuite/startlark_user_passing_test/starlark_user_passing_test.go
@@ -13,8 +13,15 @@ const (
 	noOverrideServiceName   = "no-override"
 	userOverrideServiceName = "user-override"
 
+	// We deliberately use a small image that (a) defaults to a non-root user so the
+	// "no override" case can be distinguished from the root override, and (b) is already
+	// pulled by the rest of the suite so it adds no node disk pressure. besu:24.3 was a
+	// huge image whose only role here was "has a non-root default user", and pulling it
+	// on a loaded kind node risked DiskPressure evictions; combined with
+	// RestartPolicy=Never that killed the container and made exec fail with a confusing
+	// "container not found". mendhak/http-https-echo defaults to the non-root 'node' user.
 	starlarkScriptWithUserIdPassed = `
-IMAGE = "hyperledger/besu:24.3"
+IMAGE = "mendhak/http-https-echo:26"
 def run(plan, args):
 	no_override = plan.add_service(
 		name = "` + noOverrideServiceName + `",
@@ -59,7 +66,7 @@ func TestUserIDOverridesWork(t *testing.T) {
 	expectedOutput := `Service '` + noOverrideServiceName + `' added with service UUID '[a-z0-9]{32}'
 Command returned with exit code '0' and the following output:
 --------------------
-besu
+node
 
 --------------------
 Service '` + userOverrideServiceName + `' added with service UUID '[a-z0-9]{32}'

--- a/internal_testsuites/golang/testsuite/startosis_run_sh_task_test/run_task_sh_task_test.go
+++ b/internal_testsuites/golang/testsuite/startosis_run_sh_task_test/run_task_sh_task_test.go
@@ -17,7 +17,7 @@ def run(plan):
 `
 	runshStarlarkFileArtifact = `
 def run(plan):
-  result = plan.run_sh(run="mkdir -p /src && echo kurtosis > /src/tech.txt && echo example > /src/example.txt", store=["/src/tech.txt", StoreSpec(src="/src", name="src"), StoreSpec(src="/src/*")], image="ethpandaops/ethereum-genesis-generator:1.0.14")
+  result = plan.run_sh(run="mkdir -p /src && echo kurtosis > /src/tech.txt && echo example > /src/example.txt", store=["/src/tech.txt", StoreSpec(src="/src", name="src"), StoreSpec(src="/src/*")], image="alpine:3.17")
   file_artifacts = result.files_artifacts
   result2 = plan.run_sh(run="cat /temp/tech.txt", files={"/temp": file_artifacts[0]})
   plan.verify(result2.output, "==", "kurtosis\n")


### PR DESCRIPTION
## Why

Execs against freshly started services on the Kubernetes backend intermittently fail with:

```
unable to upgrade connection: container not found ("user-service-container")
```

Pod phase `Running` only guarantees the containers have been created and at least one is running *or starting*; the kubelet refuses exec streams until the target container actually exists. This race is currently the single most frequent k8s testsuite failure in the merge queue — it killed `TestUserIDOverridesWork` in merge-queue runs on June 10 and twice on June 11 (e.g. [this run](https://github.com/kurtosis-tech/kurtosis/actions/runs/27350926539)), and affects any exec-right-after-`add_service` flow.

## What

In `KubernetesManager.RunExecCommandWithContext`, retry `StreamWithContext` when the error contains `unable to upgrade connection`, for up to 30s at 500ms intervals, honoring context cancellation.

This is safe to retry because the refusal happens **before** the SPDY stream is upgraded — nothing has been written to the stdout/stderr writers yet, so a retry can't duplicate output.

## Related

- #3147 fixes the other two merge-queue flake buckets (Docker Hub anonymous pull rate limits, apiserver-not-ready during k8s test prep).

## Update: stronger root-cause fix

The first commit's 30s retry was not enough — a run still hit `container not found` for the full window. The real hole is upstream: `waitForPodAvailability` returned on pod phase `Running`, which per the k8s docs only guarantees containers are **created** and at least one is running *or still starting/restarting*. So `add_service` could complete before the user-service container was actually running, and the immediate `exec` got refused for however long startup takes under CI load.

Second commit:
- `waitForPodAvailability` now also requires every `containerStatus` to report `State.Running` (existing 15-min timeout unchanged)
- exec retry window widened 30s → 90s (interval 500ms → 1s) as a backstop for kubelet cache lag