### PR TITLE
build(deps): Bump tar from 7.5.11 to 7.5.22 in api/typescript

### DIFF
--- a/api/typescript/package-lock.json
+++ b/api/typescript/package-lock.json
@@ -25,7 +25,7 @@
                 "neverthrow": "^4.2.2",
                 "path-browserify": "^1.0.1",
                 "semver": "^7.3.5",
-                "tar": "^7.5.11"
+                "tar": "^7.5.21"
             },
             "devDependencies": {
                 "@bufbuild/buf": "^1.26.1",
@@ -1718,9 +1718,9 @@
             }
         },
         "node_modules/tar": {
-            "version": "7.5.11",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.11.tgz",
-            "integrity": "sha512-ChjMH33/KetonMTAtpYdgUFr0tbz69Fp2v7zWxQfYZX4g5ZN2nOBXm1R2xyA+lMIKrLKIoKAwFj93jE/avX9cQ==",
+            "version": "7.5.22",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+            "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
             "license": "BlueOak-1.0.0",
             "dependencies": {
                 "@isaacs/fs-minipass": "^4.0.0",

--- a/api/typescript/package.json
+++ b/api/typescript/package.json
@@ -48,7 +48,7 @@
         "neverthrow": "^4.2.2",
         "path-browserify": "^1.0.1",
         "semver": "^7.3.5",
-        "tar": "^7.5.11"
+        "tar": "^7.5.21"
     },
     "devDependencies": {
         "@bufbuild/buf": "^1.26.1",


### PR DESCRIPTION
Updates `tar` to address GHSA-r292-9mhp-454m (uncontrolled recursion in mapHas/filesFilter, fixed in 7.5.21).

Evidence:
- `api/typescript/package.json` pinned `tar ^7.5.11` and the lockfile resolved `tar@7.5.11`
- OSV reports GHSA-r292-9mhp-454m affects `tar < 7.5.21`
- updated version: `7.5.22` (latest 7.x, also clear of the advisory)

Validation:
- `npm ci --ignore-scripts` (postinstall binaries need network assets not available here) and `npm ls tar` resolves `tar@7.5.22`
- `npx tsc` compiles with no errors
- `npm test` (`ts-mocha -p tsconfig.json 'test/**/*.ts'`) cannot run: the repo has no `test/` directory on this branch, mocha reports no test files. Not executed, not claimed.

Scope: `api/typescript/package.json` and `api/typescript/package-lock.json` only.
