### PR TITLE
perf(k8s): opt-in 0s pod-delete grace via env var

### DIFF
--- a/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_manager/kubernetes_manager.go
+++ b/container-engine-lib/lib/backend_impls/kubernetes/kubernetes_manager/kubernetes_manager.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_impls/kubernetes/object_attributes_provider/kubernetes_label_key"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/concurrent_writer"
+	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/kubernetes_grace"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/uuid_generator"
 	v1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -106,13 +107,16 @@ var commandToRunWhenCreatingUserServiceShell = []string{
 }
 
 var (
-	globalDeletePolicy  = metav1.DeletePropagationForeground
-	globalDeleteOptions = metav1.DeleteOptions{
+	globalDeletePolicy = metav1.DeletePropagationForeground
+	// nil keeps Kubernetes' default grace; the env var can set it to 0 for fast,
+	// graceless teardown of Kurtosis' ephemeral pods.
+	podDeleteGracePeriod = kubernetes_grace.Override()
+	globalDeleteOptions  = metav1.DeleteOptions{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "",
 			APIVersion: "",
 		},
-		GracePeriodSeconds: nil,
+		GracePeriodSeconds: podDeleteGracePeriod,
 		Preconditions:      nil,
 		OrphanDependents:   nil,
 		PropagationPolicy:  &globalDeletePolicy,
@@ -1113,7 +1117,7 @@ func (manager *KubernetesManager) CreatePod(
 		Containers:                    podContainers,
 		EphemeralContainers:           nil,
 		RestartPolicy:                 restartPolicy,
-		TerminationGracePeriodSeconds: nil,
+		TerminationGracePeriodSeconds: podDeleteGracePeriod,
 		ActiveDeadlineSeconds:         nil,
 		DNSPolicy:                     "",
 		NodeSelector:                  nodeSelectors,
@@ -1335,7 +1339,7 @@ func (manager *KubernetesManager) CreateDaemonSet(
 				Containers:                    containers,
 				EphemeralContainers:           nil,
 				RestartPolicy:                 "",
-				TerminationGracePeriodSeconds: nil,
+				TerminationGracePeriodSeconds: podDeleteGracePeriod,
 				ActiveDeadlineSeconds:         nil,
 				DNSPolicy:                     "",
 				NodeSelector:                  nodeSelector,
@@ -1576,7 +1580,7 @@ func (manager *KubernetesManager) CreateDeployment(
 				Containers:                    containers,
 				EphemeralContainers:           nil,
 				RestartPolicy:                 "",
-				TerminationGracePeriodSeconds: nil,
+				TerminationGracePeriodSeconds: podDeleteGracePeriod,
 				ActiveDeadlineSeconds:         nil,
 				DNSPolicy:                     "",
 				NodeSelector:                  nodeSelector,
@@ -2786,7 +2790,7 @@ func (manager *KubernetesManager) CreateJob(
 		// We don't want Kubernetes automagically restarting our containers
 		RestartPolicy:                 apiv1.RestartPolicyNever,
 		EphemeralContainers:           nil,
-		TerminationGracePeriodSeconds: nil,
+		TerminationGracePeriodSeconds: podDeleteGracePeriod,
 		ActiveDeadlineSeconds:         nil,
 		DNSPolicy:                     "",
 		NodeSelector:                  nil,

--- a/container-engine-lib/lib/kubernetes_grace/kubernetes_grace.go
+++ b/container-engine-lib/lib/kubernetes_grace/kubernetes_grace.go
@@ -1,0 +1,27 @@
+package kubernetes_grace
+
+import (
+	"os"
+	"strconv"
+
+	"github.com/sirupsen/logrus"
+)
+
+// EnvVarName overrides the grace period for deleting Kurtosis' pods (and the
+// TerminationGracePeriodSeconds stamped on their specs). Unset keeps Kubernetes'
+// default; "0" deletes immediately for fast teardown of ephemeral pods.
+const EnvVarName = "KURTOSIS_POD_DELETE_GRACE_PERIOD_SECONDS"
+
+// Override returns the configured grace period, or nil to keep Kubernetes' default.
+func Override() *int64 {
+	raw := os.Getenv(EnvVarName)
+	if raw == "" {
+		return nil
+	}
+	parsed, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || parsed < 0 {
+		logrus.Warnf("Ignoring invalid %v=%q; expected a non-negative integer", EnvVarName, raw)
+		return nil
+	}
+	return &parsed
+}

--- a/core/launcher/api_container_launcher/api_container_launcher.go
+++ b/core/launcher/api_container_launcher/api_container_launcher.go
@@ -7,9 +7,12 @@ package api_container_launcher
 import (
 	"context"
 	"fmt"
+	"os"
+
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/api_container"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/enclave"
+	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/kubernetes_grace"
 	"github.com/kurtosis-tech/kurtosis/core/launcher/args"
 	"github.com/kurtosis-tech/kurtosis/kurtosis_version"
 	"github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/metrics_client"
@@ -115,6 +118,10 @@ func (launcher ApiContainerLauncher) LaunchWithCustomVersion(
 	envVars, ownIpAddressEnvvar, err := args.GetEnvFromArgs(argsObj)
 	if err != nil {
 		return nil, stacktrace.Propagate(err, "An error occurred generating the API container's environment variables")
+	}
+	// Propagate the optional pod-delete grace override so APIC-created pods honor it.
+	if v := os.Getenv(kubernetes_grace.EnvVarName); v != "" {
+		envVars[kubernetes_grace.EnvVarName] = v
 	}
 
 	containerImageAndTag := fmt.Sprintf(

--- a/engine/launcher/engine_server_launcher/engine_server_launcher.go
+++ b/engine/launcher/engine_server_launcher/engine_server_launcher.go
@@ -8,11 +8,13 @@ package engine_server_launcher
 import (
 	"context"
 	"net"
+	"os"
 
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/logs_aggregator"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/logs_collector"
 	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/backend_interface/objects/port_spec"
+	"github.com/kurtosis-tech/kurtosis/container-engine-lib/lib/kubernetes_grace"
 	"github.com/kurtosis-tech/kurtosis/engine/launcher/args"
 	"github.com/kurtosis-tech/kurtosis/kurtosis_version"
 	"github.com/kurtosis-tech/kurtosis/metrics-library/golang/lib/metrics_client"
@@ -151,6 +153,10 @@ func (launcher *EngineServerLauncher) LaunchWithCustomVersion(
 	envVars, err := args.GetEnvFromArgs(argsObj)
 	if err != nil {
 		return nil, nil, stacktrace.Propagate(err, "An error occurred generating the engine server's environment variables")
+	}
+	// Propagate the optional pod-delete grace override so the engine (and its APICs) honor it.
+	if v := os.Getenv(kubernetes_grace.EnvVarName); v != "" {
+		envVars[kubernetes_grace.EnvVarName] = v
 	}
 
 	engine, err := launcher.kurtosisBackend.CreateEngine(


### PR DESCRIPTION
## What

Make the pod-delete grace period **configurable** rather than hardcoded. Default behavior is **unchanged** (`nil` → Kubernetes' default grace); setting `KURTOSIS_POD_DELETE_GRACE_PERIOD_SECONDS=0` deletes Kurtosis' pods immediately.

## Why

Kurtosis pods are ephemeral (transient `run_sh` task pods; user-service pods torn down with their enclave) and have no graceful-shutdown needs, but they inherit Kubernetes' default 30s grace. On k8s that made `run_sh` task removal and enclave teardown block ~30s each, dominating devnet startup/teardown wall-clock. This lets operators opt into immediate deletion without changing the default for everyone.

## How

- New `container-engine-lib/lib/kubernetes_grace`: reads `KURTOSIS_POD_DELETE_GRACE_PERIOD_SECONDS`, returning `nil` when unset/invalid (so default behavior is preserved).
- `kubernetes_manager` applies the override to `DeleteOptions.GracePeriodSeconds` and to `TerminationGracePeriodSeconds` on the pod/daemonset/deployment/job specs it creates.
- The engine and APIC launchers propagate the env var, so a single setting on the engine reaches the pods it and its APICs create (needed for fast namespace-cascade teardown).

Unset = no change. Docker/Podman unaffected.